### PR TITLE
ACL fixes

### DIFF
--- a/src/enterprise/db/models/acl.rs
+++ b/src/enterprise/db/models/acl.rs
@@ -44,6 +44,8 @@ pub enum AclError {
     FirewallError(#[from] FirewallError),
     #[error("InvalidIpRangeError: {0}")]
     InvalidIpRangeError(String),
+    #[error("PortOutOfRangeError: {0}")]
+    PortOutOfRangeError(i32),
 }
 
 /// https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/in.h
@@ -507,6 +509,13 @@ pub fn parse_destination(destination: &str) -> Result<ParsedDestination, AclErro
 /// `22, 23, 8000-9000, 80-90`
 pub fn parse_ports(ports: &str) -> Result<Vec<PortRange>, AclError> {
     debug!("Parsing ports string: {ports}");
+    let ensure_in_range = |port: i32| {
+        if (0..=65535).contains(&port) {
+            Ok(port)
+        } else {
+            Err(AclError::PortOutOfRangeError(port))
+        }
+    };
     let mut result = Vec::new();
     let ports: String = ports.chars().filter(|c| !c.is_whitespace()).collect();
     if ports.is_empty() {
@@ -515,12 +524,12 @@ pub fn parse_ports(ports: &str) -> Result<Vec<PortRange>, AclError> {
     for v in ports.split(',') {
         match v.split('-').collect::<Vec<_>>() {
             l if l.len() == 1 => result.push(PortRange(Range {
-                start: l[0].parse::<i32>()?,
-                end: l[0].parse::<i32>()? + 1,
+                start: ensure_in_range(l[0].parse::<i32>()?)?,
+                end: ensure_in_range(l[0].parse::<i32>()?)? + 1,
             })),
             l if l.len() == 2 => result.push(PortRange(Range {
-                start: l[0].parse::<i32>()?,
-                end: l[1].parse::<i32>()? + 1,
+                start: ensure_in_range(l[0].parse::<i32>()?)?,
+                end: ensure_in_range(l[1].parse::<i32>()?)? + 1,
             })),
             _ => {
                 error!("Failed to parse ports string: \"{ports}\"");

--- a/src/enterprise/db/models/acl.rs
+++ b/src/enterprise/db/models/acl.rs
@@ -42,6 +42,8 @@ pub enum AclError {
     RuleAlreadyAppliedError(Id),
     #[error(transparent)]
     FirewallError(#[from] FirewallError),
+    #[error("InvalidIpRangeError: {0}")]
+    InvalidIpRangeError(String),
 }
 
 /// https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/in.h
@@ -672,7 +674,9 @@ impl AclRule<Id> {
                 start: range.0,
                 end: range.1,
             };
-            obj.save(&mut *transaction).await?;
+            obj.save(&mut *transaction)
+                .await
+                .map_err(|_| AclError::InvalidIpRangeError(format!("{}-{}", range.0, range.1)))?;
         }
 
         info!("Created related objects for ACL rule {api_rule:?}");

--- a/src/enterprise/db/models/acl.rs
+++ b/src/enterprise/db/models/acl.rs
@@ -510,11 +510,9 @@ pub fn parse_destination(destination: &str) -> Result<ParsedDestination, AclErro
 pub fn parse_ports(ports: &str) -> Result<Vec<PortRange>, AclError> {
     debug!("Parsing ports string: {ports}");
     let ensure_in_range = |port: i32| {
-        if (0..=65535).contains(&port) {
-            Ok(port)
-        } else {
-            Err(AclError::PortOutOfRangeError(port))
-        }
+        u16::try_from(port)
+            .map(|_| port)
+            .map_err(|_| AclError::PortOutOfRangeError(port))
     };
     let mut result = Vec::new();
     let ports: String = ports.chars().filter(|c| !c.is_whitespace()).collect();

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -96,6 +96,10 @@ impl From<WebError> for ApiResponse {
                     json!({"msg": "Unprocessable entity"}),
                     StatusCode::UNPROCESSABLE_ENTITY,
                 ),
+                AclError::InvalidIpRangeError(err) => ApiResponse::new(
+                    json!({"msg": format!("Invalid IP range: {err}")}),
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                ),
                 AclError::RuleNotFoundError(id) => ApiResponse::new(
                     json!({"msg": format!("Rule {id} not found")}),
                     StatusCode::NOT_FOUND,

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -115,6 +115,10 @@ impl From<WebError> for ApiResponse {
                         StatusCode::INTERNAL_SERVER_ERROR,
                     )
                 }
+                AclError::PortOutOfRangeError(port) => ApiResponse::new(
+                    json!({"msg": format!("Port out of range: {port}")}),
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                ),
             },
             WebError::Http(status) => {
                 error!("{status}");


### PR DESCRIPTION
- Fix http 500 on invalid ip ranges
- Don't allow out-of-range ports in ACL rules