### PR TITLE
Add test for dg25-19 vulnerability

### DIFF
--- a/crates/defguard_core/tests/integration/api/auth.rs
+++ b/crates/defguard_core/tests/integration/api/auth.rs
@@ -39,8 +39,6 @@ async fn dg25_19_clickjacking_vulnerability(_: PgPoolOptions, options: PgConnect
     let client = make_client(pool).await;
 
     let response = client.get("/").send().await;
-    assert_eq!(response.status(), StatusCode::OK);
-
     let headers = response.headers();
     let csp_header = headers.get("content-security-policy").unwrap();
     let csp_value = csp_header.to_str().unwrap();


### PR DESCRIPTION
This vulnerability has been patched in #1514, the linked pull request also contains more details. This pull request only adds an integration test verifying that the vulnerability has been fixed.