### PR TITLE
fix: verify mfa status during openid authorization

### DIFF
--- a/src/handlers/openid_flow.rs
+++ b/src/handlers/openid_flow.rs
@@ -406,6 +406,8 @@ pub async fn authorization(
                                         .await?
                                         .ok_or(WebError::Authorization("User not found".into()))?;
 
+                                    // Session exists even if user hasn't completed MFA verification yet,
+                                    // thus we need to check if MFA is enabled and the verification is done.
                                     if user.mfa_enabled
                                         && session.state != SessionState::MultiFactorVerified
                                     {


### PR DESCRIPTION
## 📖 Description

Previously only the session existence and its expiration status was checked during the openid authorization, which is not enough, as the session is created before the MFA verification takes place.

### 🛠️ Dev Branch Merge Checklist:

#### Documentation ###

- [x] If testing requires changes in the environment or deployment, please **update the documentation** (https://defguard.gitbook.io) first and **attach the link to the documentation** section in this pool request
- [x] I have commented on my code, particularly in hard-to-understand areas

#### Testing ### 

- [x] I have prepared end-to-end tests for all new functionalities
- [x] I have performed end-to-end tests manually and they work
- [x] New and existing unit tests pass locally with my changes

#### Deployment ###

- [x] If deployment is affected I have made corresponding/required changes to [deployment](https://github.com/defguard/deployment) (Docker, Kubernetes, one-line install)

### 🏚️ Main Branch Merge Checklist:

#### Testing ### 

- [ ] I have merged my changes before to dev and the dev checklist is done
- [ ] I have tested all functionalities on the dev instance and they work

#### Documentation ###

- [ ] I have made corresponding changes to the **user & admin documentation** and added new features documentation with screenshots for users/admins
