### PR TITLE
Fixes pentest issue DG25-13 from 2025-09-02

### DIFF
--- a/crates/defguard_core/tests/integration/api/enterprise_settings.rs
+++ b/crates/defguard_core/tests/integration/api/enterprise_settings.rs
@@ -216,3 +216,84 @@ async fn test_regular_user_device_management(_: PgPoolOptions, options: PgConnec
 
     assert_eq!(response.status(), StatusCode::OK);
 }
+
+#[sqlx::test]
+async fn dg25_12_test_enforce_client_activation_only(_: PgPoolOptions, options: PgConnectOptions) {
+    let pool = setup_pool(options).await;
+
+    // admin login
+    let (client, _) = make_test_client(pool).await;
+    let auth = Auth::new("admin", "pass123");
+    let response = client.post("/api/v1/auth").json(&auth).send().await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    exceed_enterprise_limits(&client).await;
+
+    // create network
+    let response = client
+        .post("/api/v1/network")
+        .json(&make_network())
+        .send()
+        .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    // setup admin devices management
+    let settings = EnterpriseSettings {
+        admin_device_management: false,
+        disable_all_traffic: false,
+        only_client_activation: true,
+    };
+    let response = client
+        .patch("/api/v1/settings_enterprise")
+        .json(&settings)
+        .send()
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // make sure admin can manage devices
+    let device = json!({
+        "name": "device",
+        "wireguard_pubkey": "LQKsT6/3HWKuJmMulH63R8iK+5sI8FyYEL6WDIi6lQU=",
+    });
+    let response = client
+        .post("/api/v1/device/hpotter")
+        .json(&device)
+        .send()
+        .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    // ensure normal users can't manage devices
+    let auth = Auth::new("hpotter", "pass123");
+    let response = client.post("/api/v1/auth").json(&auth).send().await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // add
+    let device = json!({
+        "name": "userdevice",
+        "wireguard_pubkey": "AJwxGkzvVVn5Q1xjpCDFo5RJSU9KOPHeoEixYaj+20M=",
+    });
+    let response = client
+        .post("/api/v1/device/hpotter")
+        .json(&device)
+        .send()
+        .await;
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+    // modify
+    let device = json!({
+        "name": "modifieddevice",
+        "wireguard_pubkey": "AJwxGkzvVVn5Q1xjpCDFo5RJSU9KOPHeoEixYaj+20M=",
+    });
+    let response = client.put("/api/v1/device/2").json(&device).send().await;
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+    // delete
+    let device = json!({
+        "name": "modifieddevice",
+        "wireguard_pubkey": "AJwxGkzvVVn5Q1xjpCDFo5RJSU9KOPHeoEixYaj+20M=",
+    });
+    let response = client.put("/api/v1/device/2").json(&device).send().await;
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}


### PR DESCRIPTION
This pull request fixes vulnerability from penetration tests done by our security team on 2025-09-02:

title: User can see configuration even when this option is not visible in GUI
ID: DG25-13
raport details: https://defguard.net/pentesting/

Restrict access to device config endpoint if `only_client_activation` setting is enabled.

Closes https://github.com/DefGuard/defguard/issues/1526