### PR TITLE
Add location MFA settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,9 +901,9 @@ checksum = "fd121741cf3eb82c08dd3023eb55bf2665e5f60ec20f89760cf836ae4562e6a0"
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -6277,9 +6277,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]

--- a/crates/defguard_core/src/db/models/activity_log/metadata.rs
+++ b/crates/defguard_core/src/db/models/activity_log/metadata.rs
@@ -391,7 +391,6 @@ pub struct SettingsNoSecrets {
     // Whether to create a new account when users try to log in with external OpenID
     pub openid_create_account: bool,
     pub openid_username_handling: OpenidUsernameHandling,
-    pub use_openid_for_mfa: bool,
     pub license: Option<String>,
     // Gateway disconnect notifications
     pub gateway_disconnect_notifications_enabled: bool,
@@ -443,7 +442,6 @@ impl From<Settings> for SettingsNoSecrets {
             ldap_sync_groups: value.ldap_sync_groups,
             openid_create_account: value.openid_create_account,
             openid_username_handling: value.openid_username_handling,
-            use_openid_for_mfa: value.use_openid_for_mfa,
             license: value.license,
             gateway_disconnect_notifications_enabled: value
                 .gateway_disconnect_notifications_enabled,

--- a/crates/defguard_core/src/db/models/device.rs
+++ b/crates/defguard_core/src/db/models/device.rs
@@ -40,8 +40,8 @@ pub struct DeviceConfig {
     pub(crate) allowed_ips: Vec<IpNetwork>,
     pub(crate) pubkey: String,
     pub(crate) dns: Option<String>,
-    pub(crate) mfa_enabled: bool,
     pub(crate) keepalive_interval: i32,
+    pub(crate) location_mfa: LocationMfaType,
 }
 
 // The type of a device:
@@ -692,8 +692,8 @@ impl Device<Id> {
             allowed_ips: network.allowed_ips.clone(),
             pubkey: network.pubkey.clone(),
             dns: network.dns.clone(),
-            mfa_enabled: network.mfa_enabled(),
             keepalive_interval: network.keepalive_interval,
+            location_mfa: network.location_mfa.clone(),
         };
 
         Ok((device_network_info, device_config))
@@ -725,8 +725,8 @@ impl Device<Id> {
             allowed_ips: network.allowed_ips.clone(),
             pubkey: network.pubkey.clone(),
             dns: network.dns.clone(),
-            mfa_enabled: network.mfa_enabled(),
             keepalive_interval: network.keepalive_interval,
+            location_mfa: network.location_mfa.clone(),
         };
 
         Ok((device_network_info, device_config))
@@ -778,7 +778,6 @@ impl Device<Id> {
                 network_info.push(device_network_info);
 
                 let config = Self::create_config(&network, &wireguard_network_device);
-                let mfa_enabled = network.mfa_enabled();
                 configs.push(DeviceConfig {
                     network_id: network.id,
                     network_name: network.name,
@@ -788,8 +787,8 @@ impl Device<Id> {
                     allowed_ips: network.allowed_ips,
                     pubkey: network.pubkey,
                     dns: network.dns,
-                    mfa_enabled,
                     keepalive_interval: network.keepalive_interval,
+                    location_mfa: network.location_mfa.clone(),
                 });
             }
         }

--- a/crates/defguard_core/src/db/models/settings.rs
+++ b/crates/defguard_core/src/db/models/settings.rs
@@ -120,7 +120,6 @@ pub struct Settings {
     // Whether to create a new account when users try to log in with external OpenID
     pub openid_create_account: bool,
     pub openid_username_handling: OpenidUsernameHandling,
-    pub use_openid_for_mfa: bool,
     pub license: Option<String>,
     // Gateway disconnect notifications
     pub gateway_disconnect_notifications_enabled: bool,
@@ -153,7 +152,7 @@ impl Settings {
             ldap_enabled, ldap_sync_enabled, ldap_is_authoritative, \
             ldap_sync_interval, ldap_user_auxiliary_obj_classes, ldap_uses_ad, \
             ldap_user_rdn_attr, ldap_sync_groups, \
-            openid_username_handling \"openid_username_handling: OpenidUsernameHandling\", use_openid_for_mfa \
+            openid_username_handling \"openid_username_handling: OpenidUsernameHandling\" \
             FROM \"settings\" WHERE id = 1",
         )
         .fetch_optional(executor)
@@ -225,8 +224,7 @@ impl Settings {
             ldap_uses_ad = $45, \
             ldap_user_rdn_attr = $46, \
             ldap_sync_groups = $47, \
-            openid_username_handling = $48, \
-            use_openid_for_mfa = $49 \
+            openid_username_handling = $48 \
             WHERE id = 1",
             self.openid_enabled,
             self.wireguard_enabled,
@@ -276,7 +274,6 @@ impl Settings {
             self.ldap_user_rdn_attr,
             &self.ldap_sync_groups as &Vec<String>,
             &self.openid_username_handling as &OpenidUsernameHandling,
-            self.use_openid_for_mfa,
         )
         .execute(executor)
         .await?;

--- a/crates/defguard_core/src/db/models/wireguard.rs
+++ b/crates/defguard_core/src/db/models/wireguard.rs
@@ -84,7 +84,8 @@ pub enum GatewayEvent {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize, ToSchema, Type)]
-#[sqlx(type_name = "location_mfa_type", rename_all = "snake_case")]
+#[sqlx(type_name = "location_mfa_type", rename_all = "lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum LocationMfaType {
     #[default]
     Disabled,

--- a/crates/defguard_core/src/db/models/wireguard.rs
+++ b/crates/defguard_core/src/db/models/wireguard.rs
@@ -35,7 +35,7 @@ use crate::{
     grpc::{
         GatewayState,
         gateway::{Peer, send_multiple_wireguard_events},
-        proto::enterprise::firewall::FirewallConfig,
+        proto::{enterprise::firewall::FirewallConfig, proxy::LocationMfa as ProtoLocationMfa},
     },
     wg_config::ImportedDevice,
 };
@@ -91,6 +91,25 @@ pub enum LocationMfaType {
     Disabled,
     Internal,
     External,
+}
+
+impl From<ProtoLocationMfa> for LocationMfaType {
+    fn from(value: ProtoLocationMfa) -> Self {
+        match value {
+            ProtoLocationMfa::Unspecified | ProtoLocationMfa::Disabled => LocationMfaType::Disabled,
+            ProtoLocationMfa::Internal => LocationMfaType::Internal,
+            ProtoLocationMfa::External => LocationMfaType::External,
+        }
+    }
+}
+impl From<LocationMfaType> for ProtoLocationMfa {
+    fn from(value: LocationMfaType) -> Self {
+        match value {
+            LocationMfaType::Disabled => ProtoLocationMfa::Disabled,
+            LocationMfaType::Internal => ProtoLocationMfa::Internal,
+            LocationMfaType::External => ProtoLocationMfa::External,
+        }
+    }
 }
 
 /// Stores configuration required to setup a WireGuard network

--- a/crates/defguard_core/src/enterprise/db/models/acl.rs
+++ b/crates/defguard_core/src/enterprise/db/models/acl.rs
@@ -17,7 +17,10 @@ use thiserror::Error;
 use crate::{
     DeviceType,
     appstate::AppState,
-    db::{Device, GatewayEvent, Group, Id, NoId, User, WireguardNetwork},
+    db::{
+        Device, GatewayEvent, Group, Id, NoId, User, WireguardNetwork,
+        models::wireguard::LocationMfaType,
+    },
     enterprise::{
         firewall::FirewallError,
         handlers::acl::{ApiAclAlias, ApiAclRule, EditAclAlias, EditAclRule},
@@ -904,8 +907,8 @@ impl AclRule<Id> {
             query_as!(
                 WireguardNetwork,
                 "SELECT n.id, name, address, port, pubkey, prvkey, endpoint, dns, allowed_ips, \
-                connected_at, mfa_enabled, keepalive_interval, peer_disconnect_threshold, \
-                acl_enabled, acl_default_allow \
+                connected_at, keepalive_interval, peer_disconnect_threshold, \
+                acl_enabled, acl_default_allow, location_mfa \"location_mfa: LocationMfaType\" \
                 FROM aclrulenetwork r \
                 JOIN wireguard_network n \
                 ON n.id = r.network_id \

--- a/crates/defguard_core/src/enterprise/db/models/acl/tests.rs
+++ b/crates/defguard_core/src/enterprise/db/models/acl/tests.rs
@@ -177,11 +177,11 @@ async fn test_rule_relations(_: PgPoolOptions, options: PgConnectOptions) {
         "endpoint1".to_string(),
         None,
         Vec::new(),
-        false,
         100,
         100,
         false,
         false,
+        LocationMfaType::Disabled,
     )
     .unwrap()
     .save(&pool)
@@ -194,11 +194,11 @@ async fn test_rule_relations(_: PgPoolOptions, options: PgConnectOptions) {
         "endpoint2".to_string(),
         None,
         Vec::new(),
-        false,
         200,
         200,
         false,
         false,
+        LocationMfaType::Disabled,
     )
     .unwrap()
     .save(&pool)

--- a/crates/defguard_core/src/enterprise/directory_sync/mod.rs
+++ b/crates/defguard_core/src/enterprise/directory_sync/mod.rs
@@ -911,7 +911,10 @@ mod test {
         config::DefGuardConfig,
         db::{
             Device, Session, SessionState, Settings, WireguardNetwork,
-            models::{device::DeviceType, settings::initialize_current_settings},
+            models::{
+                device::DeviceType, settings::initialize_current_settings,
+                wireguard::LocationMfaType,
+            },
             setup_pool,
         },
         enterprise::db::models::openid_provider::DirectorySyncTarget,
@@ -948,11 +951,11 @@ mod test {
             "123.123.123.123".to_string(),
             None,
             vec![],
-            false,
             32,
             32,
             false,
             false,
+            LocationMfaType::Disabled,
         )
         .unwrap()
         .save(pool)

--- a/crates/defguard_core/src/enterprise/handlers/openid_providers.rs
+++ b/crates/defguard_core/src/enterprise/handlers/openid_providers.rs
@@ -41,7 +41,6 @@ pub struct AddProviderData {
     pub okta_dirsync_client_id: Option<String>,
     pub directory_sync_group_match: Option<String>,
     pub username_handling: OpenidUsernameHandling,
-    pub use_openid_for_mfa: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/crates/defguard_core/src/grpc/enrollment.rs
+++ b/crates/defguard_core/src/grpc/enrollment.rs
@@ -23,6 +23,7 @@ use crate::{
             device::{DeviceConfig, DeviceInfo, DeviceType},
             enrollment::{ENROLLMENT_TOKEN_TYPE, Token, TokenError},
             polling_token::PollingToken,
+            wireguard::LocationMfaType,
         },
     },
     enterprise::{
@@ -31,7 +32,10 @@ use crate::{
         limits::update_counts,
     },
     events::{BidiRequestContext, BidiStreamEvent, BidiStreamEventType, EnrollmentEvent},
-    grpc::utils::{build_device_config_response, new_polling_token, parse_client_info},
+    grpc::{
+        proto::proxy::LocationMfa as ProtoLocationMfa,
+        utils::{build_device_config_response, new_polling_token, parse_client_info},
+    },
     handlers::{mail::send_new_device_added_email, user::check_password_strength},
     headers::get_device_info,
     mail::Mail,
@@ -856,8 +860,10 @@ impl From<DeviceConfig> for ProtoDeviceConfig {
             pubkey: config.pubkey,
             allowed_ips: config.allowed_ips.as_csv(),
             dns: config.dns,
-            mfa_enabled: config.mfa_enabled,
             keepalive_interval: config.keepalive_interval,
+            location_mfa: Some(
+                <LocationMfaType as Into<ProtoLocationMfa>>::into(config.location_mfa).into(),
+            ),
         }
     }
 }

--- a/crates/defguard_core/src/grpc/gateway/mod.rs
+++ b/crates/defguard_core/src/grpc/gateway/mod.rs
@@ -106,7 +106,7 @@ impl WireguardNetwork<Id> {
             AND u.is_active = true \
             ORDER BY d.id ASC",
             self.id,
-            self.mfa_enabled
+            self.mfa_enabled()
         )
         .fetch_all(executor)
         .await?;
@@ -393,7 +393,7 @@ impl GatewayUpdatesHandler {
                         .find(|info| info.network_id == self.network_id)
                     {
                         Some(network_info) => {
-                            if self.network.mfa_enabled && !network_info.is_authorized {
+                            if self.network.mfa_enabled() && !network_info.is_authorized {
                                 debug!(
                                     "Created WireGuard device {} is not authorized to connect to MFA enabled location {}",
                                     device.device.name, self.network.name
@@ -428,7 +428,7 @@ impl GatewayUpdatesHandler {
                         .find(|info| info.network_id == self.network_id)
                     {
                         Some(network_info) => {
-                            if self.network.mfa_enabled && !network_info.is_authorized {
+                            if self.network.mfa_enabled() && !network_info.is_authorized {
                                 debug!(
                                     "Modified WireGuard device {} is not authorized to connect to MFA enabled location {}",
                                     device.device.name, self.network.name

--- a/crates/defguard_core/src/grpc/mod.rs
+++ b/crates/defguard_core/src/grpc/mod.rs
@@ -948,7 +948,6 @@ pub struct InstanceInfo {
     username: String,
     disable_all_traffic: bool,
     enterprise_enabled: bool,
-    use_openid_for_mfa: bool,
     openid_display_name: Option<String>,
 }
 
@@ -972,11 +971,6 @@ impl InstanceInfo {
             username: username.into(),
             disable_all_traffic: enterprise_settings.disable_all_traffic,
             enterprise_enabled: is_enterprise_enabled(),
-            use_openid_for_mfa: if is_enterprise_enabled() {
-                settings.use_openid_for_mfa
-            } else {
-                false
-            },
             openid_display_name,
         }
     }
@@ -992,7 +986,6 @@ impl From<InstanceInfo> for proto::proxy::InstanceInfo {
             username: instance.username,
             disable_all_traffic: instance.disable_all_traffic,
             enterprise_enabled: instance.enterprise_enabled,
-            use_openid_for_mfa: instance.use_openid_for_mfa,
             openid_display_name: instance.openid_display_name,
         }
     }

--- a/crates/defguard_core/src/grpc/utils.rs
+++ b/crates/defguard_core/src/grpc/utils.rs
@@ -118,6 +118,7 @@ pub(crate) async fn build_device_config_response(
                     );
                     Status::internal(format!("unexpected error: {err}"))
                 })?;
+            let mfa_enabled = network.mfa_enabled();
             let config = ProtoDeviceConfig {
                 config: Device::create_config(&network, &wireguard_network_device),
                 network_id: network.id,
@@ -127,7 +128,7 @@ pub(crate) async fn build_device_config_response(
                 pubkey: network.pubkey,
                 allowed_ips: network.allowed_ips.as_csv(),
                 dns: network.dns,
-                mfa_enabled: network.mfa_enabled,
+                mfa_enabled,
                 keepalive_interval: network.keepalive_interval,
             };
             configs.push(config);
@@ -145,6 +146,7 @@ pub(crate) async fn build_device_config_response(
                 );
                 Status::internal(format!("unexpected error: {err}"))
             })?;
+            let mfa_enabled = network.mfa_enabled();
             if let Some(wireguard_network_device) = wireguard_network_device {
                 let config = ProtoDeviceConfig {
                     config: Device::create_config(&network, &wireguard_network_device),
@@ -155,7 +157,7 @@ pub(crate) async fn build_device_config_response(
                     pubkey: network.pubkey,
                     allowed_ips: network.allowed_ips.as_csv(),
                     dns: network.dns,
-                    mfa_enabled: network.mfa_enabled,
+                    mfa_enabled,
                     keepalive_interval: network.keepalive_interval,
                 };
                 configs.push(config);

--- a/crates/defguard_core/src/handlers/wireguard.rs
+++ b/crates/defguard_core/src/handlers/wireguard.rs
@@ -145,11 +145,11 @@ pub(crate) async fn create_network(
         data.endpoint,
         data.dns,
         allowed_ips,
-        data.mfa_enabled,
         data.keepalive_interval,
         data.peer_disconnect_threshold,
         data.acl_enabled,
         data.acl_default_allow,
+        todo!(),
     )
     .map_err(|_| WebError::Serialization("Invalid network address".into()))?;
 
@@ -233,11 +233,11 @@ pub(crate) async fn modify_network(
     network.port = data.port;
     network.dns = data.dns;
     network.address = parse_address_list(&data.address);
-    network.mfa_enabled = data.mfa_enabled;
     network.keepalive_interval = data.keepalive_interval;
     network.peer_disconnect_threshold = data.peer_disconnect_threshold;
     network.acl_enabled = data.acl_enabled;
     network.acl_default_allow = data.acl_default_allow;
+    network.location_mfa = todo!();
 
     network.save(&mut *transaction).await?;
     network

--- a/crates/defguard_core/src/handlers/wireguard.rs
+++ b/crates/defguard_core/src/handlers/wireguard.rs
@@ -30,8 +30,8 @@ use crate::{
                 WireguardNetworkDevice,
             },
             wireguard::{
-                DateTimeAggregation, MappedDevice, WireguardDeviceStatsRow, WireguardNetworkInfo,
-                WireguardNetworkStats, WireguardUserStatsRow, networks_stats,
+                DateTimeAggregation, LocationMfaType, MappedDevice, WireguardDeviceStatsRow,
+                WireguardNetworkInfo, WireguardNetworkStats, WireguardUserStatsRow, networks_stats,
             },
         },
     },
@@ -75,11 +75,11 @@ pub struct WireguardNetworkData {
     pub allowed_ips: Option<String>,
     pub dns: Option<String>,
     pub allowed_groups: Vec<String>,
-    pub mfa_enabled: bool,
     pub keepalive_interval: i32,
     pub peer_disconnect_threshold: i32,
     pub acl_enabled: bool,
     pub acl_default_allow: bool,
+    pub location_mfa: LocationMfaType,
 }
 
 impl WireguardNetworkData {
@@ -149,7 +149,7 @@ pub(crate) async fn create_network(
         data.peer_disconnect_threshold,
         data.acl_enabled,
         data.acl_default_allow,
-        todo!(),
+        data.location_mfa,
     )
     .map_err(|_| WebError::Serialization("Invalid network address".into()))?;
 
@@ -237,7 +237,7 @@ pub(crate) async fn modify_network(
     network.peer_disconnect_threshold = data.peer_disconnect_threshold;
     network.acl_enabled = data.acl_enabled;
     network.acl_default_allow = data.acl_default_allow;
-    network.location_mfa = todo!();
+    network.location_mfa = data.location_mfa;
 
     network.save(&mut *transaction).await?;
     network

--- a/crates/defguard_core/src/lib.rs
+++ b/crates/defguard_core/src/lib.rs
@@ -13,7 +13,7 @@ use axum::{
     routing::{delete, get, patch, post, put},
     serve,
 };
-use db::models::device::DeviceType;
+use db::models::{device::DeviceType, wireguard::LocationMfaType};
 use defguard_web_ui::{index, svg, web_asset};
 use enterprise::{
     handlers::{
@@ -734,11 +734,11 @@ pub async fn init_dev_env(config: &DefGuardConfig) {
             "0.0.0.0".to_string(),
             None,
             vec![IpNetwork::new(IpAddr::V4(Ipv4Addr::new(10, 1, 1, 0)), 24).unwrap()],
-            false,
             DEFAULT_KEEPALIVE_INTERVAL,
             DEFAULT_DISCONNECT_THRESHOLD,
             false,
             false,
+            LocationMfaType::Disabled,
         )
         .expect("Could not create network");
         network.pubkey = "zGMeVGm9HV9I4wSKF9AXmYnnAIhDySyqLMuKpcfIaQo=".to_string();
@@ -833,11 +833,11 @@ pub async fn init_vpn_location(
                 args.endpoint.clone(),
                 args.dns.clone(),
                 args.allowed_ips.clone(),
-                false,
                 DEFAULT_KEEPALIVE_INTERVAL,
                 DEFAULT_DISCONNECT_THRESHOLD,
                 false,
                 false,
+                LocationMfaType::Disabled,
             )?
             .save(&mut *transaction)
             .await?;
@@ -872,11 +872,11 @@ pub async fn init_vpn_location(
             args.endpoint.clone(),
             args.dns.clone(),
             args.allowed_ips.clone(),
-            false,
             DEFAULT_KEEPALIVE_INTERVAL,
             DEFAULT_DISCONNECT_THRESHOLD,
             false,
             false,
+            LocationMfaType::Disabled,
         )?
         .save(pool)
         .await?

--- a/crates/defguard_core/src/wg_config.rs
+++ b/crates/defguard_core/src/wg_config.rs
@@ -10,7 +10,8 @@ use crate::{
     db::{
         Device, WireguardNetwork,
         models::wireguard::{
-            DEFAULT_DISCONNECT_THRESHOLD, DEFAULT_KEEPALIVE_INTERVAL, WireguardNetworkError,
+            DEFAULT_DISCONNECT_THRESHOLD, DEFAULT_KEEPALIVE_INTERVAL, LocationMfaType,
+            WireguardNetworkError,
         },
     },
 };
@@ -106,11 +107,11 @@ pub(crate) fn parse_wireguard_config(
         String::new(),
         dns,
         allowed_ips,
-        false,
         DEFAULT_KEEPALIVE_INTERVAL,
         DEFAULT_DISCONNECT_THRESHOLD,
         false,
         false,
+        LocationMfaType::Disabled,
     )?;
     network.pubkey = pubkey;
     network.prvkey = prvkey.to_string();

--- a/crates/defguard_core/src/wireguard_peer_disconnect.rs
+++ b/crates/defguard_core/src/wireguard_peer_disconnect.rs
@@ -27,7 +27,7 @@ use crate::{
         models::{
             device::{DeviceInfo, DeviceNetworkInfo, DeviceType, WireguardNetworkDevice},
             error::ModelError,
-            wireguard::WireguardNetworkError,
+            wireguard::{LocationMfaType, WireguardNetworkError},
         },
     },
     events::{InternalEvent, InternalEventContext},
@@ -96,9 +96,9 @@ pub async fn run_periodic_peer_disconnect(
             WireguardNetwork::<Id>,
             "SELECT \
                 id, name, address, port, pubkey, prvkey, endpoint, dns, allowed_ips, \
-                connected_at, mfa_enabled, keepalive_interval, peer_disconnect_threshold, \
-                acl_enabled, acl_default_allow \
-            FROM wireguard_network WHERE mfa_enabled = true",
+                connected_at, keepalive_interval, peer_disconnect_threshold, \
+                acl_enabled, acl_default_allow, location_mfa \"location_mfa: LocationMfaType\" \
+            FROM wireguard_network WHERE location_mfa != 'disabled'::location_mfa_type",
         )
         .fetch_all(&pool)
         .await?;

--- a/crates/defguard_core/tests/integration/acl.rs
+++ b/crates/defguard_core/tests/integration/acl.rs
@@ -2,7 +2,9 @@ use defguard_core::{
     config::DefGuardConfig,
     db::{
         Device, Group, Id, User, WireguardNetwork,
-        models::{device::DeviceType, settings::initialize_current_settings},
+        models::{
+            device::DeviceType, settings::initialize_current_settings, wireguard::LocationMfaType,
+        },
     },
     enterprise::{
         db::models::acl::{AclAlias, AclRule, AliasKind, AliasState, RuleState},
@@ -418,11 +420,11 @@ async fn test_related_objects(_: PgPoolOptions, options: PgConnectOptions) {
             "endpoint1".to_string(),
             None,
             Vec::new(),
-            false,
             100,
             100,
             false,
             false,
+            LocationMfaType::Disabled,
         )
         .unwrap()
         .save(&pool)
@@ -759,11 +761,11 @@ async fn test_rule_delete_state_applied(_: PgPoolOptions, options: PgConnectOpti
         "endpoint1".to_string(),
         None,
         Vec::new(),
-        false,
         100,
         100,
         false,
         false,
+        LocationMfaType::Disabled,
     )
     .unwrap()
     .save(&pool)

--- a/crates/defguard_core/tests/integration/openid_login.rs
+++ b/crates/defguard_core/tests/integration/openid_login.rs
@@ -56,7 +56,6 @@ async fn test_openid_providers(_: PgPoolOptions, options: PgConnectOptions) {
         okta_private_jwk: None,
         directory_sync_group_match: None,
         username_handling: OpenidUsernameHandling::PruneEmailDomain,
-        use_openid_for_mfa: false,
     };
 
     let response = client

--- a/crates/defguard_core/tests/integration/wireguard.rs
+++ b/crates/defguard_core/tests/integration/wireguard.rs
@@ -5,7 +5,9 @@ use defguard_core::{
         Device, GatewayEvent, Id, WireguardNetwork,
         models::{
             device::WireguardNetworkDevice,
-            wireguard::{DEFAULT_DISCONNECT_THRESHOLD, DEFAULT_KEEPALIVE_INTERVAL},
+            wireguard::{
+                DEFAULT_DISCONNECT_THRESHOLD, DEFAULT_KEEPALIVE_INTERVAL, LocationMfaType,
+            },
         },
     },
     handlers::{Auth, GroupInfo, wireguard::WireguardNetworkData},
@@ -56,11 +58,11 @@ async fn test_network(_: PgPoolOptions, options: PgConnectOptions) {
         allowed_ips: Some("10.1.1.0/24, 10.2.0.1/16, 10.10.10.54/32".into()),
         dns: None,
         allowed_groups: vec!["admin".into()],
-        mfa_enabled: false,
         keepalive_interval: DEFAULT_KEEPALIVE_INTERVAL,
         peer_disconnect_threshold: DEFAULT_DISCONNECT_THRESHOLD,
         acl_enabled: false,
         acl_default_allow: false,
+        location_mfa: LocationMfaType::Disabled,
     };
     let response = client
         .put(format!("/api/v1/network/{}", network.id))

--- a/crates/defguard_core/tests/integration/wireguard_network_import.rs
+++ b/crates/defguard_core/tests/integration/wireguard_network_import.rs
@@ -5,7 +5,9 @@ use defguard_core::{
         Device, GatewayEvent, WireguardNetwork,
         models::{
             device::{DeviceType, UserDevice},
-            wireguard::{DEFAULT_DISCONNECT_THRESHOLD, DEFAULT_KEEPALIVE_INTERVAL},
+            wireguard::{
+                DEFAULT_DISCONNECT_THRESHOLD, DEFAULT_KEEPALIVE_INTERVAL, LocationMfaType,
+            },
         },
     },
     handlers::{Auth, wireguard::ImportedNetworkData},
@@ -55,11 +57,11 @@ async fn test_config_import(_: PgPoolOptions, options: PgConnectOptions) {
         String::new(),
         None,
         vec![],
-        false,
         DEFAULT_KEEPALIVE_INTERVAL,
         DEFAULT_DISCONNECT_THRESHOLD,
         false,
         false,
+        LocationMfaType::Disabled,
     )
     .unwrap();
     initial_network.save(&pool).await.unwrap();

--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752201818,
-        "narHash": "sha256-d8KczaVT8WFEZdWg//tMAbv8EDyn2YTWcJvSY8gqKBU=",
+        "lastModified": 1752461263,
+        "narHash": "sha256-f4XVgqkWF1vSzPbOG5xvi4aAd/n1GwSNsji3mLMFwYQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "bd8f8329780b348fedcd37b53dbbee48c08c496d",
+        "rev": "9cc51d100d24fb7ea13a0bee1480ee84fa12a0ad",
         "type": "github"
       },
       "original": {

--- a/migrations/20250714203243_add_location_mfa_settings.down.sql
+++ b/migrations/20250714203243_add_location_mfa_settings.down.sql
@@ -1,0 +1,16 @@
+-- restore boolean `mfa_enabled` column
+ALTER TABLE wireguard_network ADD COLUMN "mfa_enabled" BOOLEAN DEFAULT false;
+
+-- populate based on MFA type
+UPDATE wireguard_network
+SET mfa_enabled = CASE
+    WHEN location_mfa = 'disabled'::location_mfa_type THEN false
+    ELSE true
+END;
+--
+-- make restored column NOT NULL
+ALTER TABLE wireguard_network ALTER COLUMN "mfa_enabled" SET NOT NULL;
+
+-- drop new column and type
+ALTER TABLE wireguard_network DROP COLUMN "location_mfa";
+DROP TYPE location_mfa_type;

--- a/migrations/20250714203243_add_location_mfa_settings.down.sql
+++ b/migrations/20250714203243_add_location_mfa_settings.down.sql
@@ -14,3 +14,6 @@ ALTER TABLE wireguard_network ALTER COLUMN "mfa_enabled" SET NOT NULL;
 -- drop new column and type
 ALTER TABLE wireguard_network DROP COLUMN "location_mfa";
 DROP TYPE location_mfa_type;
+
+-- restore `use_openid_for_mfa` setting
+ALTER TABLE settings ADD COLUMN use_openid_for_mfa BOOLEAN NOT NULL DEFAULT FALSE;

--- a/migrations/20250714203243_add_location_mfa_settings.up.sql
+++ b/migrations/20250714203243_add_location_mfa_settings.up.sql
@@ -1,0 +1,23 @@
+-- add enum representing location MFA configuration
+CREATE TYPE location_mfa_type AS ENUM (
+    'disabled',
+    'internal',
+    'external'
+);
+
+-- add nullable column to `wireguard_network` table
+ALTER TABLE wireguard_network ADD COLUMN "location_mfa" location_mfa_type DEFAULT 'disabled';
+
+-- populate new column based on value in `mfa_enabled` column
+-- previously only internal MFA was available
+UPDATE wireguard_network
+SET location_mfa = CASE
+    WHEN mfa_enabled = true THEN 'internal'::location_mfa_type
+    ELSE 'disabled'::location_mfa_type
+END;
+
+-- make new column NOT NULL
+ALTER TABLE wireguard_network ALTER COLUMN "location_mfa" SET NOT NULL;
+
+-- drop the `mfa_enabled` column since it's no longer needed
+ALTER TABLE wireguard_network DROP COLUMN mfa_enabled;

--- a/migrations/20250714203243_add_location_mfa_settings.up.sql
+++ b/migrations/20250714203243_add_location_mfa_settings.up.sql
@@ -21,3 +21,6 @@ ALTER TABLE wireguard_network ALTER COLUMN "location_mfa" SET NOT NULL;
 
 -- drop the `mfa_enabled` column since it's no longer needed
 ALTER TABLE wireguard_network DROP COLUMN mfa_enabled;
+
+-- remove `use_openid_for_mfa` setting
+ALTER TABLE settings DROP COLUMN use_openid_for_mfa;

--- a/web/src/i18n/en/index.ts
+++ b/web/src/i18n/en/index.ts
@@ -1287,11 +1287,6 @@ Licensing information: [https://docs.defguard.net/enterprise/license](https://do
           helper:
             'If this option is enabled, Defguard automatically creates new accounts for users who log in for the first time using an external OpenID provider. Otherwise, the user account must first be created by an administrator.',
         },
-        useOpenIdForMfa: {
-          label: 'Use external OpenID for client MFA',
-          helper:
-            'When the external OpenID SSO Multi-Factor (MFA) process is enabled, users connecting to VPN locations that require MFA will need to authenticate via their browser using the configured provider for each connection. If this setting is disabled, MFA for those VPN locations will be handled through the internal Defguard SSO system. In that case, users must have TOTP or email-based MFA configured in their profile.',
-        },
         usernameHandling: {
           label: 'Username handling',
           helper:

--- a/web/src/i18n/en/index.ts
+++ b/web/src/i18n/en/index.ts
@@ -1130,6 +1130,14 @@ Licensing information: [https://docs.defguard.net/enterprise/license](https://do
         contact: 'by contacting:',
       },
     },
+    locationMfaTypeSelect: {
+      label: 'MFA Requirement',
+      options: {
+        disabled: 'Do not enforce MFA',
+        internal: 'Internal MFA',
+        external: 'External MFA',
+      },
+    },
   },
   settingsPage: {
     title: 'Settings',

--- a/web/src/i18n/i18n-types.ts
+++ b/web/src/i18n/i18n-types.ts
@@ -3183,16 +3183,6 @@ type RootTranslation = {
 					 */
 					helper: string
 				}
-				useOpenIdForMfa: {
-					/**
-					 * U​s​e​ ​e​x​t​e​r​n​a​l​ ​O​p​e​n​I​D​ ​f​o​r​ ​c​l​i​e​n​t​ ​M​F​A
-					 */
-					label: string
-					/**
-					 * W​h​e​n​ ​t​h​e​ ​e​x​t​e​r​n​a​l​ ​O​p​e​n​I​D​ ​S​S​O​ ​M​u​l​t​i​-​F​a​c​t​o​r​ ​(​M​F​A​)​ ​p​r​o​c​e​s​s​ ​i​s​ ​e​n​a​b​l​e​d​,​ ​u​s​e​r​s​ ​c​o​n​n​e​c​t​i​n​g​ ​t​o​ ​V​P​N​ ​l​o​c​a​t​i​o​n​s​ ​t​h​a​t​ ​r​e​q​u​i​r​e​ ​M​F​A​ ​w​i​l​l​ ​n​e​e​d​ ​t​o​ ​a​u​t​h​e​n​t​i​c​a​t​e​ ​v​i​a​ ​t​h​e​i​r​ ​b​r​o​w​s​e​r​ ​u​s​i​n​g​ ​t​h​e​ ​c​o​n​f​i​g​u​r​e​d​ ​p​r​o​v​i​d​e​r​ ​f​o​r​ ​e​a​c​h​ ​c​o​n​n​e​c​t​i​o​n​.​ ​I​f​ ​t​h​i​s​ ​s​e​t​t​i​n​g​ ​i​s​ ​d​i​s​a​b​l​e​d​,​ ​M​F​A​ ​f​o​r​ ​t​h​o​s​e​ ​V​P​N​ ​l​o​c​a​t​i​o​n​s​ ​w​i​l​l​ ​b​e​ ​h​a​n​d​l​e​d​ ​t​h​r​o​u​g​h​ ​t​h​e​ ​i​n​t​e​r​n​a​l​ ​D​e​f​g​u​a​r​d​ ​S​S​O​ ​s​y​s​t​e​m​.​ ​I​n​ ​t​h​a​t​ ​c​a​s​e​,​ ​u​s​e​r​s​ ​m​u​s​t​ ​h​a​v​e​ ​T​O​T​P​ ​o​r​ ​e​m​a​i​l​-​b​a​s​e​d​ ​M​F​A​ ​c​o​n​f​i​g​u​r​e​d​ ​i​n​ ​t​h​e​i​r​ ​p​r​o​f​i​l​e​.
-					 */
-					helper: string
-				}
 				usernameHandling: {
 					/**
 					 * U​s​e​r​n​a​m​e​ ​h​a​n​d​l​i​n​g
@@ -9763,16 +9753,6 @@ export type TranslationFunctions = {
 					label: () => LocalizedString
 					/**
 					 * If this option is enabled, Defguard automatically creates new accounts for users who log in for the first time using an external OpenID provider. Otherwise, the user account must first be created by an administrator.
-					 */
-					helper: () => LocalizedString
-				}
-				useOpenIdForMfa: {
-					/**
-					 * Use external OpenID for client MFA
-					 */
-					label: () => LocalizedString
-					/**
-					 * When the external OpenID SSO Multi-Factor (MFA) process is enabled, users connecting to VPN locations that require MFA will need to authenticate via their browser using the configured provider for each connection. If this setting is disabled, MFA for those VPN locations will be handled through the internal Defguard SSO system. In that case, users must have TOTP or email-based MFA configured in their profile.
 					 */
 					helper: () => LocalizedString
 				}

--- a/web/src/i18n/i18n-types.ts
+++ b/web/src/i18n/i18n-types.ts
@@ -2779,6 +2779,26 @@ type RootTranslation = {
 				contact: string
 			}
 		}
+		locationMfaTypeSelect: {
+			/**
+			 * M​F​A​ ​R​e​q​u​i​r​e​m​e​n​t
+			 */
+			label: string
+			options: {
+				/**
+				 * D​o​ ​n​o​t​ ​e​n​f​o​r​c​e​ ​M​F​A
+				 */
+				disabled: string
+				/**
+				 * I​n​t​e​r​n​a​l​ ​M​F​A
+				 */
+				internal: string
+				/**
+				 * E​x​t​e​r​n​a​l​ ​M​F​A
+				 */
+				external: string
+			}
+		}
 	}
 	settingsPage: {
 		/**
@@ -9343,6 +9363,26 @@ export type TranslationFunctions = {
 				 * by contacting:
 				 */
 				contact: () => LocalizedString
+			}
+		}
+		locationMfaTypeSelect: {
+			/**
+			 * MFA Requirement
+			 */
+			label: () => LocalizedString
+			options: {
+				/**
+				 * Do not enforce MFA
+				 */
+				disabled: () => LocalizedString
+				/**
+				 * Internal MFA
+				 */
+				internal: () => LocalizedString
+				/**
+				 * External MFA
+				 */
+				external: () => LocalizedString
 			}
 		}
 	}

--- a/web/src/pages/devices/modals/AddStandaloneDeviceModal/steps/MethodStep/MethodStep.tsx
+++ b/web/src/pages/devices/modals/AddStandaloneDeviceModal/steps/MethodStep/MethodStep.tsx
@@ -136,8 +136,8 @@ export const MethodStep = () => {
         />
         <DeviceSetupMethodCard
           custom={{
-            title: localLL.cards.cli.title(),
-            description: localLL.cards.cli.subtitle(),
+            title: localLL.cards.manual.title(),
+            description: localLL.cards.manual.subtitle(),
             icon: <SvgWireguardLogo />,
             testId: 'standalone-device-choice-card-manual',
           }}

--- a/web/src/pages/network/NetworkEditForm/NetworkEditForm.tsx
+++ b/web/src/pages/network/NetworkEditForm/NetworkEditForm.tsx
@@ -11,6 +11,7 @@ import { shallow } from 'zustand/shallow';
 
 import { useI18nContext } from '../../../i18n/i18n-react';
 import { FormAclDefaultPolicy } from '../../../shared/components/Form/FormAclDefaultPolicySelect/FormAclDefaultPolicy.tsx';
+import { FormLocationMfaTypeSelect } from '../../../shared/components/Form/FormLocationMfaTypeSelect/FormLocationMfaTypeSelect.tsx';
 import { FormCheckBox } from '../../../shared/defguard-ui/components/Form/FormCheckBox/FormCheckBox.tsx';
 import { FormInput } from '../../../shared/defguard-ui/components/Form/FormInput/FormInput';
 import { FormSelect } from '../../../shared/defguard-ui/components/Form/FormSelect/FormSelect';
@@ -21,7 +22,7 @@ import { useAppStore } from '../../../shared/hooks/store/useAppStore.ts';
 import useApi from '../../../shared/hooks/useApi';
 import { useToaster } from '../../../shared/hooks/useToaster';
 import { QueryKeys } from '../../../shared/queries';
-import type { Network } from '../../../shared/types';
+import { LocationMfaType, type Network } from '../../../shared/types';
 import { titleCase } from '../../../shared/utils/titleCase';
 import { trimObjectStrings } from '../../../shared/utils/trimObjectStrings.ts';
 import {
@@ -141,7 +142,6 @@ export const NetworkEditForm = () => {
             return validateIpOrDomainList(val, ',', false, true);
           }, LL.form.error.allowedIps()),
         allowed_groups: z.array(z.string().min(1, LL.form.error.minimumLength())),
-        mfa_enabled: z.boolean(),
         keepalive_interval: z
           .number({
             invalid_type_error: LL.form.error.required(),
@@ -155,6 +155,7 @@ export const NetworkEditForm = () => {
           .min(120, LL.form.error.invalid()),
         acl_enabled: z.boolean(),
         acl_default_allow: z.boolean(),
+        location_mfa: z.nativeEnum(LocationMfaType),
       }),
     [LL.form.error],
   );
@@ -170,11 +171,11 @@ export const NetworkEditForm = () => {
       allowed_ips: '',
       allowed_groups: [],
       dns: '',
-      mfa_enabled: false,
       keepalive_interval: 25,
       peer_disconnect_threshold: 180,
       acl_enabled: false,
       acl_default_allow: false,
+      location_mfa: LocationMfaType.DISABLED,
     }),
     [],
   );
@@ -315,11 +316,6 @@ export const NetworkEditForm = () => {
             displayValue: titleCase(val),
           })}
         />
-        <FormCheckBox
-          controller={{ control, name: 'mfa_enabled' }}
-          label={LL.networkConfiguration.form.fields.mfa_enabled.label()}
-          labelPlacement="right"
-        />
         {!enterpriseEnabled && (
           <MessageBox type={MessageBoxType.WARNING}>
             <p>{LL.networkConfiguration.form.helpers.aclFeatureDisabled()}</p>
@@ -345,6 +341,7 @@ export const NetworkEditForm = () => {
           label={LL.networkConfiguration.form.fields.peer_disconnect_threshold.label()}
           type="number"
         />
+        <FormLocationMfaTypeSelect controller={{ control, name: 'location_mfa' }} />
         <button type="submit" className="hidden" ref={submitRef}></button>
       </form>
     </section>

--- a/web/src/pages/settings/components/OpenIdSettings/components/OpenIdGeneralSettings.tsx
+++ b/web/src/pages/settings/components/OpenIdSettings/components/OpenIdGeneralSettings.tsx
@@ -22,14 +22,6 @@ export const OpenIdGeneralSettings = ({ isLoading }: { isLoading: boolean }) => 
     control,
     name: 'create_account',
   }) as boolean;
-  const use_openid_for_mfa = useWatch({
-    control,
-    name: 'use_openid_for_mfa',
-  }) as boolean;
-  const providerName = useWatch({
-    control,
-    name: 'name',
-  }) as string;
 
   const options: SelectOption<UsernameHandling>[] = useMemo(
     () => [
@@ -52,10 +44,6 @@ export const OpenIdGeneralSettings = ({ isLoading }: { isLoading: boolean }) => 
     [localLL.general.usernameHandling.options],
   );
 
-  const providerConfigured = useMemo(() => {
-    return providerName !== '';
-  }, [providerName]);
-
   return (
     <div id="general-settings">
       <div className="subsection-header helper-row">
@@ -77,22 +65,6 @@ export const OpenIdGeneralSettings = ({ isLoading }: { isLoading: boolean }) => 
           disabled={isLoading}
         />
         <Helper>{localLL.general.createAccount.helper()}</Helper>
-      </div>
-      <div className="helper-row checkbox-padding">
-        {/* FIXME: Really buggy when using the controller, investigate why */}
-        <LabeledCheckbox
-          label={localLL.general.useOpenIdForMfa.label()}
-          // controller={{
-          //   control,
-          //   name: 'use_openid_for_mfa',
-          // }}
-          value={providerConfigured ? use_openid_for_mfa : false}
-          onChange={(e) => {
-            setValue('use_openid_for_mfa', e);
-          }}
-          disabled={isLoading || !providerConfigured}
-        />
-        <Helper>{localLL.general.useOpenIdForMfa.helper()}</Helper>
       </div>
       <FormSelect
         controller={{

--- a/web/src/pages/settings/components/OpenIdSettings/components/OpenIdSettingsForm.tsx
+++ b/web/src/pages/settings/components/OpenIdSettings/components/OpenIdSettingsForm.tsx
@@ -108,7 +108,6 @@ export const OpenIdSettingsForm = () => {
           okta_private_jwk: z.string(),
           okta_dirsync_client_id: z.string(),
           directory_sync_group_match: z.string(),
-          use_openid_for_mfa: z.boolean(),
         })
         .superRefine((val, ctx) => {
           if (val.name === '') {
@@ -172,7 +171,6 @@ export const OpenIdSettingsForm = () => {
       okta_dirsync_client_id: '',
       directory_sync_group_match: '',
       username_handling: 'RemoveForbidden',
-      use_openid_for_mfa: false,
     };
 
     if (openidData) {

--- a/web/src/pages/wizard/components/WizardNetworkConfiguration/WizardNetworkConfiguration.tsx
+++ b/web/src/pages/wizard/components/WizardNetworkConfiguration/WizardNetworkConfiguration.tsx
@@ -9,6 +9,7 @@ import { shallow } from 'zustand/shallow';
 
 import { useI18nContext } from '../../../../i18n/i18n-react';
 import { FormAclDefaultPolicy } from '../../../../shared/components/Form/FormAclDefaultPolicySelect/FormAclDefaultPolicy.tsx';
+import { FormLocationMfaTypeSelect } from '../../../../shared/components/Form/FormLocationMfaTypeSelect/FormLocationMfaTypeSelect.tsx';
 import { FormCheckBox } from '../../../../shared/defguard-ui/components/Form/FormCheckBox/FormCheckBox.tsx';
 import { FormInput } from '../../../../shared/defguard-ui/components/Form/FormInput/FormInput';
 import { FormSelect } from '../../../../shared/defguard-ui/components/Form/FormSelect/FormSelect';
@@ -18,6 +19,7 @@ import type { SelectOption } from '../../../../shared/defguard-ui/components/Lay
 import useApi from '../../../../shared/hooks/useApi';
 import { useToaster } from '../../../../shared/hooks/useToaster';
 import { QueryKeys } from '../../../../shared/queries';
+import { LocationMfaType } from '../../../../shared/types.ts';
 import { titleCase } from '../../../../shared/utils/titleCase';
 import { trimObjectStrings } from '../../../../shared/utils/trimObjectStrings.ts';
 import { validateIpList, validateIpOrDomainList } from '../../../../shared/validators';
@@ -118,7 +120,6 @@ export const WizardNetworkConfiguration = () => {
             return validateIpOrDomainList(val, ',', true);
           }, LL.form.error.allowedIps()),
         allowed_groups: z.array(z.string().min(1, LL.form.error.minimumLength())),
-        mfa_enabled: z.boolean(),
         keepalive_interval: z
           .number({
             invalid_type_error: LL.form.error.invalid(),
@@ -131,6 +132,7 @@ export const WizardNetworkConfiguration = () => {
           .refine((v) => v >= 120, LL.form.error.minimumLength()),
         acl_enabled: z.boolean(),
         acl_default_allow: z.boolean(),
+        location_mfa: z.nativeEnum(LocationMfaType),
       }),
     [LL.form.error],
   );
@@ -222,11 +224,6 @@ export const WizardNetworkConfiguration = () => {
           })}
         />
         <FormCheckBox
-          controller={{ control, name: 'mfa_enabled' }}
-          label={LL.networkConfiguration.form.fields.mfa_enabled.label()}
-          labelPlacement="right"
-        />
-        <FormCheckBox
           controller={{ control, name: 'acl_enabled' }}
           label={LL.networkConfiguration.form.fields.acl_enabled.label()}
           labelPlacement="right"
@@ -242,6 +239,7 @@ export const WizardNetworkConfiguration = () => {
           label={LL.networkConfiguration.form.fields.peer_disconnect_threshold.label()}
           type="number"
         />
+        <FormLocationMfaTypeSelect controller={{ control, name: 'location_mfa' }} />
         <input type="submit" className="visually-hidden" ref={submitRef} />
       </form>
     </Card>

--- a/web/src/pages/wizard/hooks/useWizardStore.ts
+++ b/web/src/pages/wizard/hooks/useWizardStore.ts
@@ -3,7 +3,11 @@ import { Subject } from 'rxjs';
 import { createJSONStorage, persist } from 'zustand/middleware';
 import { createWithEqualityFn } from 'zustand/traditional';
 
-import type { ImportedDevice, Network } from '../../../shared/types';
+import {
+  type ImportedDevice,
+  LocationMfaType,
+  type Network,
+} from '../../../shared/types';
 
 export enum WizardSetupType {
   IMPORT = 'IMPORT',
@@ -25,11 +29,11 @@ const defaultValues: StoreFields = {
     allowed_ips: '',
     allowed_groups: [],
     dns: '',
-    mfa_enabled: false,
     keepalive_interval: 25,
     peer_disconnect_threshold: 180,
     acl_enabled: false,
     acl_default_allow: false,
+    location_mfa: LocationMfaType.DISABLED,
   },
 };
 
@@ -81,11 +85,11 @@ type StoreFields = {
     allowed_ips: string;
     allowed_groups: string[];
     dns?: string;
-    mfa_enabled: boolean;
     keepalive_interval: number;
     peer_disconnect_threshold: number;
     acl_enabled: boolean;
     acl_default_allow: boolean;
+    location_mfa: LocationMfaType;
   };
 };
 

--- a/web/src/shared/components/Form/FormLocationMfaTypeSelect/FormLocationMfaTypeSelect.tsx
+++ b/web/src/shared/components/Form/FormLocationMfaTypeSelect/FormLocationMfaTypeSelect.tsx
@@ -1,0 +1,48 @@
+import { useMemo } from 'react';
+import type { FieldValues, UseControllerProps } from 'react-hook-form';
+
+import { useI18nContext } from '../../../../i18n/i18n-react';
+import { FormSelect } from '../../../defguard-ui/components/Form/FormSelect/FormSelect';
+import type { SelectOption } from '../../../defguard-ui/components/Layout/Select/types';
+import { LocationMfaType } from '../../../types';
+
+type Props<T extends FieldValues> = {
+  controller: UseControllerProps<T>;
+  disabled?: boolean;
+};
+
+export const FormLocationMfaTypeSelect = <T extends FieldValues>({
+  controller,
+  disabled = false,
+}: Props<T>) => {
+  const { LL } = useI18nContext();
+
+  const options = useMemo(
+    (): SelectOption<LocationMfaType>[] => [
+      {
+        key: LocationMfaType.DISABLED,
+        value: LocationMfaType.DISABLED,
+        label: LL.components.locationMfaTypeSelect.options.disabled(),
+      },
+      {
+        key: LocationMfaType.INTERNAL,
+        value: LocationMfaType.INTERNAL,
+        label: LL.components.locationMfaTypeSelect.options.internal(),
+      },
+      {
+        key: LocationMfaType.EXTERNAL,
+        value: LocationMfaType.EXTERNAL,
+        label: LL.components.locationMfaTypeSelect.options.external(),
+      },
+    ],
+    [LL.components.aclDefaultPolicySelect.options],
+  );
+  return (
+    <FormSelect
+      controller={controller}
+      options={options}
+      label={LL.components.locationMfaTypeSelect.label()}
+      disabled={disabled}
+    />
+  );
+};

--- a/web/src/shared/types.ts
+++ b/web/src/shared/types.ts
@@ -118,6 +118,12 @@ export type GatewayStatus = {
   uid: string;
 };
 
+export enum LocationMfaType {
+  DISABLED = 'disabled',
+  INTERNAL = 'internal',
+  EXTERNAL = 'external',
+}
+
 export interface Network {
   id: number;
   name: string;
@@ -130,11 +136,11 @@ export interface Network {
   allowed_ips?: string[];
   allowed_groups?: string[];
   dns?: string;
-  mfa_enabled: boolean;
   keepalive_interval: number;
   peer_disconnect_threshold: number;
   acl_enabled: boolean;
   acl_default_allow: boolean;
+  location_mfa: LocationMfaType;
 }
 
 export type ModifyNetworkRequest = {


### PR DESCRIPTION
Implement per-location MFA configuration. 
Each location can be configured separately to use internal MFA, external OIDC MFA or not use MFA at all.

Closes https://github.com/DefGuard/defguard/issues/1294