### PR TITLE
fix: remove device data from admin emails

### DIFF
--- a/src/grpc/enrollment.rs
+++ b/src/grpc/enrollment.rs
@@ -354,7 +354,7 @@ impl enrollment_service_server::EnrollmentService for EnrollmentServer {
             &template_locations,
             &user.email,
             &self.mail_tx,
-            ip_address,
+            Some(ip_address),
             device_info,
         )
         .await

--- a/src/handlers/mail.rs
+++ b/src/handlers/mail.rs
@@ -171,7 +171,7 @@ pub async fn send_new_device_added_email(
     template_locations: &Vec<TemplateLocation>,
     user_email: &str,
     mail_tx: &UnboundedSender<Mail>,
-    ip_address: String,
+    ip_address: Option<String>,
     device_info: Option<String>,
 ) -> Result<(), TemplateError> {
     debug!("User {user_email} new device added mail to {SUPPORT_EMAIL_ADDRESS}");

--- a/src/handlers/user.rs
+++ b/src/handlers/user.rs
@@ -543,7 +543,7 @@ pub async fn set_wallet(
 }
 
 /// Change wallet.
-/// Currenly only `use_for_mfa` flag can be set or unset.
+/// Currently only `use_for_mfa` flag can be set or unset.
 pub async fn update_wallet(
     session: SessionInfo,
     Path((username, address)): Path<(String, String)>,

--- a/src/handlers/wireguard.rs
+++ b/src/handlers/wireguard.rs
@@ -514,15 +514,23 @@ pub async fn add_device(
         })
         .collect();
 
-    // FIXME: remove session info for admin
+    // hide session info if triggered by admin
+    let (session_ip, session_device_info) = if session.is_admin {
+        (None, None)
+    } else {
+        (
+            Some(session.session.ip_address.clone()),
+            session.session.device_info.clone(),
+        )
+    };
     send_new_device_added_email(
         &device.name,
         &device.wireguard_pubkey,
         &template_locations,
         &user.email,
         &appstate.mail_tx,
-        Some(session.session.ip_address.clone()),
-        session.session.device_info.clone(),
+        session_ip,
+        session_device_info,
     )
     .await?;
 

--- a/src/handlers/wireguard.rs
+++ b/src/handlers/wireguard.rs
@@ -514,13 +514,14 @@ pub async fn add_device(
         })
         .collect();
 
+    // FIXME: remove session info for admin
     send_new_device_added_email(
         &device.name,
         &device.wireguard_pubkey,
         &template_locations,
         &user.email,
         &appstate.mail_tx,
-        session.session.ip_address.clone(),
+        Some(session.session.ip_address.clone()),
         session.session.device_info.clone(),
     )
     .await?;

--- a/src/handlers/wireguard.rs
+++ b/src/handlers/wireguard.rs
@@ -514,8 +514,8 @@ pub async fn add_device(
         })
         .collect();
 
-    // hide session info if triggered by admin
-    let (session_ip, session_device_info) = if session.is_admin {
+    // hide session info if triggered by admin for other user
+    let (session_ip, session_device_info) = if session.is_admin && session.user != user {
         (None, None)
     } else {
         (

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -352,7 +352,7 @@ mod test {
             "Test device",
             "TestKey",
             &template_locations,
-            "1.1.1.1".to_string(),
+            Some("1.1.1.1".to_string()),
             None,
         ));
     }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -180,10 +180,10 @@ pub fn new_device_added_mail(
     device_name: &str,
     public_key: &str,
     template_locations: &Vec<TemplateLocation>,
-    ip_address: String,
+    ip_address: Option<String>,
     device_info: Option<String>,
 ) -> Result<String, TemplateError> {
-    let (mut tera, mut context) = get_base_tera(None, None, Some(ip_address), device_info)?;
+    let (mut tera, mut context) = get_base_tera(None, None, ip_address, device_info)?;
     context.insert("device_name", device_name);
     context.insert("public_key", public_key);
     context.insert("locations", template_locations);

--- a/tests/user.rs
+++ b/tests/user.rs
@@ -589,6 +589,14 @@ async fn test_user_add_device() {
         .await;
     assert_eq!(response.status(), StatusCode::OK);
 
+    // first email received is regarding admin login
+    let mail = mail_rx.try_recv().unwrap();
+    assert_eq!(mail.to, "admin@defguard");
+    assert_eq!(
+        mail.subject,
+        "Defguard: new device logged in to your account"
+    );
+
     // create network
     let response = client
         .post("/api/v1/network")
@@ -596,6 +604,52 @@ async fn test_user_add_device() {
         .send()
         .await;
     assert_eq!(response.status(), StatusCode::CREATED);
+
+    // add device for user
+    let device_data = AddDevice {
+        name: "TestDevice1".into(),
+        wireguard_pubkey: "mgVXE8WcfStoD8mRatHcX5aaQ0DlcpjvPXibHEOr9y8=".into(),
+    };
+    let response = client
+        .post("/api/v1/device/hpotter")
+        .header(USER_AGENT, user_agent_header)
+        .json(&device_data)
+        .send()
+        .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    // send email regarding new device being added
+    // it does not contain session info
+    let mail = mail_rx.try_recv().unwrap();
+    assert_eq!(mail.to, "h.potter@hogwart.edu.uk");
+    assert_eq!(mail.subject, "Defguard: new device added to your account");
+    assert!(!mail.content.contains("IP Address:</span>"));
+    assert!(!mail
+        .content
+        .contains("Device type:</span>"));
+
+    // add device for themselves
+    let device_data = AddDevice {
+        name: "TestDevice2".into(),
+        wireguard_pubkey: "mgVXE8WcfStoD8mRatHcX5aaQ0DlcpjvPXibHEOr9y8=".into(),
+    };
+    let response = client
+        .post("/api/v1/device/admin")
+        .header(USER_AGENT, user_agent_header)
+        .json(&device_data)
+        .send()
+        .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    // send email regarding new device being added
+    // it should contain session info
+    let mail = mail_rx.try_recv().unwrap();
+    assert_eq!(mail.to, "admin@defguard");
+    assert_eq!(mail.subject, "Defguard: new device added to your account");
+    assert!(mail.content.contains("IP Address:</span> 127.0.0.1"));
+    assert!(mail
+        .content
+        .contains("Device type:</span> iPhone, OS: iOS 17.1, Mobile Safari"));
 
     // log in as normal user
     let auth = Auth::new("hpotter".into(), "pass123".into());
@@ -610,28 +664,7 @@ async fn test_user_add_device() {
     let response = client.get("/api/v1/me").send().await;
     assert_eq!(response.status(), StatusCode::OK);
 
-    let device_data = AddDevice {
-        name: "TestDevice".into(),
-        wireguard_pubkey: "mgVXE8WcfStoD8mRatHcX5aaQ0DlcpjvPXibHEOr9y8=".into(),
-    };
-    let response = client
-        .post("/api/v1/device/hpotter")
-        .header(USER_AGENT, user_agent_header)
-        .json(&device_data)
-        .send()
-        .await;
-
-    assert_eq!(response.status(), StatusCode::CREATED);
-
-    // First email received is regarding admin login
-    let mail = mail_rx.try_recv().unwrap();
-    assert_eq!(mail.to, "admin@defguard");
-    assert_eq!(
-        mail.subject,
-        "Defguard: new device logged in to your account"
-    );
-
-    // First email received is regarding user login
+    // send email regarding user login
     let mail = mail_rx.try_recv().unwrap();
     assert_eq!(mail.to, "h.potter@hogwart.edu.uk");
     assert_eq!(
@@ -643,7 +676,29 @@ async fn test_user_add_device() {
         .content
         .contains("Device type:</span> iPhone, OS: iOS 17.1, Mobile Safari"));
 
-    // Third email received is regarding new device being added
+    // normal user cannot add a device for other users
+    let device_data = AddDevice {
+        name: "TestDevice3".into(),
+        wireguard_pubkey: "mgVXE8WcfStoD8mRatHcX5aaQ0DlcpjvPXibHEOr9y8=".into(),
+    };
+    let response = client
+        .post("/api/v1/device/admin")
+        .header(USER_AGENT, user_agent_header)
+        .json(&device_data)
+        .send()
+        .await;
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+    // user adds a device for themselves
+    let response = client
+        .post("/api/v1/device/hpotter")
+        .header(USER_AGENT, user_agent_header)
+        .json(&device_data)
+        .send()
+        .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    // send email regarding new device being added
     let mail = mail_rx.try_recv().unwrap();
     assert_eq!(mail.to, "h.potter@hogwart.edu.uk");
     assert_eq!(mail.subject, "Defguard: new device added to your account");

--- a/tests/user.rs
+++ b/tests/user.rs
@@ -624,9 +624,7 @@ async fn test_user_add_device() {
     assert_eq!(mail.to, "h.potter@hogwart.edu.uk");
     assert_eq!(mail.subject, "Defguard: new device added to your account");
     assert!(!mail.content.contains("IP Address:</span>"));
-    assert!(!mail
-        .content
-        .contains("Device type:</span>"));
+    assert!(!mail.content.contains("Device type:</span>"));
 
     // add device for themselves
     let device_data = AddDevice {


### PR DESCRIPTION
Remove session info from emails triggered by admin actions.