### PR TITLE
fix: invalid new MFA peer

### DIFF
--- a/.sqlx/query-63dd22326d77a452d5624d378b0653a7b6b98d71caaf55c6651a44bbd57df017.json
+++ b/.sqlx/query-63dd22326d77a452d5624d378b0653a7b6b98d71caaf55c6651a44bbd57df017.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT wireguard_network_id as network_id, wireguard_ip as \"device_wireguard_ip: IpAddr\", preshared_key FROM wireguard_network_device WHERE device_id = $1",
+  "query": "SELECT wireguard_network_id as network_id, wireguard_ip as \"device_wireguard_ip: IpAddr\", preshared_key, is_authorized FROM wireguard_network_device WHERE device_id = $1",
   "describe": {
     "columns": [
       {
@@ -17,6 +17,11 @@
         "ordinal": 2,
         "name": "preshared_key",
         "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "is_authorized",
+        "type_info": "Bool"
       }
     ],
     "parameters": {
@@ -27,8 +32,9 @@
     "nullable": [
       false,
       false,
-      true
+      true,
+      false
     ]
   },
-  "hash": "6eff81e0ddc89652014c10c9b5c1561dfa68bc80db59bc000dc217ffa639b53b"
+  "hash": "63dd22326d77a452d5624d378b0653a7b6b98d71caaf55c6651a44bbd57df017"
 }

--- a/src/db/models/device.rs
+++ b/src/db/models/device.rs
@@ -62,6 +62,7 @@ pub struct DeviceNetworkInfo {
     pub device_wireguard_ip: IpAddr,
     #[serde(skip_serializing)]
     pub preshared_key: Option<String>,
+    pub is_authorized: bool,
 }
 
 impl DeviceInfo {
@@ -73,7 +74,7 @@ impl DeviceInfo {
         let device_id = device.get_id()?;
         let network_info = query_as!(
             DeviceNetworkInfo,
-            "SELECT wireguard_network_id as network_id, wireguard_ip as \"device_wireguard_ip: IpAddr\", preshared_key \
+            "SELECT wireguard_network_id as network_id, wireguard_ip as \"device_wireguard_ip: IpAddr\", preshared_key, is_authorized \
             FROM wireguard_network_device \
             WHERE device_id = $1",
             device_id
@@ -538,6 +539,7 @@ impl Device {
                     network_id,
                     device_wireguard_ip: wireguard_network_device.wireguard_ip,
                     preshared_key: wireguard_network_device.preshared_key.clone(),
+                    is_authorized: wireguard_network_device.is_authorized,
                 };
                 network_info.push(device_network_info);
 

--- a/src/db/models/wireguard.rs
+++ b/src/db/models/wireguard.rs
@@ -420,6 +420,7 @@ impl WireguardNetwork {
                             network_id,
                             device_wireguard_ip: wireguard_network_device.wireguard_ip,
                             preshared_key: wireguard_network_device.preshared_key,
+                            is_authorized: wireguard_network_device.is_authorized,
                         }],
                     }));
                 }
@@ -439,6 +440,7 @@ impl WireguardNetwork {
                             network_id,
                             device_wireguard_ip: device_network_config.wireguard_ip,
                             preshared_key: device_network_config.preshared_key,
+                            is_authorized: device_network_config.is_authorized,
                         }],
                     }));
                 } else {
@@ -460,6 +462,7 @@ impl WireguardNetwork {
                     network_id,
                     device_wireguard_ip: wireguard_network_device.wireguard_ip,
                     preshared_key: wireguard_network_device.preshared_key,
+                    is_authorized: wireguard_network_device.is_authorized,
                 }],
             }));
         }
@@ -516,6 +519,7 @@ impl WireguardNetwork {
                                     network_id,
                                     device_wireguard_ip: wireguard_network_device.wireguard_ip,
                                     preshared_key: wireguard_network_device.preshared_key,
+                                    is_authorized: wireguard_network_device.is_authorized,
                                 }],
                             }));
                         }
@@ -591,6 +595,7 @@ impl WireguardNetwork {
                         network_id,
                         device_wireguard_ip: wireguard_network_device.wireguard_ip,
                         preshared_key: wireguard_network_device.preshared_key,
+                        is_authorized: wireguard_network_device.is_authorized,
                     });
                 }
                 Some(allowed) => {
@@ -607,6 +612,7 @@ impl WireguardNetwork {
                             network_id,
                             device_wireguard_ip: wireguard_network_device.wireguard_ip,
                             preshared_key: wireguard_network_device.preshared_key,
+                            is_authorized: wireguard_network_device.is_authorized,
                         });
                     }
                 }

--- a/src/grpc/desktop_client_mfa.rs
+++ b/src/grpc/desktop_client_mfa.rs
@@ -250,6 +250,7 @@ impl ClientMfaServer {
                 network_id: location.id.expect("Missing location ID"),
                 device_wireguard_ip: network_device.wireguard_ip,
                 preshared_key: network_device.preshared_key,
+                is_authorized: network_device.is_authorized,
             }],
         };
         let event = GatewayEvent::DeviceCreated(device_info);

--- a/src/handlers/wireguard.rs
+++ b/src/handlers/wireguard.rs
@@ -582,6 +582,7 @@ pub async fn modify_device(
                         network_id,
                         device_wireguard_ip: wireguard_network_device.wireguard_ip,
                         preshared_key: wireguard_network_device.preshared_key,
+                        is_authorized: wireguard_network_device.is_authorized,
                     };
                     network_info.push(device_network_info);
                 }

--- a/src/wireguard_peer_disconnect.rs
+++ b/src/wireguard_peer_disconnect.rs
@@ -103,6 +103,7 @@ pub async fn run_periodic_peer_disconnect(
                             network_id: location_id,
                             device_wireguard_ip: device_network_config.wireguard_ip,
                             preshared_key: device_network_config.preshared_key,
+                            is_authorized: device_network_config.is_authorized,
                         }],
                     };
                     let event = GatewayEvent::DeviceDeleted(device_info);


### PR DESCRIPTION
Prevent sending unauthorized peer to MFA-enabled location's gateway when adding a new device. 
