### PR TITLE
Prepare the database for licenses

### DIFF
--- a/migrations/20240809083720_add_licenses.down.sql
+++ b/migrations/20240809083720_add_licenses.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE settings DROP COLUMN license;

--- a/migrations/20240809083720_add_licenses.up.sql
+++ b/migrations/20240809083720_add_licenses.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE settings ADD COLUMN license TEXT DEFAULT NULL;


### PR DESCRIPTION
This PR adds license migrations necessary for #709. This PR has been separated to ease the development testing of #709, it will make switching dev instance images easier, without the issue of mismatched migration versions.