### PR TITLE
fix: show configured allowed groups in location edit form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build
 ladle-build
 .idea/
 .vscode/
+.envrc

--- a/web/src/pages/network/NetworkEditForm/NetworkEditForm.tsx
+++ b/web/src/pages/network/NetworkEditForm/NetworkEditForm.tsx
@@ -49,23 +49,15 @@ const defaultValues: FormFields = {
 const networkToForm = (data?: Network): FormFields => {
   if (!data) return defaultValues;
   let omited = omitBy<Network>(data, isNull);
-  omited = omit(omited, [
-    'id',
-    'connected_at',
-    'connected',
-    'allowed_ips',
-    'allowed_groups',
-    'gateways',
-  ]);
+  omited = omit(omited, ['id', 'connected_at', 'connected', 'allowed_ips', 'gateways']);
 
   let allowed_ips = '';
-  const allowed_groups: string[] = [];
 
   if (Array.isArray(data.allowed_ips)) {
     allowed_ips = data.allowed_ips.join(',');
   }
 
-  return { ...defaultValues, ...omited, allowed_groups, allowed_ips };
+  return { ...defaultValues, ...omited, allowed_ips };
 };
 
 export const NetworkEditForm = () => {


### PR DESCRIPTION
Actually show the allowed groups that are assigned to a location in Web UI.