### PR TITLE
Migrate docker builds to AWS

### DIFF
--- a/.github/workflows/current.yml
+++ b/.github/workflows/current.yml
@@ -9,7 +9,6 @@ on:
       - main
       - dev
       - "release/**"
-      - aws_docker_build
     paths-ignore:
       - "*.md"
       - "LICENSE"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,7 +37,6 @@ jobs:
             # main/dev branch
             IMAGE_TAG=$BRANCH
           fi
-          IMAGE_TAG=main
           echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
           echo "E2E tests will run on IMAGE_TAG=$IMAGE_TAG"
 


### PR DESCRIPTION
Leverage our CodeBuild runners for quicker docker builds.

Resolves https://github.com/DefGuard/defguard/issues/1565