### PR TITLE
Fix LDAP login

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1070,7 +1070,7 @@ dependencies = [
 
 [[package]]
 name = "defguard"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "defguard"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2021"
 license-file = "LICENSE.md"
 homepage = "https://defguard.net/"
@@ -18,6 +18,10 @@ axum-extra = { version = "0.10", features = ["cookie-private", "typed-header"] }
 base32 = "0.5"
 base64 = "0.22"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
+chrono = { version = "0.4", default-features = false, features = [
+    "clock",
+    "serde",
+] }
 clap = { version = "4.5", features = ["derive", "env"] }
 dotenvy = "0.15"
 humantime = "2.1"
@@ -30,7 +34,9 @@ lettre = { version = "0.11", features = ["tokio1-native-tls"] }
 md4 = "0.10"
 mime_guess = "2.0"
 model_derive = { path = "model-derive" }
-openidconnect = { version = "4.0", default-features = false, optional = true, features = ["reqwest"] }
+openidconnect = { version = "4.0", default-features = false, optional = true, features = [
+    "reqwest",
+] }
 parse_link_header = "0.4"
 paste = "1.0.15"
 pgp = "0.14"
@@ -52,14 +58,26 @@ serde_json = "1.0"
 serde_urlencoded = "0.7"
 sha-1 = "0.10"
 sha256 = "1.5"
-sqlx = { version = "0.8", features = ["chrono", "ipnetwork", "postgres", "runtime-tokio-native-tls", "uuid"] }
+sqlx = { version = "0.8", features = [
+    "chrono",
+    "ipnetwork",
+    "postgres",
+    "runtime-tokio-native-tls",
+    "uuid",
+] }
 ssh-key = "0.6"
 struct-patch = "0.8"
 tera = "1.20"
 thiserror = "2.0"
 # match axum-extra -> cookies
 time = { version = "0.3", default-features = false }
-tokio = { version = "1", features = ["macros", "parking_lot", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1", features = [
+    "macros",
+    "parking_lot",
+    "rt-multi-thread",
+    "sync",
+    "time",
+] }
 tokio-stream = "0.1"
 tokio-util = "0.7"
 tonic = { version = "0.12", features = ["gzip", "tls-native-roots"] }
@@ -75,7 +93,9 @@ utoipa = { version = "5", features = ["axum_extras", "chrono", "uuid"] }
 utoipa-swagger-ui = { version = "9", features = ["axum", "vendored"] }
 uuid = { version = "1.9", features = ["v4"] }
 webauthn-authenticator-rs = { version = "0.5" }
-webauthn-rs = { version = "0.5", features = ["danger-allow-state-serialisation"] }
+webauthn-rs = { version = "0.5", features = [
+    "danger-allow-state-serialisation",
+] }
 webauthn-rs-proto = "0.5"
 x25519-dalek = { version = "2.0", features = ["static_secrets"] }
 
@@ -88,7 +108,13 @@ bytes = "1.6"
 claims = "0.8"
 matches = "0.1"
 regex = "1.10"
-reqwest = { version = "0.12", features = ["cookies", "json", "multipart", "rustls-tls", "stream"], default-features = false }
+reqwest = { version = "0.12", features = [
+    "cookies",
+    "json",
+    "multipart",
+    "rustls-tls",
+    "stream",
+], default-features = false }
 serde_qs = "0.13"
 webauthn-authenticator-rs = { version = "0.5", features = ["softpasskey"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ axum-client-ip = "0.7"
 axum-extra = { version = "0.10", features = ["cookie-private", "typed-header"] }
 base32 = "0.5"
 base64 = "0.22"
-chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 chrono = { version = "0.4", default-features = false, features = [
     "clock",
     "serde",

--- a/src/db/models/user.rs
+++ b/src/db/models/user.rs
@@ -172,11 +172,12 @@ impl<I> User<I> {
     }
 
     pub(crate) fn verify_password(&self, password: &str) -> Result<(), HashError> {
+        debug!("Checking if password matches for user {}", self.username);
         if let Some(hash) = &self.password_hash {
             let parsed_hash = PasswordHash::new(hash)?;
             Argon2::default().verify_password(password.as_bytes(), &parsed_hash)
         } else {
-            error!("Password not set for user {}", self.username);
+            info!("User {} has no password set", self.username);
             Err(HashError::Password)
         }
     }

--- a/src/enterprise/ldap/client.rs
+++ b/src/enterprise/ldap/client.rs
@@ -93,6 +93,7 @@ impl super::LDAPConnection {
             .success()?;
         debug!("LDAP user groups search result: {res}");
         debug!("Performed LDAP group search with filter = {filter}");
+        debug!("Found groups: {rs:?}");
         Ok(rs.into_iter().map(SearchEntry::construct).collect())
     }
 


### PR DESCRIPTION
- adds more logs displayed during LDAP login process
- removes some redundant checks during LDAP login which may have previously prevented some users from logging in, the user login is now accepted if the user belongs to one of the sync groups in LDAP (if defined) and is active
- always marks user as coming from ldap if the LDAP login succeeds