### PR TITLE
fix WireGuard network peer stats DB view

### DIFF
--- a/migrations/20250509095404_fix_wireguard_network_stats_view.down.sql
+++ b/migrations/20250509095404_fix_wireguard_network_stats_view.down.sql
@@ -1,0 +1,12 @@
+CREATE OR REPLACE VIEW wireguard_peer_stats_view AS
+    SELECT
+        device_id,
+        greatest(upload - lag(upload, 1, 0::bigint) OVER (PARTITION BY device_id ORDER BY collected_at), 0) upload,
+        greatest(download - lag(download, 1, 0::bigint) OVER (PARTITION BY device_id ORDER BY collected_at), 0) download,
+        latest_handshake - (lag(latest_handshake, 1, latest_handshake) OVER (PARTITION BY device_id ORDER BY collected_at)) latest_handshake_diff,
+        latest_handshake,
+        collected_at,
+        network,
+        endpoint,
+        allowed_ips
+    FROM wireguard_peer_stats;

--- a/migrations/20250509095404_fix_wireguard_network_stats_view.up.sql
+++ b/migrations/20250509095404_fix_wireguard_network_stats_view.up.sql
@@ -1,0 +1,12 @@
+CREATE OR REPLACE VIEW wireguard_peer_stats_view AS
+    SELECT
+        device_id,
+        greatest(upload - lag(upload, 1, upload) OVER (PARTITION BY device_id, network ORDER BY collected_at), 0) upload,
+        greatest(download - lag(download, 1, download) OVER (PARTITION BY device_id, network ORDER BY collected_at), 0) download,
+        latest_handshake - (lag(latest_handshake, 1, latest_handshake) OVER (PARTITION BY device_id, network ORDER BY collected_at)) latest_handshake_diff,
+        latest_handshake,
+        collected_at,
+        network,
+        endpoint,
+        allowed_ips
+    FROM wireguard_peer_stats;


### PR DESCRIPTION
Changes `wireguard_peer_stats_view` that we use to pre-aggregate statistics for location overview:
- include `network` in `PARTITION BY` statements to avoid using values from two different networks for calculations
- change default transfer values in the `LAG` statements to avoid counting total transfer as a difference for the first sample in time series

resolves https://github.com/DefGuard/defguard/issues/1145