### PR TITLE
fix ACL info API response

### DIFF
--- a/.sqlx/query-4dcd43e0b78c8948ffe3e9cc13c094bd2da10e535164bece43fe1f52945c8910.json
+++ b/.sqlx/query-4dcd43e0b78c8948ffe3e9cc13c094bd2da10e535164bece43fe1f52945c8910.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT id, name, wireguard_pubkey, user_id, created, description, device_type \"device_type: DeviceType\", configured FROM device WHERE device_type = 'network'::device_type",
+  "query": "SELECT d.id, name, wireguard_pubkey, user_id, created, description, device_type \"device_type: DeviceType\", configured FROM aclruledevice r JOIN device d ON d.id = r.device_id WHERE r.rule_id = $1 AND r.allow = true AND d.configured = true",
   "describe": {
     "columns": [
       {
@@ -55,7 +55,9 @@
       }
     ],
     "parameters": {
-      "Left": []
+      "Left": [
+        "Int8"
+      ]
     },
     "nullable": [
       false,
@@ -68,5 +70,5 @@
       false
     ]
   },
-  "hash": "3c015f1a129f272c434dba23b46c04f923ed3a2aaf9b4336c8242d43a758bb0f"
+  "hash": "4dcd43e0b78c8948ffe3e9cc13c094bd2da10e535164bece43fe1f52945c8910"
 }

--- a/.sqlx/query-7a1fd9a69b398f51efd5199aefb305d358693b0211cdb27b14b910a3515d501e.json
+++ b/.sqlx/query-7a1fd9a69b398f51efd5199aefb305d358693b0211cdb27b14b910a3515d501e.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT d.id, name, wireguard_pubkey, user_id, created, description, device_type \"device_type: DeviceType\", configured FROM aclruledevice r JOIN device d ON d.id = r.device_id WHERE r.rule_id = $1 AND r.allow = true",
+  "query": "SELECT id, name, wireguard_pubkey, user_id, created, description, device_type \"device_type: DeviceType\", configured FROM device WHERE device_type = 'network'::device_type AND configured = true",
   "describe": {
     "columns": [
       {
@@ -55,9 +55,7 @@
       }
     ],
     "parameters": {
-      "Left": [
-        "Int8"
-      ]
+      "Left": []
     },
     "nullable": [
       false,
@@ -70,5 +68,5 @@
       false
     ]
   },
-  "hash": "73b448972080f6e7ca671fc7108276f42627596e83121863c70e0a039bb6caf4"
+  "hash": "7a1fd9a69b398f51efd5199aefb305d358693b0211cdb27b14b910a3515d501e"
 }

--- a/.sqlx/query-b6e20a2b66be63641872b921a963bf0e9a25cab905322cc1ada5e03f1b5076c7.json
+++ b/.sqlx/query-b6e20a2b66be63641872b921a963bf0e9a25cab905322cc1ada5e03f1b5076c7.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT d.id, name, wireguard_pubkey, user_id, created, description, device_type \"device_type: DeviceType\", configured FROM aclruledevice r JOIN device d ON d.id = r.device_id WHERE r.rule_id = $1 AND r.allow = false",
+  "query": "SELECT d.id, name, wireguard_pubkey, user_id, created, description, device_type \"device_type: DeviceType\", configured FROM aclruledevice r JOIN device d ON d.id = r.device_id WHERE r.rule_id = $1 AND r.allow = false AND d.configured = true",
   "describe": {
     "columns": [
       {
@@ -70,5 +70,5 @@
       false
     ]
   },
-  "hash": "ebce5ce65aa03987f9204ba81ec0e8e040deade5a0d9c0ad84b4a3bd2e82face"
+  "hash": "b6e20a2b66be63641872b921a963bf0e9a25cab905322cc1ada5e03f1b5076c7"
 }

--- a/src/enterprise/db/models/acl.rs
+++ b/src/enterprise/db/models/acl.rs
@@ -1973,7 +1973,7 @@ mod test {
         rule.allow_all_users = true;
         rule.deny_all_users = false;
         rule.save(&pool).await.unwrap();
-        assert_eq!(rule.get_users(&pool, true).await.unwrap().len(), 2);
+        assert_eq!(rule.get_users(&pool, true).await.unwrap().len(), 1);
         assert_eq!(rule.get_users(&pool, false).await.unwrap().len(), 1);
 
         // test `deny_all_users` flag
@@ -1981,14 +1981,14 @@ mod test {
         rule.deny_all_users = true;
         rule.save(&pool).await.unwrap();
         assert_eq!(rule.get_users(&pool, true).await.unwrap().len(), 1);
-        assert_eq!(rule.get_users(&pool, false).await.unwrap().len(), 2);
+        assert_eq!(rule.get_users(&pool, false).await.unwrap().len(), 1);
 
         // test both flags
         rule.allow_all_users = true;
         rule.deny_all_users = true;
         rule.save(&pool).await.unwrap();
-        assert_eq!(rule.get_users(&pool, true).await.unwrap().len(), 2);
-        assert_eq!(rule.get_users(&pool, false).await.unwrap().len(), 2);
+        assert_eq!(rule.get_users(&pool, true).await.unwrap().len(), 1);
+        assert_eq!(rule.get_users(&pool, false).await.unwrap().len(), 1);
 
         // deactivate user1
         user1.is_active = false;
@@ -2001,8 +2001,7 @@ mod test {
 
         let allowed_users = rule.get_users(&pool, true).await.unwrap();
         let denied_users = rule.get_users(&pool, false).await.unwrap();
-        assert_eq!(allowed_users.len(), 1);
-        assert_eq!(allowed_users[0], user2);
+        assert_eq!(allowed_users.len(), 0);
         assert_eq!(denied_users.len(), 1);
 
         // ensure only active users are allowed when `allow_all_users = false`
@@ -2025,8 +2024,7 @@ mod test {
         let allowed_users = rule.get_users(&pool, true).await.unwrap();
         let denied_users = rule.get_users(&pool, false).await.unwrap();
         assert_eq!(allowed_users.len(), 1);
-        assert_eq!(denied_users.len(), 1);
-        assert_eq!(denied_users[0], user2);
+        assert_eq!(denied_users.len(), 0);
 
         // ensure only active users are denied when `deny_all_users = false`
         rule.allow_all_users = false;

--- a/src/enterprise/firewall.rs
+++ b/src/enterprise/firewall.rs
@@ -61,8 +61,15 @@ pub async fn generate_firewall_rules_from_acls(
         // get network IPs for devices belonging to those users
         let user_device_ips = get_user_device_ips(&users, location_id, &mut *conn).await?;
 
+        // fetch allowed network devices
+        let allowed_network_devices = acl.get_all_allowed_devices(&mut *conn).await?;
+
+        // fetch denied network devices
+        let denied_network_devices = acl.get_all_denied_devices(&mut *conn).await?;
+
         // get network device IPs for rule source
-        let network_devices = get_source_network_devices(acl.allowed_devices, acl.denied_devices);
+        let network_devices =
+            get_source_network_devices(allowed_network_devices, denied_network_devices);
         let network_device_ips =
             get_network_device_ips(&network_devices, location_id, &mut *conn).await?;
 


### PR DESCRIPTION
Prevent adding all active users to explicitly specified allowed/denied users if allow/deny_all flag is enabled.
Also do the same for network devices.