### PR TITLE
Fix initial wizard always redirecting to vpn overview

### DIFF
--- a/web/src/pages/SetupPage/initial/SetupPage.tsx
+++ b/web/src/pages/SetupPage/initial/SetupPage.tsx
@@ -112,11 +112,13 @@ export const SetupPage = () => {
     [],
   );
 
+  const isFinishing = useSetupWizardStore((s) => s.isFinishing);
+
   useEffect(() => {
-    if (sessionInfo?.active_wizard === null) {
+    if (!isFinishing && sessionInfo?.active_wizard === null) {
       navigate({ to: '/vpn-overview', replace: true });
     }
-  }, [navigate, sessionInfo?.active_wizard]);
+  }, [isFinishing, navigate, sessionInfo?.active_wizard]);
 
   return (
     <WizardPage

--- a/web/src/pages/SetupPage/initial/steps/SetupConfirmationStep.tsx
+++ b/web/src/pages/SetupPage/initial/steps/SetupConfirmationStep.tsx
@@ -49,6 +49,7 @@ export const SetupConfirmationStep = () => {
   const handleFinish = async () => {
     try {
       setIsSubmitting(true);
+      useSetupWizardStore.setState({ isFinishing: true });
       await finishSetup();
       await waitForSettingsEssentials({});
       await navigate({ to: '/add-location', replace: true });
@@ -57,6 +58,7 @@ export const SetupConfirmationStep = () => {
       }, 100);
     } catch (error) {
       console.error('Failed to finish setup flow:', error);
+      useSetupWizardStore.setState({ isFinishing: false });
       Snackbar.error(m.initial_setup_confirmation_error_finish_failed());
     } finally {
       setIsSubmitting(false);
@@ -66,6 +68,7 @@ export const SetupConfirmationStep = () => {
   const handleExit = async () => {
     try {
       setIsSubmitting(true);
+      useSetupWizardStore.setState({ isFinishing: true });
       await finishSetup();
       await waitForSettingsEssentials({});
       await navigate({ to: '/vpn-overview', replace: true });
@@ -74,6 +77,7 @@ export const SetupConfirmationStep = () => {
       }, 100);
     } catch (error) {
       console.error('Failed to finish setup flow:', error);
+      useSetupWizardStore.setState({ isFinishing: false });
       Snackbar.error(m.initial_setup_confirmation_error_finish_failed());
     } finally {
       setIsSubmitting(false);

--- a/web/src/pages/SetupPage/initial/useSetupWizardStore.tsx
+++ b/web/src/pages/SetupPage/initial/useSetupWizardStore.tsx
@@ -15,6 +15,7 @@ const edgeAdoptionStateDefaults: EdgeAdoptionState = {
 
 type StoreValues = {
   isOnWelcomePage: boolean;
+  isFinishing: boolean;
   activeStep: SetupPageStepValue;
   // Admin config
   admin_first_name: string;
@@ -51,6 +52,7 @@ type StoreMethods = {
 
 const defaults: StoreValues = {
   isOnWelcomePage: true,
+  isFinishing: false,
   activeStep: SetupPageStep.AdminUser,
   // Admin config
   admin_first_name: '',
@@ -108,6 +110,7 @@ export const useSetupWizardStore = create<StoreMethods & StoreValues>()(
       storage: createJSONStorage(() => sessionStorage),
       partialize: (state) =>
         omit(state, [
+          'isFinishing',
           'reset',
           'start',
           'setActiveStep',


### PR DESCRIPTION
Sometimes we'd like to redirect to the location wizard after completing the initial wizard.