### PR TITLE
fix how VPN client endpoint is parsed

### DIFF
--- a/crates/defguard_core/src/grpc/gateway/client_state.rs
+++ b/crates/defguard_core/src/grpc/gateway/client_state.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, net::IpAddr};
+use std::{collections::HashMap, net::SocketAddr};
 
 use chrono::{NaiveDateTime, TimeDelta, Utc};
 use thiserror::Error;
@@ -31,8 +31,8 @@ pub struct ClientState {
     pub device: Device<Id>,
     pub user_id: Id,
     pub username: String,
-    // current IP from which the client is connecting
-    pub endpoint: IpAddr,
+    // current IP & port from which the client is connecting
+    pub endpoint: SocketAddr,
     pub latest_handshake: NaiveDateTime,
     // when last stats update was received
     pub latest_update: NaiveDateTime,
@@ -46,7 +46,7 @@ impl ClientState {
     pub fn new(
         device: Device<Id>,
         user: &User<Id>,
-        endpoint: IpAddr,
+        endpoint: SocketAddr,
         latest_handshake: NaiveDateTime,
         total_upload: i64,
         total_download: i64,
@@ -67,7 +67,7 @@ impl ClientState {
     pub fn update_client_state(
         &mut self,
         current_device: Device<Id>,
-        current_endpoint: IpAddr,
+        current_endpoint: SocketAddr,
         latest_handshake: NaiveDateTime,
         upload: i64,
         download: i64,
@@ -110,7 +110,7 @@ impl ClientMap {
         public_key: &str,
         device: &Device<Id>,
         user: &User<Id>,
-        endpoint: IpAddr,
+        endpoint: SocketAddr,
         stats: &WireguardPeerStats,
     ) -> Result<(), ClientMapError> {
         info!(
@@ -182,7 +182,7 @@ impl ClientMap {
                 let disconnect_event_context = GrpcRequestContext::new(
                     client_state.user_id,
                     client_state.username.clone(),
-                    client_state.endpoint,
+                    client_state.endpoint.ip(),
                     client_state.device.id,
                     client_state.device.name.clone(),
                 );

--- a/crates/defguard_core/src/grpc/gateway/mod.rs
+++ b/crates/defguard_core/src/grpc/gateway/mod.rs
@@ -1,6 +1,6 @@
 mod client_state;
 use std::{
-    net::IpAddr,
+    net::{IpAddr, SocketAddr},
     pin::Pin,
     sync::{Arc, Mutex},
     task::{Context, Poll},
@@ -755,7 +755,7 @@ impl gateway_service_server::GatewayService for GatewayServer {
             // but has not connected yet
             if let Some(endpoint) = &stats.endpoint {
                 // parse client endpoint IP
-                let ip_addr = endpoint.clone().parse().map_err(|err| {
+                let socket_addr: SocketAddr = endpoint.clone().parse().map_err(|err| {
                     error!("Failed to parse VPN client endpoint: {err}");
                     Status::new(
                         Code::Internal,
@@ -774,7 +774,7 @@ impl gateway_service_server::GatewayService for GatewayServer {
                             // update connected client state
                             client_state.update_client_state(
                                 device,
-                                ip_addr,
+                                socket_addr,
                                 stats.latest_handshake,
                                 stats.upload,
                                 stats.download,
@@ -788,7 +788,7 @@ impl gateway_service_server::GatewayService for GatewayServer {
                                 &public_key,
                                 &device,
                                 &user,
-                                ip_addr,
+                                socket_addr,
                                 &stats,
                             )?;
 
@@ -796,7 +796,7 @@ impl gateway_service_server::GatewayService for GatewayServer {
                             let context = GrpcRequestContext::new(
                                 user.id,
                                 user.username.clone(),
-                                ip_addr,
+                                socket_addr.ip(),
                                 device.id,
                                 device.name.clone(),
                             );


### PR DESCRIPTION
The endpoint we receive from gateway in wireguard peer stats updates includes a port, so it should actually be parsed as SocketAddr and only later converted to IpAddr