### PR TITLE
use non-Alpine Node 24 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/node:24-alpine AS web
+FROM public.ecr.aws/docker/library/node:24 AS web
 
 WORKDIR /app
 COPY web/package.json web/pnpm-lock.yaml web/.npmrc ./


### PR DESCRIPTION
fix failing ARM image builds by switching to a non-Alpine base image