### PR TITLE
fix alias-only rules handling

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1745391562,
-        "narHash": "sha256-sPwcCYuiEopaafePqlG826tBhctuJsLx/mhKKM5Fmjo=",
+        "lastModified": 1747179050,
+        "narHash": "sha256-qhFMmDkeJX9KJwr5H32f1r7Prs7XbQWtO0h3V0a0rFY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8a2f738d9d1f1d986b5a4cd2fd2061a7127237d7",
+        "rev": "adaa24fbf46737f3f1b5497bf64bae750f82942e",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745548521,
-        "narHash": "sha256-xyliq8oS5OnzXjHRGr92RtmrtYI/dflf2gSEo0wMFjc=",
+        "lastModified": 1747363019,
+        "narHash": "sha256-N4dwkRBmpOosa4gfFkFf/LTD8oOcNkAyvZ07JvRDEf0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "eb0afb4ac0720d55c29e88eb29432103d73ae11d",
+        "rev": "0e624f2b1972a34be1a9b35290ed18ea4b419b6f",
         "type": "github"
       },
       "original": {

--- a/src/enterprise/firewall.rs
+++ b/src/enterprise/firewall.rs
@@ -123,11 +123,12 @@ pub async fn generate_firewall_rules_from_acls(
         protocols.dedup();
 
         // skip creating default firewall rules if given ACL includes only destination aliases and no manual destination config
-        if !(!destination_aliases.is_empty()
-            && destination_addrs.is_empty()
-            && destination_ports.is_empty()
-            && protocols.is_empty())
-        {
+        let has_no_manual_destination =
+            destination_addrs.is_empty() && destination_ports.is_empty() && protocols.is_empty();
+        let has_destination_aliases = !destination_aliases.is_empty();
+        let is_destination_alias_only_rule = has_destination_aliases && has_no_manual_destination;
+
+        if !is_destination_alias_only_rule {
             // check if source addrs list is empty
             if source_addrs.is_empty() {
                 debug!(

--- a/src/enterprise/firewall.rs
+++ b/src/enterprise/firewall.rs
@@ -2513,4 +2513,209 @@ mod test {
             Some("ACL 1 - test rule, ALIAS 1 - destination alias DENY".to_string())
         );
     }
+
+    #[sqlx::test]
+    async fn test_destination_alias_only_acl(_: PgPoolOptions, options: PgConnectOptions) {
+        let pool = setup_pool(options).await;
+
+        let mut rng = thread_rng();
+
+        // Create test location
+        let location = WireguardNetwork {
+            id: NoId,
+            acl_enabled: true,
+            ..Default::default()
+        }
+        .save(&pool)
+        .await
+        .unwrap();
+
+        // Setup some test users and their devices
+        let user_1: User<NoId> = rng.gen();
+        let user_1 = user_1.save(&pool).await.unwrap();
+        let user_2: User<NoId> = rng.gen();
+        let user_2 = user_2.save(&pool).await.unwrap();
+
+        for user in [&user_1, &user_2] {
+            // Create 2 devices per user
+            for device_num in 1..3 {
+                let device = Device {
+                    id: NoId,
+                    name: format!("device-{}-{}", user.id, device_num),
+                    user_id: user.id,
+                    device_type: DeviceType::User,
+                    description: None,
+                    wireguard_pubkey: Default::default(),
+                    created: Default::default(),
+                    configured: true,
+                };
+                let device = device.save(&pool).await.unwrap();
+
+                // Add device to location's VPN network
+                let network_device = WireguardNetworkDevice {
+                    device_id: device.id,
+                    wireguard_network_id: location.id,
+                    wireguard_ip: IpAddr::V4(Ipv4Addr::new(10, 0, user.id as u8, device_num as u8)),
+                    preshared_key: None,
+                    is_authorized: true,
+                    authorized_at: None,
+                };
+                network_device.insert(&pool).await.unwrap();
+            }
+        }
+
+        // create ACL rule without manually configured destination
+        let acl_rule = AclRule {
+            id: NoId,
+            name: "test rule".to_string(),
+            expires: None,
+            enabled: true,
+            state: RuleState::Applied,
+            destination: Vec::new(),
+            allow_all_users: true,
+            ..Default::default()
+        }
+        .save(&pool)
+        .await
+        .unwrap();
+
+        // create different kinds of aliases and add them to the rule
+        let destination_alias_1 = AclAlias {
+            id: NoId,
+            name: "postgres".to_string(),
+            kind: AliasKind::Destination,
+            destination: vec!["10.0.2.3".parse().unwrap()],
+            ports: vec![PortRange::new(5432, 5432).into()],
+            ..Default::default()
+        }
+        .save(&pool)
+        .await
+        .unwrap();
+        let destination_alias_2 = AclAlias {
+            id: NoId,
+            name: "redis".to_string(),
+            kind: AliasKind::Destination,
+            destination: vec!["10.0.2.4".parse().unwrap()],
+            ports: vec![PortRange::new(6379, 6379).into()],
+            ..Default::default()
+        }
+        .save(&pool)
+        .await
+        .unwrap();
+        for alias in [&destination_alias_1, &destination_alias_2] {
+            let obj = AclRuleAlias {
+                id: NoId,
+                rule_id: acl_rule.id,
+                alias_id: alias.id,
+            };
+            obj.save(&pool).await.unwrap();
+        }
+
+        // assign rule to location
+        let obj = AclRuleNetwork {
+            id: NoId,
+            rule_id: acl_rule.id,
+            network_id: location.id,
+        };
+        obj.save(&pool).await.unwrap();
+
+        let mut conn = pool.acquire().await.unwrap();
+        let generated_firewall_rules = location
+            .try_get_firewall_config(&mut conn)
+            .await
+            .unwrap()
+            .unwrap()
+            .rules;
+
+        // check generated rules
+        assert_eq!(generated_firewall_rules.len(), 4);
+        let expected_source_addrs = vec![
+            IpAddress {
+                address: Some(Address::IpRange(IpRange {
+                    start: "10.0.1.1".to_string(),
+                    end: "10.0.1.2".to_string(),
+                })),
+            },
+            IpAddress {
+                address: Some(Address::IpRange(IpRange {
+                    start: "10.0.2.1".to_string(),
+                    end: "10.0.2.2".to_string(),
+                })),
+            },
+        ];
+
+        let alias_allow_rule_1 = &generated_firewall_rules[0];
+        assert_eq!(alias_allow_rule_1.verdict, i32::from(FirewallPolicy::Allow));
+        assert_eq!(alias_allow_rule_1.source_addrs, expected_source_addrs);
+        assert_eq!(
+            alias_allow_rule_1.destination_addrs,
+            vec![IpAddress {
+                address: Some(Address::Ip("10.0.2.3".to_string())),
+            },]
+        );
+        assert_eq!(
+            alias_allow_rule_1.destination_ports,
+            vec![Port {
+                port: Some(PortInner::SinglePort(5432))
+            }]
+        );
+        assert!(alias_allow_rule_1.protocols.is_empty());
+        assert_eq!(
+            alias_allow_rule_1.comment,
+            Some("ACL 1 - test rule, ALIAS 1 - postgres ALLOW".to_string())
+        );
+
+        let alias_allow_rule_2 = &generated_firewall_rules[1];
+        assert_eq!(alias_allow_rule_2.verdict, i32::from(FirewallPolicy::Allow));
+        assert_eq!(alias_allow_rule_2.source_addrs, expected_source_addrs);
+        assert_eq!(
+            alias_allow_rule_2.destination_addrs,
+            vec![IpAddress {
+                address: Some(Address::Ip("10.0.2.4".to_string())),
+            },]
+        );
+        assert_eq!(
+            alias_allow_rule_2.destination_ports,
+            vec![Port {
+                port: Some(PortInner::SinglePort(6379))
+            }]
+        );
+        assert!(alias_allow_rule_2.protocols.is_empty());
+        assert_eq!(
+            alias_allow_rule_2.comment,
+            Some("ACL 1 - test rule, ALIAS 2 - redis ALLOW".to_string())
+        );
+
+        let alias_deny_rule_1 = &generated_firewall_rules[2];
+        assert_eq!(alias_deny_rule_1.verdict, i32::from(FirewallPolicy::Deny));
+        assert!(alias_deny_rule_1.source_addrs.is_empty());
+        assert_eq!(
+            alias_deny_rule_1.destination_addrs,
+            vec![IpAddress {
+                address: Some(Address::Ip("10.0.2.3".to_string())),
+            },]
+        );
+        assert!(alias_deny_rule_1.destination_ports.is_empty(),);
+        assert!(alias_deny_rule_1.protocols.is_empty());
+        assert_eq!(
+            alias_deny_rule_1.comment,
+            Some("ACL 1 - test rule, ALIAS 1 - postgres DENY".to_string())
+        );
+
+        let alias_deny_rule_2 = &generated_firewall_rules[3];
+        assert_eq!(alias_deny_rule_2.verdict, i32::from(FirewallPolicy::Deny));
+        assert!(alias_deny_rule_2.source_addrs.is_empty());
+        assert_eq!(
+            alias_deny_rule_2.destination_addrs,
+            vec![IpAddress {
+                address: Some(Address::Ip("10.0.2.4".to_string())),
+            },]
+        );
+        assert!(alias_deny_rule_2.destination_ports.is_empty(),);
+        assert!(alias_deny_rule_2.protocols.is_empty());
+        assert_eq!(
+            alias_deny_rule_2.comment,
+            Some("ACL 1 - test rule, ALIAS 2 - redis DENY".to_string())
+        );
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 #![allow(clippy::too_many_arguments)]
+// FIXME: actually refactor errors instead
+#![allow(clippy::result_large_err)]
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     sync::{Arc, Mutex},

--- a/web/src/i18n/en/index.ts
+++ b/web/src/i18n/en/index.ts
@@ -991,7 +991,7 @@ Licensing information: [https://docs.defguard.net/enterprise/license](https://do
       support: 'Support',
       devices: 'Network Devices',
     },
-    copyright: 'Copyright ©2023-2024',
+    copyright: 'Copyright ©2023-2025',
     version: {
       open: 'Application version: {version: string}',
       closed: 'v{version: string}',

--- a/web/src/i18n/ko/index.ts
+++ b/web/src/i18n/ko/index.ts
@@ -774,7 +774,7 @@ const translation: Translation = {
       enrollment: '등록',
       support: '지원',
     },
-    copyright: 'Copyright ©2023-2024',
+    copyright: 'Copyright ©2023-2025',
     version: {
       open: '애플리케이션 버전: {version: string}',
       closed: 'v{version: string}',

--- a/web/src/i18n/pl/index.ts
+++ b/web/src/i18n/pl/index.ts
@@ -958,7 +958,7 @@ Uwaga, podane tutaj konfiguracje nie posiadają klucza prywatnego. Musisz uzupe�
       support: 'Wsparcie',
       groups: 'Grupy',
     },
-    copyright: 'Copyright ©2023-2024',
+    copyright: 'Copyright ©2023-2025',
     version: {
       open: 'Wersja aplikacji: {version}',
       closed: 'v{version}',


### PR DESCRIPTION
Avoid creating allow-all firewall rules for ACLs which consist of only destination aliases.

resolves https://github.com/DefGuard/defguard/issues/1153 https://github.com/DefGuard/defguard/issues/1156
