### PR TITLE
fix: remove enterprise settings error toast

### DIFF
--- a/web/src/components/AppLoader.tsx
+++ b/web/src/components/AppLoader.tsx
@@ -86,8 +86,6 @@ export const AppLoader = () => {
       setAppStore({ enterprise_settings: settings });
     },
     onError: (err) => {
-      // FIXME: Add a proper error message
-      toaster.error(LL.messages.errorVersion());
       console.error(err);
     },
     refetchOnWindowFocus: true,


### PR DESCRIPTION
Fetching the enterprise settings may happen on the login screen, when there is no session, resulting in a 401 response and a toast being displayed every time. 