### PR TITLE
Pass admin device management flag in enrollment start response

### DIFF
--- a/crates/defguard_core/src/grpc/enrollment.rs
+++ b/crates/defguard_core/src/grpc/enrollment.rs
@@ -227,9 +227,10 @@ impl EnrollmentServer {
                         error!("Failed to get enterprise settings: {err}");
                         Status::internal("unexpected error")
                     })?;
-            let enrollment_settings = super::proto::proxy::Settings {
+            let enrollment_settings = super::proto::proxy::EnrollmentSettings {
                 vpn_setup_optional,
                 only_client_activation: enterprise_settings.only_client_activation,
+                admin_device_management: enterprise_settings.admin_device_management,
             };
             let response = super::proto::proxy::EnrollmentStartResponse {
                 admin: admin_info,

--- a/crates/defguard_core/src/grpc/enrollment.rs
+++ b/crates/defguard_core/src/grpc/enrollment.rs
@@ -742,6 +742,7 @@ impl InitialUserInfo {
         let enrolled = user.is_enrolled();
         let devices = user.user_devices(pool).await?;
         let device_names = devices.into_iter().map(|dev| dev.device.name).collect();
+        let is_admin = user.is_admin(pool).await?;
         Ok(Self {
             first_name: user.first_name,
             last_name: user.last_name,
@@ -751,6 +752,7 @@ impl InitialUserInfo {
             is_active: user.is_active,
             device_names,
             enrolled,
+            is_admin,
         })
     }
 }


### PR DESCRIPTION
Send admin device management flag from enterprise settings to the proxy in enrollment start response.

Also actually validate this flag during device creation in enrollment process.

Related to https://github.com/DefGuard/proxy/issues/111