### PR TITLE
fix: handle devices with no network access

### DIFF
--- a/web/src/i18n/en/index.ts
+++ b/web/src/i18n/en/index.ts
@@ -443,6 +443,7 @@ const en: BaseTranslation = {
       Please be advised that configuration provided here <strong> does not include private key and uses public key to fill it's place </strong> you will need to replace it on your own for configuration to work properly.
     </p>
 `,
+          warningNoNetworks: "You don't have access to any network.",
           qrHelper: `
       <p>
         You can setup your device faster with wireguard application by scanning this QR code.

--- a/web/src/i18n/i18n-types.ts
+++ b/web/src/i18n/i18n-types.ts
@@ -995,6 +995,10 @@ type RootTranslation = {
 					 */
 					warningManualMode: string
 					/**
+					 * Y​o​u​ ​d​o​n​'​t​ ​h​a​v​e​ ​a​c​c​e​s​s​ ​t​o​ ​a​n​y​ ​n​e​t​w​o​r​k​.
+					 */
+					warningNoNetworks: string
+					/**
 					 * 
 				​ ​ ​ ​ ​ ​ ​<​p​>​
 				​ ​ ​ ​ ​ ​ ​ ​ ​Y​o​u​ ​c​a​n​ ​s​e​t​u​p​ ​y​o​u​r​ ​d​e​v​i​c​e​ ​f​a​s​t​e​r​ ​w​i​t​h​ ​w​i​r​e​g​u​a​r​d​ ​a​p​p​l​i​c​a​t​i​o​n​ ​b​y​ ​s​c​a​n​n​i​n​g​ ​t​h​i​s​ ​Q​R​ ​c​o​d​e​.​
@@ -4775,6 +4779,10 @@ export type TranslationFunctions = {
 			
 					 */
 					warningManualMode: () => LocalizedString
+					/**
+					 * You don't have access to any network.
+					 */
+					warningNoNetworks: () => LocalizedString
 					/**
 					 * 
 				      <p>

--- a/web/src/i18n/pl/index.ts
+++ b/web/src/i18n/pl/index.ts
@@ -455,6 +455,7 @@ const pl: Translation = {
         qrInfo:
           'Użyj poniższych konfiguracji aby połączyć się z wybranymi lokalizacjami.',
         helpers: {
+          warningNoNetworks: 'Nie posiadasz dostępu do żadnej sieci.',
           qrHelper: `<p>Możesz skonfigurować WireGuard na telefonie skanując QR kod używając aplikacji WireGuard.</p>`,
           warningAutoMode: `
 <p>Uwaga, Defguard nie przechowuje twojego klucza prywatnego. Gdy opuścisz obecną stronę <strong>nie będziesz mógł</strong> pobrać ponownie konfiguracji z kluczem prywatnym.</p>

--- a/web/src/pages/addDevice/steps/AddDeviceConfigStep/AddDeviceConfigStep.tsx
+++ b/web/src/pages/addDevice/steps/AddDeviceConfigStep/AddDeviceConfigStep.tsx
@@ -78,7 +78,7 @@ export const AddDeviceConfigStep = () => {
       <div className="info">
         <p>{localLL.qrInfo()}</p>
       </div>
-      {networks.length ? (
+      {networks.length > 0 && (
         <DeviceConfigsCard
           deviceId={device.id}
           publicKey={publicKey}
@@ -87,7 +87,8 @@ export const AddDeviceConfigStep = () => {
           networks={networks}
           deviceName={device.name}
         />
-      ) : (
+      )}
+      {networks.length === 0 && (
         <MessageBox type={MessageBoxType.WARNING}>
           {localLL.helpers.warningNoNetworks()}
         </MessageBox>

--- a/web/src/pages/addDevice/steps/AddDeviceConfigStep/AddDeviceConfigStep.tsx
+++ b/web/src/pages/addDevice/steps/AddDeviceConfigStep/AddDeviceConfigStep.tsx
@@ -78,14 +78,20 @@ export const AddDeviceConfigStep = () => {
       <div className="info">
         <p>{localLL.qrInfo()}</p>
       </div>
-      <DeviceConfigsCard
-        deviceId={device.id}
-        publicKey={publicKey}
-        privateKey={privateKey}
-        userId={userData.id}
-        networks={networks}
-        deviceName={device.name}
-      />
+      {networks.length ? (
+        <DeviceConfigsCard
+          deviceId={device.id}
+          publicKey={publicKey}
+          privateKey={privateKey}
+          userId={userData.id}
+          networks={networks}
+          deviceName={device.name}
+        />
+      ) : (
+        <MessageBox type={MessageBoxType.WARNING}>
+          {localLL.helpers.warningNoNetworks()}
+        </MessageBox>
+      )}
     </Card>
   );
 };

--- a/web/src/pages/users/UserProfile/UserDevices/DeviceCard/DeviceCard.tsx
+++ b/web/src/pages/users/UserProfile/UserDevices/DeviceCard/DeviceCard.tsx
@@ -154,6 +154,7 @@ export const DeviceCard = ({ device }: Props) => {
           <EditButtonOption
             styleVariant={EditButtonOptionStyleVariant.STANDARD}
             text={LL.userPage.devices.card.edit.showConfigurations()}
+            disabled={!device.networks?.length}
             onClick={() => {
               openDeviceConfigModal({
                 deviceName: device.name,

--- a/web/src/pages/users/UserProfile/UserDevices/UserDevices.tsx
+++ b/web/src/pages/users/UserProfile/UserDevices/UserDevices.tsx
@@ -2,9 +2,9 @@ import './style.scss';
 
 import Skeleton from 'react-loading-skeleton';
 import { useNavigate } from 'react-router';
+import { shallow } from 'zustand/shallow';
 
 import { useI18nContext } from '../../../../i18n/i18n-react';
-import { useAppStore } from '../../../../shared/hooks/store/useAppStore';
 import { useUserProfileStore } from '../../../../shared/hooks/store/useUserProfileStore';
 import { useAddDevicePageStore } from '../../../addDevice/hooks/useAddDevicePageStore';
 import { AddComponentBox } from '../../shared/components/AddComponentBox/AddComponentBox';
@@ -15,11 +15,22 @@ import { EditUserDeviceModal } from './modals/EditUserDeviceModal/EditUserDevice
 
 export const UserDevices = () => {
   const navigate = useNavigate();
-  const appInfo = useAppStore((state) => state.appInfo);
   const { LL } = useI18nContext();
   const userProfile = useUserProfileStore((state) => state.userProfile);
-  const initAddDevice = useAddDevicePageStore((state) => state.init);
+  // const [initAddDevice, networks] = useAddDevicePageStore((state) => [
+  const [initAddDevice, networks] = useAddDevicePageStore((state) => [
+    state.init,
+    state.networks,
+  ]);
 
+  // const [networks] = useAddDevicePageStore(
+  //   (state) => [
+  //     state.networks,
+  //   ],
+  //   shallow,
+  // );
+
+  console.log(networks, !networks?.length);
   return (
     <section id="user-devices">
       <header>
@@ -45,7 +56,7 @@ export const UserDevices = () => {
             <AddComponentBox
               data-testid="add-device"
               text={LL.userPage.devices.addDevice.web()}
-              disabled={!appInfo?.network_present}
+              disabled={!networks?.length}
               callback={() => {
                 initAddDevice({
                   username: userProfile.user.username,

--- a/web/src/pages/users/UserProfile/UserDevices/UserDevices.tsx
+++ b/web/src/pages/users/UserProfile/UserDevices/UserDevices.tsx
@@ -4,6 +4,7 @@ import Skeleton from 'react-loading-skeleton';
 import { useNavigate } from 'react-router';
 
 import { useI18nContext } from '../../../../i18n/i18n-react';
+import { useAppStore } from '../../../../shared/hooks/store/useAppStore';
 import { useUserProfileStore } from '../../../../shared/hooks/store/useUserProfileStore';
 import { useAddDevicePageStore } from '../../../addDevice/hooks/useAddDevicePageStore';
 import { AddComponentBox } from '../../shared/components/AddComponentBox/AddComponentBox';
@@ -14,6 +15,7 @@ import { EditUserDeviceModal } from './modals/EditUserDeviceModal/EditUserDevice
 
 export const UserDevices = () => {
   const navigate = useNavigate();
+  const appInfo = useAppStore((state) => state.appInfo);
   const { LL } = useI18nContext();
   const userProfile = useUserProfileStore((state) => state.userProfile);
   const initAddDevice = useAddDevicePageStore((state) => state.init);
@@ -43,6 +45,7 @@ export const UserDevices = () => {
             <AddComponentBox
               data-testid="add-device"
               text={LL.userPage.devices.addDevice.web()}
+              disabled={!appInfo?.network_present}
               callback={() => {
                 initAddDevice({
                   username: userProfile.user.username,

--- a/web/src/pages/users/UserProfile/UserDevices/UserDevices.tsx
+++ b/web/src/pages/users/UserProfile/UserDevices/UserDevices.tsx
@@ -2,7 +2,6 @@ import './style.scss';
 
 import Skeleton from 'react-loading-skeleton';
 import { useNavigate } from 'react-router';
-import { shallow } from 'zustand/shallow';
 
 import { useI18nContext } from '../../../../i18n/i18n-react';
 import { useUserProfileStore } from '../../../../shared/hooks/store/useUserProfileStore';
@@ -17,20 +16,8 @@ export const UserDevices = () => {
   const navigate = useNavigate();
   const { LL } = useI18nContext();
   const userProfile = useUserProfileStore((state) => state.userProfile);
-  // const [initAddDevice, networks] = useAddDevicePageStore((state) => [
-  const [initAddDevice, networks] = useAddDevicePageStore((state) => [
-    state.init,
-    state.networks,
-  ]);
+  const initAddDevice = useAddDevicePageStore((state) => state.init);
 
-  // const [networks] = useAddDevicePageStore(
-  //   (state) => [
-  //     state.networks,
-  //   ],
-  //   shallow,
-  // );
-
-  console.log(networks, !networks?.length);
   return (
     <section id="user-devices">
       <header>
@@ -56,7 +43,6 @@ export const UserDevices = () => {
             <AddComponentBox
               data-testid="add-device"
               text={LL.userPage.devices.addDevice.web()}
-              disabled={!networks?.length}
               callback={() => {
                 initAddDevice({
                   username: userProfile.user.username,


### PR DESCRIPTION
When all networks assigned to groups and the user has access to none:
* display "no network access" during device configuration
* disable device "show config" option