### PR TITLE
Fix syntax error in list_groups_info with name columns

### DIFF
--- a/src/handlers/group.rs
+++ b/src/handlers/group.rs
@@ -136,7 +136,7 @@ pub(crate) async fn list_groups_info(
     debug!("Listing groups info");
     let q_result = query_as!(
         GroupInfo,
-        "SELECT g.name name, \
+        "SELECT g.name \"name\", \
         COALESCE(ARRAY_AGG(DISTINCT u.username) FILTER (WHERE u.username IS NOT NULL), '{}') \"members!\", \
         COALESCE(ARRAY_AGG(DISTINCT wn.name) FILTER (WHERE wn.name IS NOT NULL), '{}') \"vpn_locations!\", \
         is_admin \


### PR DESCRIPTION
Fixed a bug with the list of groups described in issue #912 
