### PR TITLE
Fixes pentest issue DG25-3 from 2025-09-02

### DIFF
--- a/.sqlx/query-25b07b45cfd25643e750e2ec0fe51bd760fae6db5f5416d017a3f4a24c44c185.json
+++ b/.sqlx/query-25b07b45cfd25643e750e2ec0fe51bd760fae6db5f5416d017a3f4a24c44c185.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT id, user_id, created_at, name, token_hash FROM api_token WHERE token_hash = $1",
+  "query": "SELECT at.id, user_id, created_at, name, token_hash FROM api_token at JOIN \"user\" ON \"user\".id = user_id WHERE token_hash = $1 AND \"user\".is_active = true",
   "describe": {
     "columns": [
       {
@@ -42,5 +42,5 @@
       false
     ]
   },
-  "hash": "3b3c28a99faeeaf24ff0fc5a3592e8010ceb453fbcf1672b23ef086e76c48958"
+  "hash": "25b07b45cfd25643e750e2ec0fe51bd760fae6db5f5416d017a3f4a24c44c185"
 }

--- a/crates/defguard_core/src/db/models/group.rs
+++ b/crates/defguard_core/src/db/models/group.rs
@@ -110,7 +110,7 @@ impl Group<Id> {
         .await
     }
 
-    pub(crate) async fn find_by_permission<'e, E>(
+    pub async fn find_by_permission<'e, E>(
         executor: E,
         permission: Permission,
     ) -> Result<Vec<Self>, SqlxError>

--- a/crates/defguard_core/src/enterprise/db/models/api_tokens.rs
+++ b/crates/defguard_core/src/enterprise/db/models/api_tokens.rs
@@ -58,8 +58,9 @@ impl ApiToken<Id> {
         let token_hash = ApiToken::hash_token(auth_token);
         let maybe_token = query_as!(
             Self,
-            "SELECT id, user_id, created_at, name, token_hash \
-                    FROM api_token WHERE token_hash = $1",
+            "SELECT at.id, user_id, created_at, name, token_hash \
+             FROM api_token at JOIN \"user\" ON \"user\".id = user_id \
+             WHERE token_hash = $1 AND \"user\".is_active = true",
             token_hash
         )
         .fetch_optional(executor)

--- a/crates/defguard_core/tests/integration/api/api_tokens.rs
+++ b/crates/defguard_core/tests/integration/api/api_tokens.rs
@@ -1,6 +1,6 @@
 use chrono::Utc;
 use defguard_core::{
-    db::UserInfo,
+    db::{Group, UserInfo, models::group::Permission},
     enterprise::{
         db::models::api_tokens::{ApiToken, ApiTokenInfo},
         handlers::api_tokens::{AddApiTokenData, RenameRequest},
@@ -9,7 +9,10 @@ use defguard_core::{
 };
 use reqwest::{StatusCode, header::HeaderName};
 use serde::Deserialize;
+use serde_json::json;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
+
+use crate::api::common::fetch_user_details;
 
 use super::common::{make_client, make_client_with_state, setup_pool};
 
@@ -84,6 +87,11 @@ async fn test_normal_user_cannot_use_token_auth(_: PgPoolOptions, options: PgCon
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
 }
 
+#[derive(Deserialize)]
+struct NewTokenResponse {
+    token: String,
+}
+
 #[sqlx::test]
 async fn test_admin_user_can_manage_api_tokens(_: PgPoolOptions, options: PgConnectOptions) {
     let pool = setup_pool(options).await;
@@ -96,10 +104,6 @@ async fn test_admin_user_can_manage_api_tokens(_: PgPoolOptions, options: PgConn
     assert_eq!(response.status(), StatusCode::OK);
 
     // create some API tokens
-    #[derive(Deserialize)]
-    struct NewTokenResponse {
-        token: String,
-    }
     let response = client
         .post("/api/v1/user/admin/api_token")
         .json(&AddApiTokenData {
@@ -209,10 +213,6 @@ async fn test_admin_user_can_use_api_tokens_to_authenticate(
     assert_eq!(response.status(), StatusCode::OK);
 
     // create API token
-    #[derive(Deserialize)]
-    struct NewTokenResponse {
-        token: String,
-    }
     let response = client
         .post("/api/v1/user/admin/api_token")
         .json(&AddApiTokenData {
@@ -280,4 +280,99 @@ async fn test_admin_user_can_use_api_tokens_to_authenticate(
     assert_eq!(response.status(), StatusCode::OK);
     let user: UserInfo = response.json().await;
     assert_eq!(user.username, "admin");
+}
+
+#[sqlx::test]
+async fn dg25_3_test_token_invalidation(_: PgPoolOptions, options: PgConnectOptions) {
+    let pool = setup_pool(options).await;
+
+    let client = make_client(pool.clone()).await;
+
+    // log in as admin user
+    let auth = Auth::new("admin", "pass123");
+    let response = client.post("/api/v1/auth").json(&auth).send().await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // add another user to admin group
+    let admin_groups = Group::find_by_permission(&pool, Permission::IsAdmin)
+        .await
+        .unwrap();
+    let admin_group = admin_groups.first().unwrap();
+
+    let response = client
+        .post(format!("/api/v1/group/{}", admin_group.name))
+        .json(&json!({"username": "hpotter"}))
+        .send()
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // switch to second admin account
+    let response = client.post("/api/v1/auth/logout").send().await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let auth = Auth::new("hpotter", "pass123");
+    let response = client.post("/api/v1/auth").json(&auth).send().await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // create api token
+    let response = client
+        .post("/api/v1/user/hpotter/api_token")
+        .json(&AddApiTokenData {
+            name: "dummy token 1".into(),
+        })
+        .send()
+        .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let token = response
+        .into_inner()
+        .json::<NewTokenResponse>()
+        .await
+        .unwrap()
+        .token;
+
+    // log out
+    let response = client.post("/api/v1/auth/logout").send().await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // use token for authentication
+    let response = client
+        .get("/api/v1/me")
+        .header(
+            HeaderName::from_static("authorization"),
+            &format!("Bearer {token}"),
+        )
+        .send()
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // log in as first admin and disable second user
+    let auth = Auth::new("admin", "pass123");
+    let response = client.post("/api/v1/auth").json(&auth).send().await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let mut user_details = fetch_user_details(&client, "hpotter").await;
+    user_details.user.is_active = false;
+
+    let response = client
+        .put("/api/v1/user/hpotter")
+        .json(&user_details.user)
+        .send()
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let user_details = fetch_user_details(&client, "hpotter").await;
+    assert!(!user_details.user.is_active);
+
+    // log out
+    let response = client.post("/api/v1/auth/logout").send().await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // cannot use token for authentication anymore
+    let response = client
+        .get("/api/v1/me")
+        .header(
+            HeaderName::from_static("authorization"),
+            &format!("Bearer {token}"),
+        )
+        .send()
+        .await;
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 }

--- a/crates/defguard_core/tests/integration/api/user.rs
+++ b/crates/defguard_core/tests/integration/api/user.rs
@@ -621,7 +621,7 @@ async fn test_disable(_: PgPoolOptions, options: PgConnectOptions) {
     let mut user_details = fetch_user_details(&client, "admin").await;
     user_details.user.is_active = false;
 
-    // disable yourself
+    // cannot disable yourself
     let response = client
         .put("/api/v1/user/admin")
         .json(&user_details.user)
@@ -645,6 +645,7 @@ async fn test_disable(_: PgPoolOptions, options: PgConnectOptions) {
     // get user
     let mut user_details = fetch_user_details(&client, "adumbledore").await;
     assert_eq!(user_details.user.first_name, "Albus");
+    assert!(user_details.user.is_active);
 
     // disable user
     user_details.user.is_active = false;
@@ -654,6 +655,10 @@ async fn test_disable(_: PgPoolOptions, options: PgConnectOptions) {
         .send()
         .await;
     assert_eq!(response.status(), StatusCode::OK);
+
+    let user_details = fetch_user_details(&client, "adumbledore").await;
+    assert_eq!(user_details.user.first_name, "Albus");
+    assert!(!user_details.user.is_active);
 }
 
 #[sqlx::test]


### PR DESCRIPTION
This pull request fixes vulnerability from penetration tests done by our security team on 2025-09-02:
- title: API Tokens of inactive users are not being invalidated
- ID: DG25-3
- raport details: https://defguard.net/pentesting/

Closes https://github.com/DefGuard/defguard/issues/1509