### PR TITLE
fix cache invalidation for client behavior settings page

### DIFF
--- a/web/src/pages/settings/SettingsClientPage/SettingsClientPage.tsx
+++ b/web/src/pages/settings/SettingsClientPage/SettingsClientPage.tsx
@@ -77,7 +77,7 @@ const Content = () => {
   const { mutateAsync: patchSettings } = useMutation({
     mutationFn: api.settings.patchEnterpriseSettings,
     meta: {
-      invalidate: [['enterprise_settings'], ['settings']],
+      invalidate: [['settings_enterprise'], ['settings']],
     },
     onSuccess: () => {
       Snackbar.success(m.settings_msg_saved());


### PR DESCRIPTION
Related issue: https://github.com/DefGuard/defguard/issues/2278