### PR TITLE
Fix ldap attribute names case sensitive comparison

### DIFF
--- a/crates/defguard_core/src/enterprise/ldap/mod.rs
+++ b/crates/defguard_core/src/enterprise/ldap/mod.rs
@@ -247,7 +247,7 @@ impl LDAPConfig {
         // RDN set = username is used as RDN if they are the same
         self.ldap_user_rdn_attr
             .as_deref()
-            .is_none_or(|rdn| rdn == self.ldap_username_attr || rdn.is_empty())
+            .is_none_or(|rdn| rdn.eq_ignore_ascii_case(&self.ldap_username_attr) || rdn.is_empty())
     }
 }
 

--- a/crates/defguard_core/src/enterprise/ldap/model.rs
+++ b/crates/defguard_core/src/enterprise/ldap/model.rs
@@ -123,11 +123,15 @@ impl<I> User<I> {
             ]);
 
             // Allow renaming the user if the CN is not a part of the RDN
-            if config.get_rdn_attr() != "cn" {
+            if !config.get_rdn_attr().eq_ignore_ascii_case("cn") {
                 changes.push(Mod::Replace("cn", hashset![self.username.as_str()]));
             }
 
-            if config.ldap_username_attr != "uid" && config.ldap_user_rdn_attr != Some("uid".into())
+            if !config.ldap_username_attr.eq_ignore_ascii_case("uid")
+                && !config
+                    .ldap_user_rdn_attr
+                    .as_ref()
+                    .is_some_and(|rdn_attr| rdn_attr.eq_ignore_ascii_case("uid"))
             {
                 changes.push(Mod::Replace("uid", hashset![self.username.as_str()]));
             }
@@ -146,7 +150,7 @@ impl<I> User<I> {
             );
         }
 
-        if config.ldap_uses_ad && config.get_rdn_attr() != "sAMAccountName" {
+        if config.ldap_uses_ad && !config.get_rdn_attr().eq_ignore_ascii_case("sAMAccountName") {
             changes.push(Mod::Replace(
                 "sAMAccountName",
                 hashset![self.username.as_str()],
@@ -155,9 +159,12 @@ impl<I> User<I> {
 
         let username_attr = config.ldap_username_attr.as_str();
         // add anything the user provided, if we haven't already added it AND it's not the same as the RDN
-        if username_attr != "sAMAccountName"
-            && username_attr != "cn"
-            && Some(username_attr.into()) != config.ldap_user_rdn_attr
+        if !username_attr.eq_ignore_ascii_case("sAMAccountName")
+            && !username_attr.eq_ignore_ascii_case("cn")
+            && !config
+                .ldap_user_rdn_attr
+                .as_ref()
+                .is_some_and(|rdn_attr| rdn_attr.eq_ignore_ascii_case(username_attr))
         {
             changes.push(Mod::Replace(
                 username_attr,
@@ -169,8 +176,14 @@ impl<I> User<I> {
     }
 
     // check if key is already in attrs, if not return false
+    #[cfg(test)]
+    pub(crate) fn in_attrs<'a>(attrs: &'a Vec<(&'a str, HashSet<&'a str>)>, key: &str) -> bool {
+        attrs.iter().any(|(k, _)| k.eq_ignore_ascii_case(key))
+    }
+
+    #[cfg(not(test))]
     fn in_attrs<'a>(attrs: &'a Vec<(&'a str, HashSet<&'a str>)>, key: &str) -> bool {
-        attrs.iter().any(|(k, _)| *k == key)
+        attrs.iter().any(|(k, _)| k.eq_ignore_ascii_case(key))
     }
 
     #[must_use]
@@ -318,5 +331,58 @@ pub(crate) fn extract_dn_path(dn: &str) -> Option<String> {
     } else {
         warn!("Failed to extract DN path from '{dn}': no comma found");
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_in_attrs() {
+        // Create test attributes with mixed case keys
+        let attrs = vec![
+            ("cn", hashset!["user1"]),
+            ("Mail", hashset!["user@example.com"]),
+            ("PHONE", hashset!["123456789"]),
+            ("givenName", hashset!["John"]),
+        ];
+
+        // Test exact case match
+        assert!(User::<()>::in_attrs(&attrs, "cn"));
+        assert!(User::<()>::in_attrs(&attrs, "Mail"));
+        assert!(User::<()>::in_attrs(&attrs, "PHONE"));
+        assert!(User::<()>::in_attrs(&attrs, "givenName"));
+
+        // Test case-insensitive matching
+        assert!(User::<()>::in_attrs(&attrs, "CN"));
+        assert!(User::<()>::in_attrs(&attrs, "cn"));
+        assert!(User::<()>::in_attrs(&attrs, "mail"));
+        assert!(User::<()>::in_attrs(&attrs, "MAIL"));
+        assert!(User::<()>::in_attrs(&attrs, "phone"));
+        assert!(User::<()>::in_attrs(&attrs, "Phone"));
+        assert!(User::<()>::in_attrs(&attrs, "GIVENNAME"));
+        assert!(User::<()>::in_attrs(&attrs, "givenname"));
+
+        // Test non-existent attributes
+        assert!(!User::<()>::in_attrs(&attrs, "nonexistent"));
+        assert!(!User::<()>::in_attrs(&attrs, "sn"));
+        assert!(!User::<()>::in_attrs(&attrs, "uid"));
+
+        // Test empty attributes vector
+        let empty_attrs = vec![];
+        assert!(!User::<()>::in_attrs(&empty_attrs, "cn"));
+        assert!(!User::<()>::in_attrs(&empty_attrs, "any"));
+
+        // Test with empty string key
+        assert!(!User::<()>::in_attrs(&attrs, ""));
+
+        // Test with attributes that have empty values (should still match on key)
+        let attrs_with_empty_values =
+            vec![("cn", HashSet::new())("mail", hashset!["test@example.com"])];
+        assert!(User::<()>::in_attrs(&attrs_with_empty_values, "cn"));
+        assert!(User::<()>::in_attrs(&attrs_with_empty_values, "CN"));
+        assert!(User::<()>::in_attrs(&attrs_with_empty_values, "mail"));
+        assert!(!User::<()>::in_attrs(&attrs_with_empty_values, "phone"));
     }
 }

--- a/crates/defguard_core/src/enterprise/ldap/model.rs
+++ b/crates/defguard_core/src/enterprise/ldap/model.rs
@@ -378,8 +378,10 @@ mod tests {
         assert!(!User::<()>::in_attrs(&attrs, ""));
 
         // Test with attributes that have empty values (should still match on key)
-        let attrs_with_empty_values =
-            vec![("cn", HashSet::new())("mail", hashset!["test@example.com"])];
+        let attrs_with_empty_values = vec![
+            ("cn", HashSet::new()),
+            ("mail", hashset!["test@example.com"]),
+        ];
         assert!(User::<()>::in_attrs(&attrs_with_empty_values, "cn"));
         assert!(User::<()>::in_attrs(&attrs_with_empty_values, "CN"));
         assert!(User::<()>::in_attrs(&attrs_with_empty_values, "mail"));

--- a/crates/defguard_core/src/enterprise/ldap/test_client.rs
+++ b/crates/defguard_core/src/enterprise/ldap/test_client.rs
@@ -278,10 +278,10 @@ impl super::LDAPConnection {
         if let Some((attr, value)) = search_value {
             for (dn, object) in &self.test_client.objects {
                 if let Object::User(user) = object {
-                    let matches = if attr == username_attr {
+                    let matches = if attr.eq_ignore_ascii_case(&username_attr) {
                         user.username == value
-                    } else if attr == rdn_attr {
-                        let rdn_value = if rdn_attr == username_attr {
+                    } else if attr.eq_ignore_ascii_case(&rdn_attr) {
+                        let rdn_value = if rdn_attr.eq_ignore_ascii_case(&username_attr) {
                             &user.username
                         } else {
                             dn.split(',')

--- a/crates/defguard_core/src/enterprise/ldap/tests.rs
+++ b/crates/defguard_core/src/enterprise/ldap/tests.rs
@@ -2846,7 +2846,11 @@ fn test_as_ldap_attrs() {
         "cn",
     );
 
-    assert!(!attrs.iter().any(|(key, _)| *key == "mobile"));
+    assert!(
+        !attrs
+            .iter()
+            .any(|(key, _)| key.eq_ignore_ascii_case("mobile"))
+    );
 }
 
 #[test]


### PR DESCRIPTION
LDAP attribute names should be compared case insensitively, as this is how most LDAP implementations do it.

Fixes #1445