### PR TITLE
make IP optional in activity log

### DIFF
--- a/.sqlx/query-47c406366d0b53ca805cff303dfe2a67880adeaca1e10e50bea9b9fc53e08845.json
+++ b/.sqlx/query-47c406366d0b53ca805cff303dfe2a67880adeaca1e10e50bea9b9fc53e08845.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT id, \"timestamp\",\"user_id\",\"username\",\"location\",\"ip\",\"event\" \"event: _\",\"module\" \"module: _\",\"device\",\"description\",\"metadata\" FROM \"activity_log_event\"",
+  "query": "SELECT id, \"timestamp\",\"user_id\",\"username\",\"location\",\"ip\" \"ip?: _\",\"event\" \"event: _\",\"module\" \"module: _\",\"device\",\"description\",\"metadata\" FROM \"activity_log_event\" WHERE id = $1",
   "describe": {
     "columns": [
       {
@@ -30,7 +30,7 @@
       },
       {
         "ordinal": 5,
-        "name": "ip",
+        "name": "ip?: _",
         "type_info": "Inet"
       },
       {
@@ -72,7 +72,9 @@
       }
     ],
     "parameters": {
-      "Left": []
+      "Left": [
+        "Int8"
+      ]
     },
     "nullable": [
       false,
@@ -88,5 +90,5 @@
       true
     ]
   },
-  "hash": "32e8f8f8a19578caad21123b4a5f2cbe4336115c83f341311bec75e3a817138b"
+  "hash": "47c406366d0b53ca805cff303dfe2a67880adeaca1e10e50bea9b9fc53e08845"
 }

--- a/.sqlx/query-59d048f8110a53745afd80c607fc52cb537dfded663e6bbee73d5f908f0ca89e.json
+++ b/.sqlx/query-59d048f8110a53745afd80c607fc52cb537dfded663e6bbee73d5f908f0ca89e.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT id, \"timestamp\",\"user_id\",\"username\",\"location\",\"ip\",\"event\" \"event: _\",\"module\" \"module: _\",\"device\",\"description\",\"metadata\" FROM \"activity_log_event\" WHERE id = $1",
+  "query": "SELECT id, \"timestamp\",\"user_id\",\"username\",\"location\",\"ip\" \"ip?: _\",\"event\" \"event: _\",\"module\" \"module: _\",\"device\",\"description\",\"metadata\" FROM \"activity_log_event\"",
   "describe": {
     "columns": [
       {
@@ -30,7 +30,7 @@
       },
       {
         "ordinal": 5,
-        "name": "ip",
+        "name": "ip?: _",
         "type_info": "Inet"
       },
       {
@@ -72,9 +72,7 @@
       }
     ],
     "parameters": {
-      "Left": [
-        "Int8"
-      ]
+      "Left": []
     },
     "nullable": [
       false,
@@ -90,5 +88,5 @@
       true
     ]
   },
-  "hash": "1aea3a14458db09848bd40493a931ee33640bd508ff8a63209288e075383d11f"
+  "hash": "59d048f8110a53745afd80c607fc52cb537dfded663e6bbee73d5f908f0ca89e"
 }

--- a/crates/defguard_core/src/db/models/activity_log/mod.rs
+++ b/crates/defguard_core/src/db/models/activity_log/mod.rs
@@ -130,7 +130,8 @@ pub struct ActivityLogEvent<I = NoId> {
     pub user_id: Id,
     pub username: String,
     pub location: Option<String>,
-    pub ip: IpNetwork,
+    #[model(option)]
+    pub ip: Option<IpNetwork>,
     #[model(enum)]
     pub event: EventType,
     #[model(enum)]

--- a/crates/defguard_core/src/events.rs
+++ b/crates/defguard_core/src/events.rs
@@ -28,19 +28,24 @@ pub struct ApiRequestContext {
     pub timestamp: NaiveDateTime,
     pub user_id: Id,
     pub username: String,
-    pub ip: IpAddr,
+    pub ip: Option<IpAddr>,
     pub device: String,
 }
 
 impl ApiRequestContext {
     #[must_use]
-    pub fn new(user_id: Id, username: String, ip: IpAddr, device: String) -> Self {
+    pub fn new(
+        user_id: Id,
+        username: String,
+        ip: impl Into<Option<IpAddr>>,
+        device: String,
+    ) -> Self {
         let timestamp = Utc::now().naive_utc();
         Self {
             timestamp,
             user_id,
             username,
-            ip,
+            ip: ip.into(),
             device,
         }
     }
@@ -54,7 +59,7 @@ pub struct GrpcRequestContext {
     pub timestamp: NaiveDateTime,
     pub user_id: Id,
     pub username: String,
-    pub ip: IpAddr,
+    pub ip: Option<IpAddr>,
     pub device_id: Id,
     pub device_name: String,
     pub location: WireguardNetwork<Id>,
@@ -65,7 +70,7 @@ impl GrpcRequestContext {
     pub fn new(
         user_id: Id,
         username: String,
-        ip: IpAddr,
+        ip: impl Into<Option<IpAddr>>,
         device_id: Id,
         device_name: String,
         location: WireguardNetwork<Id>,
@@ -75,7 +80,7 @@ impl GrpcRequestContext {
             timestamp,
             user_id,
             username,
-            ip,
+            ip: ip.into(),
             device_id,
             device_name,
             location,
@@ -328,19 +333,24 @@ pub struct BidiRequestContext {
     pub timestamp: NaiveDateTime,
     pub user_id: Id,
     pub username: String,
-    pub ip: IpAddr,
+    pub ip: Option<IpAddr>,
     pub device_name: String,
 }
 
 impl BidiRequestContext {
     #[must_use]
-    pub fn new(user_id: Id, username: String, ip: IpAddr, device_name: String) -> Self {
+    pub fn new(
+        user_id: Id,
+        username: String,
+        ip: impl Into<Option<IpAddr>>,
+        device_name: String,
+    ) -> Self {
         let timestamp = Utc::now().naive_utc();
         Self {
             timestamp,
             user_id,
             username,
-            ip,
+            ip: ip.into(),
             device_name,
         }
     }

--- a/crates/defguard_core/src/handlers/activity_log.rs
+++ b/crates/defguard_core/src/handlers/activity_log.rs
@@ -105,7 +105,7 @@ pub struct ApiActivityLogEvent {
     pub user_id: Id,
     pub username: String,
     pub location: Option<String>,
-    pub ip: IpNetwork,
+    pub ip: Option<IpNetwork>,
     pub event: String,
     pub module: ActivityLogModule,
     pub device: String,

--- a/crates/defguard_core/tests/integration/api/activity_log.rs
+++ b/crates/defguard_core/tests/integration/api/activity_log.rs
@@ -1,0 +1,72 @@
+use chrono::{TimeDelta, Utc};
+use defguard_common::db::{NoId, setup_pool};
+use defguard_core::db::models::activity_log::{ActivityLogEvent, ActivityLogModule, EventType};
+use reqwest::StatusCode;
+use serde::Deserialize;
+use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
+
+use super::common::{get_db_user, make_client_with_db};
+
+#[derive(Deserialize)]
+struct PaginatedResponse<T> {
+    data: Vec<T>,
+}
+
+#[derive(Deserialize)]
+struct ApiActivityLogEvent {
+    id: i64,
+    ip: Option<String>,
+    description: Option<String>,
+}
+
+#[sqlx::test]
+async fn test_activity_log_persists_and_returns_null_ip(
+    _: PgPoolOptions,
+    options: PgConnectOptions,
+) {
+    let pool = setup_pool(options).await;
+    let (mut client, db) = make_client_with_db(pool.clone()).await;
+    let admin = get_db_user(&db, "admin").await;
+
+    client.login_user("admin", "pass123").await;
+
+    let marker = format!(
+        "nullable-ip-{}",
+        Utc::now().timestamp_nanos_opt().unwrap_or_default()
+    );
+    let saved_event = ActivityLogEvent {
+        id: NoId,
+        timestamp: Utc::now().naive_utc() + TimeDelta::seconds(5),
+        user_id: admin.id,
+        username: admin.username,
+        location: None,
+        ip: None,
+        event: EventType::UserLogout,
+        module: ActivityLogModule::Defguard,
+        device: "integration-test".to_string(),
+        description: Some(marker.clone()),
+        metadata: None,
+    }
+    .save(&db)
+    .await
+    .expect("activity log event with null ip should persist");
+
+    let fetched_event = ActivityLogEvent::find_by_id(&db, saved_event.id)
+        .await
+        .expect("activity log event query should succeed")
+        .expect("saved activity log event should exist");
+    assert_eq!(fetched_event.ip, None);
+
+    let response = client.get("/api/v1/activity_log").send().await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let payload: PaginatedResponse<ApiActivityLogEvent> = response.json().await;
+    let api_event = payload
+        .data
+        .into_iter()
+        .find(|event| event.id == saved_event.id)
+        .expect("activity log endpoint should return saved event");
+
+    assert_eq!(api_event.description.as_deref(), Some(marker.as_str()));
+    assert_eq!(api_event.ip, None);
+}

--- a/crates/defguard_core/tests/integration/api/mod.rs
+++ b/crates/defguard_core/tests/integration/api/mod.rs
@@ -1,4 +1,5 @@
 mod acl;
+mod activity_log;
 mod api_tokens;
 mod auth;
 mod common;

--- a/crates/defguard_event_logger/src/lib.rs
+++ b/crates/defguard_event_logger/src/lib.rs
@@ -610,3 +610,33 @@ pub async fn run_event_logger(
         transaction.commit().await?;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use defguard_common::db::NoId;
+    use serde_json::Value;
+
+    use super::*;
+
+    #[test]
+    fn activity_log_event_serialization_supports_null_ip() {
+        let event = ActivityLogEvent {
+            id: NoId,
+            timestamp: Utc::now().naive_utc(),
+            user_id: 1,
+            username: "admin".to_string(),
+            location: None,
+            ip: None,
+            event: EventType::UserLogin,
+            module: ActivityLogModule::Defguard,
+            device: "test-device".to_string(),
+            description: None,
+            metadata: None,
+        };
+
+        let serialized = serde_json::to_value(event).expect("activity log event should serialize");
+
+        assert_eq!(serialized.get("ip"), Some(&Value::Null));
+    }
+}

--- a/crates/defguard_event_logger/src/lib.rs
+++ b/crates/defguard_event_logger/src/lib.rs
@@ -573,7 +573,7 @@ pub async fn run_event_logger(
                     user_id,
                     username,
                     location,
-                    ip: ip.into(),
+                    ip: ip.map(Into::into),
                     event,
                     module,
                     device,

--- a/crates/defguard_event_logger/src/message.rs
+++ b/crates/defguard_event_logger/src/message.rs
@@ -44,7 +44,7 @@ pub struct EventContext {
     pub user_id: Id,
     pub username: String,
     pub location: Option<String>,
-    pub ip: IpAddr,
+    pub ip: Option<IpAddr>,
     pub device: String,
 }
 

--- a/crates/defguard_session_manager/src/events.rs
+++ b/crates/defguard_session_manager/src/events.rs
@@ -18,7 +18,7 @@ pub struct SessionManagerEventContext {
     pub location: WireguardNetwork<Id>,
     pub user: User<Id>,
     pub device: Device<Id>,
-    pub public_ip: IpAddr,
+    pub public_ip: Option<IpAddr>,
 }
 
 #[derive(Debug)]

--- a/crates/defguard_session_manager/src/lib.rs
+++ b/crates/defguard_session_manager/src/lib.rs
@@ -1,5 +1,3 @@
-use std::net::{IpAddr, Ipv4Addr};
-
 use chrono::Utc;
 use defguard_common::{
     db::{
@@ -312,8 +310,7 @@ impl SessionManager {
             location: location.clone(),
             user,
             device,
-            // FIXME: this is a workaround since we require an IP for each audit log event
-            public_ip: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            public_ip: None,
         };
         let event = SessionManagerEvent {
             context,

--- a/crates/defguard_session_manager/src/session_state.rs
+++ b/crates/defguard_session_manager/src/session_state.rs
@@ -337,7 +337,7 @@ impl ActiveSessionsMap {
             location,
             user,
             device,
-            public_ip,
+            public_ip: Some(public_ip),
         };
         let event = SessionManagerEvent {
             context,

--- a/crates/defguard_session_manager/tests/session_manager/event_flow.rs
+++ b/crates/defguard_session_manager/tests/session_manager/event_flow.rs
@@ -55,7 +55,7 @@ async fn test_session_manager_emits_connected_event_for_first_stats(
     assert_eq!(event.context.location.id, location.id);
     assert_eq!(event.context.user.id, user.id);
     assert_eq!(event.context.device.id, device.id);
-    assert_eq!(event.context.public_ip, endpoint.ip());
+    assert_eq!(event.context.public_ip, Some(endpoint.ip()));
 }
 
 #[sqlx::test]
@@ -149,6 +149,7 @@ async fn test_session_manager_emits_disconnect_event_for_inactive_standard_sessi
     assert_eq!(event.context.location.id, location.id);
     assert_eq!(event.context.user.id, user.id);
     assert_eq!(event.context.device.id, device.id);
+    assert_eq!(event.context.public_ip, None);
 
     let disconnected_session = VpnClientSession::find_by_id(&pool, session.id)
         .await

--- a/crates/defguard_session_manager/tests/session_manager/sessions.rs
+++ b/crates/defguard_session_manager/tests/session_manager/sessions.rs
@@ -144,7 +144,7 @@ async fn test_duplicate_stats_in_same_batch_reuse_existing_session(
     assert_eq!(connected_event.context.location.id, location.id);
     assert_eq!(connected_event.context.user.id, user.id);
     assert_eq!(connected_event.context.device.id, device.id);
-    assert_eq!(connected_event.context.public_ip, endpoint.ip());
+    assert_eq!(connected_event.context.public_ip, Some(endpoint.ip()));
     assert_no_session_manager_events(&mut harness);
     assert_no_gateway_events(&mut harness);
 
@@ -221,7 +221,7 @@ async fn test_duplicate_stats_across_iterations_reuse_existing_session(
     assert_eq!(connected_event.context.location.id, location.id);
     assert_eq!(connected_event.context.user.id, user.id);
     assert_eq!(connected_event.context.device.id, device.id);
-    assert_eq!(connected_event.context.public_ip, endpoint.ip());
+    assert_eq!(connected_event.context.public_ip, Some(endpoint.ip()));
     assert_no_session_manager_events(&mut harness);
     assert_no_gateway_events(&mut harness);
 

--- a/migrations/20260317100000_[2.0.0]_activity_log_optional_ip.down.sql
+++ b/migrations/20260317100000_[2.0.0]_activity_log_optional_ip.down.sql
@@ -1,0 +1,5 @@
+UPDATE activity_log_event
+SET ip = '0.0.0.0'::inet
+WHERE ip IS NULL;
+
+ALTER TABLE activity_log_event ALTER COLUMN ip SET NOT NULL;

--- a/migrations/20260317100000_[2.0.0]_activity_log_optional_ip.up.sql
+++ b/migrations/20260317100000_[2.0.0]_activity_log_optional_ip.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE activity_log_event ALTER COLUMN ip DROP NOT NULL;

--- a/web/src/pages/ActivityLogPage/ActivityLogTable.tsx
+++ b/web/src/pages/ActivityLogPage/ActivityLogTable.tsx
@@ -21,6 +21,18 @@ import { displayDate } from '../../shared/utils/displayDate';
 type RowData = ActivityLogEvent;
 
 const columnHelper = createColumnHelper<RowData>();
+const missingValuePlaceholder = '—';
+
+const renderOptionalTableValue = (
+  value: string | null | undefined,
+  missingValueLabel: string,
+) => {
+  if (!isPresent(value)) {
+    return <span aria-label={missingValueLabel}>{missingValuePlaceholder}</span>;
+  }
+
+  return <span>{value}</span>;
+};
 
 interface Props {
   data: RowData[];
@@ -73,11 +85,12 @@ export const ActivityLogTable = ({
       columnHelper.accessor('ip', {
         header: 'IP',
         minSize: 150,
-        cell: (info) => (
-          <TableCell>
-            <span>{info.getValue()}</span>
-          </TableCell>
-        ),
+        cell: (info) => {
+          const value = info.getValue();
+          return (
+            <TableCell>{renderOptionalTableValue(value, 'No IP recorded')}</TableCell>
+          );
+        },
       }),
       columnHelper.accessor('location', {
         header: 'Location',
@@ -86,7 +99,7 @@ export const ActivityLogTable = ({
           const value = info.getValue();
           return (
             <TableCell>
-              {isPresent(value) ? <span>{value}</span> : <span>{`~`}</span>}
+              {renderOptionalTableValue(value, 'No location recorded')}
             </TableCell>
           );
         },

--- a/web/src/shared/api/types.ts
+++ b/web/src/shared/api/types.ts
@@ -1191,7 +1191,7 @@ export interface ActivityLogEvent {
   user_id: number;
   username: string;
   location?: string;
-  ip: string;
+  ip: string | null;
   event: ActivityLogEventTypeValue;
   module: ActivityLogModuleValue;
   device: string;


### PR DESCRIPTION
Make IP field optional in activity log events to avoid forcing fake IPs in some cases (like VPN session disconnect which is triggered by defguard itself, not an external request).

Closes https://github.com/DefGuard/defguard/issues/2317