### PR TITLE
Fixes pentest issue DG25-23 from 2025-09-02

### DIFF
--- a/crates/defguard_core/src/handlers/openid_clients.rs
+++ b/crates/defguard_core/src/handlers/openid_clients.rs
@@ -97,10 +97,9 @@ pub async fn change_openid_client(
             client.name = data.name;
             client.redirect_uri = data.redirect_uri;
             client.enabled = data.enabled;
-            let scope_differs = client.scope != data.scope;
             client.scope = data.scope;
             client.save(&mut *transaction).await?;
-            if scope_differs {
+            if before.scope != client.scope {
                 client.clear_authorizations(&mut *transaction).await?;
             }
             transaction.commit().await?;


### PR DESCRIPTION
This pull request fixes vulnerability from penetration tests done by our security team on 2025-09-02:

title: OpenID apps remain authorized even after the scope change
ID: DG25-23
raport details: https://defguard.net/pentesting/

Closes https://github.com/DefGuard/defguard/issues/1520