### PR TITLE
Prevent pre-shared keys from being sent when mfa is disabled

### DIFF
--- a/crates/defguard_core/src/grpc/gateway/mod.rs
+++ b/crates/defguard_core/src/grpc/gateway/mod.rs
@@ -119,7 +119,14 @@ impl WireguardNetwork<Id> {
             .map(|row| Peer {
                 pubkey: row.pubkey,
                 allowed_ips: row.allowed_ips,
-                preshared_key: row.preshared_key,
+                // Don't send preshared key if MFA is not enabled, it can't be used and may
+                // cause issues with clients connecting if they expect no preshared key
+                // e.g. when you disable MFA on a location
+                preshared_key: if self.mfa_enabled() {
+                    row.preshared_key
+                } else {
+                    None
+                },
                 keepalive_interval: Some(self.keepalive_interval as u32),
             })
             .collect();


### PR DESCRIPTION
When MFA is disabled clients don't expect preshared keys and if they are present the client can't connect properly.