### PR TITLE
Fixes pentest issue DG25-17 from 2025-09-02

### DIFF
--- a/crates/defguard_core/src/db/models/oauth2client.rs
+++ b/crates/defguard_core/src/db/models/oauth2client.rs
@@ -101,6 +101,18 @@ impl OAuth2Client<Id> {
         .fetch_optional(pool)
         .await
     }
+
+    /// Checks if `url` matches client config (ignoring trailing slashes)
+    pub(crate) fn contains_redirect_url(&self, url: &str) -> bool {
+        let parsed_redirect_uris: Vec<String> = self
+            .redirect_uri
+            .iter()
+            .map(|uri| uri.trim_end_matches('/').into())
+            .collect();
+        !url.split(' ')
+            .map(|uri| uri.trim_end_matches('/'))
+            .all(|uri| !parsed_redirect_uris.iter().any(|u| u == uri))
+    }
 }
 
 // Safe to show for not privileged users

--- a/crates/defguard_core/src/db/models/oauth2client.rs
+++ b/crates/defguard_core/src/db/models/oauth2client.rs
@@ -111,14 +111,13 @@ impl OAuth2Client<Id> {
             .map(|uri| uri.trim_end_matches('/').into())
             .collect();
 
-		// extract origin from url
-		let Ok(url) = Url::parse(url) else {
-			return false;
-		};
-		let url = url.origin().ascii_serialization();
+        // extract origin from url
+        let Ok(url) = Url::parse(url) else {
+            return false;
+        };
+        let url = url.origin().ascii_serialization();
 
-        !url
-            .split(' ')
+        !url.split(' ')
             .map(|uri| uri.trim_end_matches('/'))
             .all(|uri| !parsed_redirect_uris.iter().any(|u| u == uri))
     }

--- a/crates/defguard_core/src/db/models/oauth2client.rs
+++ b/crates/defguard_core/src/db/models/oauth2client.rs
@@ -110,14 +110,17 @@ impl OAuth2Client<Id> {
             .iter()
             .map(|uri| uri.trim_end_matches('/').into())
             .collect();
-        eprintln!("parsed uris: {parsed_redirect_uris:?}, url: {url}");
-		let url = Url::parse(url).expect("Failed to parse url").origin().ascii_serialization();
-        let contains = !url
+
+		// extract origin from url
+		let Ok(url) = Url::parse(url) else {
+			return false;
+		};
+		let url = url.origin().ascii_serialization();
+
+        !url
             .split(' ')
             .map(|uri| uri.trim_end_matches('/'))
-            .all(|uri| !parsed_redirect_uris.iter().any(|u| u == uri));
-        eprintln!("contains: {contains}");
-        contains
+            .all(|uri| !parsed_redirect_uris.iter().any(|u| u == uri))
     }
 }
 

--- a/crates/defguard_core/src/db/models/oauth2client.rs
+++ b/crates/defguard_core/src/db/models/oauth2client.rs
@@ -1,4 +1,5 @@
 use model_derive::Model;
+use reqwest::Url;
 use sqlx::{Error as SqlxError, PgExecutor, PgPool, query_as};
 
 use super::NewOpenIDClient;
@@ -109,9 +110,14 @@ impl OAuth2Client<Id> {
             .iter()
             .map(|uri| uri.trim_end_matches('/').into())
             .collect();
-        !url.split(' ')
+        eprintln!("parsed uris: {parsed_redirect_uris:?}, url: {url}");
+		let url = Url::parse(url).expect("Failed to parse url").origin().ascii_serialization();
+        let contains = !url
+            .split(' ')
             .map(|uri| uri.trim_end_matches('/'))
-            .all(|uri| !parsed_redirect_uris.iter().any(|u| u == uri))
+            .all(|uri| !parsed_redirect_uris.iter().any(|u| u == uri));
+        eprintln!("contains: {contains}");
+        contains
     }
 }
 

--- a/crates/defguard_core/src/handlers/openid_flow.rs
+++ b/crates/defguard_core/src/handlers/openid_flow.rs
@@ -516,9 +516,8 @@ pub async fn authorization(
         error = CoreAuthErrorResponseType::UnauthorizedClient;
     }
 
-    let mut url =
-        Url::parse(&data.redirect_uri).map_err(|_| WebError::Http(StatusCode::BAD_REQUEST))?;
-
+    // Don't allow open redirects (DG25-17)
+    let mut url = server_config().url.clone();
     {
         let mut query_pairs = url.query_pairs_mut();
         query_pairs.append_pair("error", error.as_ref());
@@ -552,8 +551,6 @@ pub async fn secure_authorization(
     Query(data): Query<AuthenticationRequest>,
     private_cookies: PrivateCookieJar,
 ) -> Result<(StatusCode, HeaderMap, PrivateCookieJar), WebError> {
-    let mut url =
-        Url::parse(&data.redirect_uri).map_err(|_| WebError::Http(StatusCode::BAD_REQUEST))?;
     let error;
     if data.allow {
         if let Some(oauth2client) =
@@ -616,6 +613,8 @@ pub async fn secure_authorization(
         error = CoreAuthErrorResponseType::AccessDenied;
     }
 
+    // Don't allow open redirects (DG25-17)
+    let mut url = server_config().url.clone();
     {
         let mut query_pairs = url.query_pairs_mut();
         query_pairs.append_pair("error", error.as_ref());

--- a/crates/defguard_core/src/handlers/openid_flow.rs
+++ b/crates/defguard_core/src/handlers/openid_flow.rs
@@ -271,18 +271,7 @@ impl AuthenticationRequest {
 
         // assume `client_id` is the same here and in `oauth2client`
 
-        // check `redirect_uri` matches client config (ignoring trailing slashes)
-        let parsed_redirect_uris: Vec<String> = oauth2client
-            .redirect_uri
-            .iter()
-            .map(|uri| uri.trim_end_matches('/').into())
-            .collect();
-        if self
-            .redirect_uri
-            .split(' ')
-            .map(|uri| uri.trim_end_matches('/'))
-            .all(|uri| !parsed_redirect_uris.iter().any(|u| u == uri))
-        {
+        if !oauth2client.contains_redirect_url(&self.redirect_uri) {
             error!(
                 "Invalid redirect_uri for client {}: {} not in [{}]",
                 oauth2client.name,
@@ -392,9 +381,11 @@ pub async fn authorization(
     private_cookies: PrivateCookieJar,
 ) -> Result<(StatusCode, HeaderMap, PrivateCookieJar), WebError> {
     let error;
+    let mut is_redirect_allowed = false;
     if let Some(oauth2client) =
         OAuth2Client::find_by_client_id(&appstate.pool, &data.client_id).await?
     {
+        is_redirect_allowed = oauth2client.contains_redirect_url(&data.redirect_uri);
         match data.validate_for_client(&oauth2client) {
             Ok(()) => {
                 match &data.prompt {
@@ -516,8 +507,12 @@ pub async fn authorization(
         error = CoreAuthErrorResponseType::UnauthorizedClient;
     }
 
-    // Don't allow open redirects (DG25-17)
-    let mut url = server_config().url.clone();
+    let mut url = if is_redirect_allowed {
+        Url::parse(&data.redirect_uri).map_err(|_| WebError::Http(StatusCode::BAD_REQUEST))?
+    } else {
+        // Don't allow open redirects (DG25-17)
+        server_config().url.clone()
+    };
     {
         let mut query_pairs = url.query_pairs_mut();
         query_pairs.append_pair("error", error.as_ref());
@@ -552,10 +547,12 @@ pub async fn secure_authorization(
     private_cookies: PrivateCookieJar,
 ) -> Result<(StatusCode, HeaderMap, PrivateCookieJar), WebError> {
     let error;
+    let mut is_redirect_allowed = false;
     if data.allow {
         if let Some(oauth2client) =
             OAuth2Client::find_by_client_id(&appstate.pool, &data.client_id).await?
         {
+            is_redirect_allowed = oauth2client.contains_redirect_url(&data.redirect_uri);
             match data.validate_for_client(&oauth2client) {
                 Ok(()) => {
                     if OAuth2AuthorizedApp::find_by_user_and_oauth2client_id(
@@ -613,8 +610,12 @@ pub async fn secure_authorization(
         error = CoreAuthErrorResponseType::AccessDenied;
     }
 
-    // Don't allow open redirects (DG25-17)
-    let mut url = server_config().url.clone();
+    let mut url = if is_redirect_allowed {
+        Url::parse(&data.redirect_uri).map_err(|_| WebError::Http(StatusCode::BAD_REQUEST))?
+    } else {
+        // Don't allow open redirects (DG25-17)
+        server_config().url.clone()
+    };
     {
         let mut query_pairs = url.query_pairs_mut();
         query_pairs.append_pair("error", error.as_ref());

--- a/crates/defguard_core/src/handlers/openid_flow.rs
+++ b/crates/defguard_core/src/handlers/openid_flow.rs
@@ -552,7 +552,6 @@ pub async fn secure_authorization(
         OAuth2Client::find_by_client_id(&appstate.pool, &data.client_id).await?
     {
         is_redirect_allowed = oauth2client.contains_redirect_url(&data.redirect_uri);
-        eprintln!("is_redirect_allowed: {is_redirect_allowed}");
         if data.allow {
             match data.validate_for_client(&oauth2client) {
                 Ok(()) => {
@@ -604,7 +603,6 @@ pub async fn secure_authorization(
             error = CoreAuthErrorResponseType::AccessDenied;
         }
     } else {
-        eprintln!("is_redirect_allowed 2: {is_redirect_allowed}");
         error!(
             "User {} tried to log in with non-existent OIDC client id {}",
             session_info.user.username, data.client_id
@@ -613,11 +611,9 @@ pub async fn secure_authorization(
     }
 
     let mut url = if is_redirect_allowed {
-        eprintln!("redirect allowed");
         Url::parse(&data.redirect_uri).map_err(|_| WebError::Http(StatusCode::BAD_REQUEST))?
     } else {
         // Don't allow open redirects (DG25-17)
-        eprintln!("redirect NOT allowed (secure)");
         server_config().url.clone()
     };
     {

--- a/crates/defguard_core/tests/integration/api/openid.rs
+++ b/crates/defguard_core/tests/integration/api/openid.rs
@@ -294,22 +294,22 @@ async fn test_openid_flow(_: PgPoolOptions, options: PgConnectOptions) {
     assert!(location.starts_with(fallback_url));
     assert!(location.contains("error"));
 
-    // // test invalid redirect uri
-    // let response = client
-    //     .post(format!(
-    //         "/api/v1/oauth/authorize?\
-    //         response_type=code&\
-    //         client_id={}&\
-    //         redirect_uri=http%3A%2F%example%3A3000%2F&\
-    //         scope=openid&\
-    //         state=ABCDEF&\
-    //         nonce=blabla",
-    //         openid_client.client_id
-    //     ))
-    //     .send()
-    //     .await;
-    // assert_eq!(response.status(), StatusCode::FOUND);
-    // assert!(location.starts_with(fallback_url));
+    // test invalid redirect uri
+    let response = client
+        .post(format!(
+            "/api/v1/oauth/authorize?\
+            response_type=code&\
+            client_id={}&\
+            redirect_uri=http%3A%2F%example%3A3000%2F&\
+            scope=openid&\
+            state=ABCDEF&\
+            nonce=blabla",
+            openid_client.client_id
+        ))
+        .send()
+        .await;
+    assert_eq!(response.status(), StatusCode::FOUND);
+    assert!(location.starts_with(fallback_url));
 
     // test non-whitelisted uri
     let response = client

--- a/crates/defguard_core/tests/integration/api/openid.rs
+++ b/crates/defguard_core/tests/integration/api/openid.rs
@@ -818,7 +818,7 @@ async fn dg25_17_test_openid_open_redirects(_: PgPoolOptions, options: PgConnect
 
     // Try to authorize with allowed redirect url - invalid client id
     let response = client
-        .post(format!(
+        .post(
             "/api/v1/oauth/authorize?\
             response_type=code&\
             client_id=xxx&\
@@ -827,14 +827,14 @@ async fn dg25_17_test_openid_open_redirects(_: PgPoolOptions, options: PgConnect
             state=ABCDEF&\
             allow=true&\
             nonce=blabla",
-        ))
+        )
         .send()
         .await;
     assert_eq!(response.status(), StatusCode::FOUND);
     assert_eq!(redirect_url(&response), fallback_url,);
 
     let response = client
-        .get(format!(
+        .get(
             "/api/v1/oauth/authorize?\
             response_type=code&\
             client_id=xxx&\
@@ -843,7 +843,7 @@ async fn dg25_17_test_openid_open_redirects(_: PgPoolOptions, options: PgConnect
             state=ABCDEF&\
             allow=true&\
             nonce=blabla",
-        ))
+        )
         .send()
         .await;
     assert_eq!(response.status(), StatusCode::FOUND);
@@ -851,7 +851,7 @@ async fn dg25_17_test_openid_open_redirects(_: PgPoolOptions, options: PgConnect
 
     // Try to authorize with forbidden redirect url - invalid client id
     let response = client
-        .post(format!(
+        .post(
             "/api/v1/oauth/authorize?\
             response_type=code&\
             client_id=xxx&\
@@ -860,14 +860,14 @@ async fn dg25_17_test_openid_open_redirects(_: PgPoolOptions, options: PgConnect
             state=ABCDEF&\
             allow=true&\
             nonce=blabla",
-        ))
+        )
         .send()
         .await;
     assert_eq!(response.status(), StatusCode::FOUND);
     assert_eq!(redirect_url(&response), fallback_url);
 
     let response = client
-        .get(format!(
+        .get(
             "/api/v1/oauth/authorize?\
             response_type=code&\
             client_id=xxx&\
@@ -876,7 +876,7 @@ async fn dg25_17_test_openid_open_redirects(_: PgPoolOptions, options: PgConnect
             state=ABCDEF&\
             allow=true&\
             nonce=blabla",
-        ))
+        )
         .send()
         .await;
     assert_eq!(response.status(), StatusCode::FOUND);

--- a/crates/defguard_core/tests/integration/api/openid.rs
+++ b/crates/defguard_core/tests/integration/api/openid.rs
@@ -1192,7 +1192,7 @@ async fn dg25_22_test_respect_openid_scope_in_userinfo(
     assert!(claims.phone_number().is_none());
 }
 
-// #[sqlx::test]
+#[sqlx::test]
 async fn test_openid_flow_new_login_mail(_: PgPoolOptions, options: PgConnectOptions) {
     let pool = setup_pool(options).await;
 


### PR DESCRIPTION
This pull request fixes vulnerability from penetration tests done by our security team on 2025-09-02:

- title: Open redirect
- ID: DG25-17
- report details: https://defguard.net/pentesting/

Don't allow open redirects when handling invalid openid authorization requests.

Related issue https://github.com/DefGuard/defguard/issues/1548