### PR TITLE
Fixes pentest issue DG25-11 from 2025-09-02

### DIFF
--- a/crates/defguard_common/src/db/models/settings.rs
+++ b/crates/defguard_common/src/db/models/settings.rs
@@ -397,7 +397,7 @@ impl From<Settings> for SettingsEssentials {
     }
 }
 
-mod defaults {
+pub mod defaults {
     pub static WELCOME_MESSAGE: &str = "Dear {{ first_name }} {{ last_name }},
 
 By completing the enrollment process, you now have access to all company systems.


### PR DESCRIPTION
This pull request fixes vulnerabilities from penetration tests done by our security team on 2025-09-02:

title: Improper handling of user-provided input leads to panic
ID: DG25-11
raport details: https://defguard.net/pentesting/

Fall back to default enrollment email subject if it is somehow None. The field itself is indeed nullable, but it gets initialized on system startup so the issue would not occur under normal circumstances. 

Closes https://github.com/DefGuard/defguard/issues/1552