### PR TITLE
Auth cookie lifetime option

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -17,11 +17,13 @@ pub struct DefGuardConfig {
     #[arg(long, env = "DEFGUARD_LOG_LEVEL", default_value = "info")]
     pub log_level: String,
 
+    // TODO: restore file logging, seems to have vanished during the switch to tracing
     #[arg(long, env = "DEFGUARD_LOG_FILE")]
     pub log_file: Option<String>,
 
-    #[arg(long, env = "DEFGUARD_AUTH_SESSION_LIFETIME")]
-    pub session_auth_lifetime: Option<i64>,
+    #[arg(long, env = "DEFGUARD_AUTH_COOKIE_TIMEOUT", default_value = "7d")]
+    #[serde(skip_serializing)]
+    pub auth_cookie_timeout: Duration,
 
     #[arg(long, env = "DEFGUARD_SECRET_KEY")]
     #[serde(skip_serializing)]

--- a/src/handlers/auth.rs
+++ b/src/handlers/auth.rs
@@ -100,11 +100,7 @@ pub async fn authenticate(
     );
     session.save(&appstate.pool).await?;
 
-    let max_age = match &server_config().session_auth_lifetime {
-        Some(seconds) => Duration::seconds(*seconds),
-        None => Duration::days(7),
-    };
-
+    let max_age = Duration::seconds(server_config().auth_cookie_timeout.as_secs() as i64);
     let config = server_config();
     let auth_cookie = Cookie::build((SESSION_COOKIE_NAME, session.id.clone()))
         .domain(


### PR DESCRIPTION
Rename `DEFGUARD_AUTH_SESSION_LIFETIME` to `DEFGUARD_AUTH_COOKIE_TIMEOUT` and change it's type to humantime::Duration to be consistent with other timeout options.