### PR TITLE
chore(ci): pin older pnpm version

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,7 +49,8 @@ jobs:
         id: pnpm-install
         uses: pnpm/action-setup@v4
         with:
-          version: 10.18
+          # FIXME: temporarily pinned because of https://github.com/pnpm/pnpm/pull/9959
+          version: 10.17
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/lint-e2e.yml
+++ b/.github/workflows/lint-e2e.yml
@@ -24,7 +24,8 @@ jobs:
           node-version-file: "./e2e/.nvmrc"
       - uses: pnpm/action-setup@v4
         with:
-          version: 10.18
+          # FIXME: temporarily pinned because of https://github.com/pnpm/pnpm/pull/9959
+          version: 10.17
           run_install: false
       - name: install deps
         working-directory: ./e2e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,8 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.18
+          # FIXME: temporarily pinned because of https://github.com/pnpm/pnpm/pull/9959
+          version: 10.17
 
       - name: Use Node.js 24
         uses: actions/setup-node@v4


### PR DESCRIPTION
Pin pnpm version used in CI as a workaround for https://github.com/pnpm/pnpm/pull/9959
