### PR TITLE
Autoadoption logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1623,6 +1623,7 @@ dependencies = [
  "tokio",
  "tonic",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/defguard/src/main.rs
+++ b/crates/defguard/src/main.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<(), anyhow::Error> {
     }
     let mut config = DefGuardConfig::new();
     let log_filter = format!(
-        "{},defguard_core::handlers::component_setup=debug",
+        "{},defguard_core::handlers::component_setup=debug,defguard_setup::auto_adoption=debug",
         config.log_level
     );
 

--- a/crates/defguard_setup/Cargo.toml
+++ b/crates/defguard_setup/Cargo.toml
@@ -35,3 +35,4 @@ reqwest = { version = "0.12", features = [
     "json",
     "rustls-tls",
 ], default-features = false }
+tracing-subscriber.workspace = true

--- a/crates/defguard_setup/src/auto_adoption.rs
+++ b/crates/defguard_setup/src/auto_adoption.rs
@@ -1,4 +1,8 @@
-use std::time::Duration;
+use std::{
+	collections::VecDeque,
+	sync::{Arc, Mutex},
+	time::Duration,
+};
 
 use anyhow::Context;
 use defguard_certs::{CertificateAuthority, CertificateInfo, Csr, PemLabel, der_to_pem};
@@ -18,6 +22,7 @@ use defguard_common::{
     },
 };
 use defguard_core::version::{MIN_GATEWAY_VERSION, MIN_PROXY_VERSION};
+use defguard_core::setup_logs::scope_setup_logs;
 use defguard_proto::{
     gateway::{
         CertificateInfo as GatewayCertificateInfo, DerPayload as GatewayDerPayload,
@@ -48,6 +53,8 @@ const AUTO_ADOPTION_CA_VALIDITY_DAYS: u32 = 3650;
 const GATEWAY_NAME: &str = "Gateway";
 const PROXY_NAME: &str = "Edge";
 const KEEPALIVE_INTERVAL_SECONDS: Duration = Duration::from_secs(5);
+
+type SetupLogBuffer = Arc<Mutex<VecDeque<String>>>;
 
 async fn ensure_ca_for_auto_adoption(pool: &PgPool) -> Result<(), anyhow::Error> {
     let mut settings = Settings::get_current_settings();
@@ -149,12 +156,6 @@ impl Drop for TaskGuard {
     }
 }
 
-fn adoption_failure(message: impl Into<String>) -> (bool, Vec<String>, Option<CertificateInfo>) {
-    let msg = message.into();
-    error!("{msg}");
-    (false, vec![msg], None)
-}
-
 fn format_component_log(timestamp: &str, level: &str, target: &str, message: &str) -> String {
     let level = level
         .strip_prefix("Level(")
@@ -166,87 +167,145 @@ fn format_component_log(timestamp: &str, level: &str, target: &str, message: &st
 }
 
 fn collect_stream_logs(log_rx: &mut UnboundedReceiver<String>) -> Vec<String> {
-    let mut logs = Vec::new();
-    while let Ok(log) = log_rx.try_recv() {
-        logs.push(log);
-    }
-    logs
+	let mut logs = Vec::new();
+	while let Ok(log) = log_rx.try_recv() {
+		logs.push(log);
+	}
+	logs
 }
 
-fn adoption_failure_with_logs(
-    message: impl Into<String>,
-    log_rx: &mut UnboundedReceiver<String>,
+fn collect_core_logs(log_buffer: &SetupLogBuffer) -> Vec<String> {
+	let mut guard = log_buffer
+		.lock()
+		.unwrap_or_else(std::sync::PoisonError::into_inner);
+	std::mem::take(&mut *guard).into_iter().collect()
+}
+
+fn merge_failure_logs(
+	message: impl Into<String>,
+	log_buffer: &SetupLogBuffer,
+	log_rx: &mut UnboundedReceiver<String>,
 ) -> (bool, Vec<String>, Option<CertificateInfo>) {
-    let msg = message.into();
-    error!("{msg}");
-    let logs = collect_stream_logs(log_rx);
-    (false, logs, None)
+	let msg = message.into();
+	error!("{msg}");
+	let mut logs = collect_core_logs(log_buffer);
+	logs.extend(collect_stream_logs(log_rx));
+	if !logs.iter().any(|line| line.contains(&msg)) {
+		logs.push(msg);
+	}
+	(false, logs, None)
 }
 
 async fn run_edge_adoption_attempt(
-    _pool: &PgPool,
-    host: &str,
-    port: u16,
+	_pool: &PgPool,
+	host: &str,
+	port: u16,
 ) -> (bool, Vec<String>, Option<CertificateInfo>) {
-    debug!("Starting edge adoption attempt host={host} port={port}");
-    let (log_tx, mut log_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+	let log_buffer = Arc::new(Mutex::new(VecDeque::new()));
+	scope_setup_logs(Arc::clone(&log_buffer), async move {
+		run_edge_adoption_attempt_scoped(host, port, log_buffer).await
+	})
+	.await
+}
 
-    let settings = Settings::get_current_settings();
-    let Some(ca_cert_der) = settings.ca_cert_der else {
-        return adoption_failure("CA certificate not found in settings");
-    };
-    let Some(ca_key_der) = settings.ca_key_der else {
-        return adoption_failure(
-            "CA private key not found in settings. Uploading CA cert without key cannot auto-adopt.",
-        );
-    };
-    let endpoint_str = format!("http://{host}:{port}");
-    let url = match Url::parse(&endpoint_str) {
-        Ok(url) => url,
-        Err(err) => return adoption_failure(format!("Invalid edge endpoint URL: {err}")),
-    };
+async fn run_edge_adoption_attempt_scoped(
+	host: &str,
+	port: u16,
+	log_buffer: SetupLogBuffer,
+) -> (bool, Vec<String>, Option<CertificateInfo>) {
+	debug!("Starting edge adoption attempt host={host} port={port}");
+	let (log_tx, mut log_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
 
-    let cert_pem = match der_to_pem(&ca_cert_der, PemLabel::Certificate) {
-        Ok(pem) => pem,
-        Err(err) => {
-            return adoption_failure(format!("Failed to convert CA certificate to PEM: {err}"));
-        }
-    };
+	let settings = Settings::get_current_settings();
+	let Some(ca_cert_der) = settings.ca_cert_der else {
+		return merge_failure_logs("CA certificate not found in settings", &log_buffer, &mut log_rx);
+	};
+	let Some(ca_key_der) = settings.ca_key_der else {
+		return merge_failure_logs(
+			"CA private key not found in settings. Uploading CA cert without key cannot auto-adopt.",
+			&log_buffer,
+			&mut log_rx,
+		);
+	};
+	let endpoint_str = format!("http://{host}:{port}");
+	let url = match Url::parse(&endpoint_str) {
+		Ok(url) => url,
+		Err(err) => {
+			return merge_failure_logs(
+				format!("Invalid edge endpoint URL: {err}"),
+				&log_buffer,
+				&mut log_rx,
+			)
+		}
+	};
 
-    let base_endpoint = match Endpoint::from_shared(endpoint_str.clone()) {
-        Ok(endpoint) => endpoint,
-        Err(err) => return adoption_failure(format!("Failed to build edge endpoint: {err}")),
-    };
+	let cert_pem = match der_to_pem(&ca_cert_der, PemLabel::Certificate) {
+		Ok(pem) => pem,
+		Err(err) => {
+			return merge_failure_logs(
+				format!("Failed to convert CA certificate to PEM: {err}"),
+				&log_buffer,
+				&mut log_rx,
+			);
+		}
+	};
+
+	let base_endpoint = match Endpoint::from_shared(endpoint_str.clone()) {
+		Ok(endpoint) => endpoint,
+		Err(err) => {
+			return merge_failure_logs(
+				format!("Failed to build edge endpoint: {err}"),
+				&log_buffer,
+				&mut log_rx,
+			)
+		}
+	};
 
     let base_endpoint = base_endpoint
         .http2_keep_alive_interval(KEEPALIVE_INTERVAL_SECONDS)
         .tcp_keepalive(Some(KEEPALIVE_INTERVAL_SECONDS))
         .keep_alive_while_idle(true);
 
-    let tls = ClientTlsConfig::new().ca_certificate(Certificate::from_pem(cert_pem));
-    let endpoint = match base_endpoint.tls_config(tls) {
-        Ok(endpoint) => endpoint,
-        Err(err) => {
-            return adoption_failure(format!("Failed to configure TLS for edge endpoint: {err}"));
-        }
-    };
+	let tls = ClientTlsConfig::new().ca_certificate(Certificate::from_pem(cert_pem));
+	let endpoint = match base_endpoint.tls_config(tls) {
+		Ok(endpoint) => endpoint,
+		Err(err) => {
+			return merge_failure_logs(
+				format!("Failed to configure TLS for edge endpoint: {err}"),
+				&log_buffer,
+				&mut log_rx,
+			);
+		}
+	};
 
-    let core_version = match Version::parse(VERSION) {
-        Ok(version) => version,
-        Err(err) => return adoption_failure(format!("Failed to parse core version: {err}")),
-    };
+	let core_version = match Version::parse(VERSION) {
+		Ok(version) => version,
+		Err(err) => {
+			return merge_failure_logs(
+				format!("Failed to parse core version: {err}"),
+				&log_buffer,
+				&mut log_rx,
+			)
+		}
+	};
 
     let token = match Claims::new(
         ClaimsType::Gateway,
         url.to_string(),
         TOKEN_CLIENT_ID.to_string(),
         u32::MAX.into(),
-    )
-    .to_jwt()
-    {
-        Ok(token) => token,
-        Err(err) => return adoption_failure(format!("Failed to generate setup token: {err}")),
-    };
+	)
+	.to_jwt()
+	{
+		Ok(token) => token,
+		Err(err) => {
+			return merge_failure_logs(
+				format!("Failed to generate setup token: {err}"),
+				&log_buffer,
+				&mut log_rx,
+			)
+		}
+	};
 
     let version_interceptor = ClientVersionInterceptor::new(core_version.clone());
     let auth_interceptor = AuthInterceptor::new(token);
@@ -257,19 +316,27 @@ async fn run_edge_adoption_attempt(
             auth_interceptor.clone().call(req)
         });
 
-    let response_with_metadata =
-        match tokio::time::timeout(STARTUP_ADOPTION_TIMEOUT, client.start(())).await {
-            Ok(Ok(response)) => response,
-            Ok(Err(err)) => {
-                return adoption_failure(format!("Failed to start edge setup stream: {err}"));
-            }
-            Err(_) => {
-                return adoption_failure(format!(
-                    "Timed out connecting to edge setup endpoint after {} seconds",
-                    STARTUP_ADOPTION_TIMEOUT.as_secs()
-                ));
-            }
-        };
+	let response_with_metadata =
+		match tokio::time::timeout(STARTUP_ADOPTION_TIMEOUT, client.start(())).await {
+			Ok(Ok(response)) => response,
+			Ok(Err(err)) => {
+				return merge_failure_logs(
+					format!("Failed to start edge setup stream: {err}"),
+					&log_buffer,
+					&mut log_rx,
+				);
+			}
+			Err(_) => {
+				return merge_failure_logs(
+					format!(
+					"Timed out connecting to edge setup endpoint after {} seconds",
+					STARTUP_ADOPTION_TIMEOUT.as_secs()
+					),
+					&log_buffer,
+					&mut log_rx,
+				);
+			}
+		};
 
     let edge_version = response_with_metadata
         .metadata()
@@ -279,54 +346,58 @@ async fn run_edge_adoption_attempt(
         .transpose()
         .unwrap_or(None);
 
-    if let Some(edge_version) = edge_version {
-        if edge_version < MIN_PROXY_VERSION {
-            return adoption_failure_with_logs(
-                format!(
-                    "Edge version {edge_version} is below minimum required {MIN_PROXY_VERSION}; aborting adoption"
-                ),
-                &mut log_rx,
-            );
-        }
-        debug!("Edge version {edge_version} accepted; proceeding with CSR exchange");
-    } else {
-        return adoption_failure_with_logs(
-            "Edge component did not return a version header; cannot verify compatibility",
-            &mut log_rx,
-        );
-    }
+	if let Some(edge_version) = edge_version {
+		if edge_version < MIN_PROXY_VERSION {
+			return merge_failure_logs(
+				format!(
+					"Edge version {edge_version} is below minimum required {MIN_PROXY_VERSION}; aborting adoption"
+				),
+				&log_buffer,
+				&mut log_rx,
+			);
+		}
+		debug!("Edge version {edge_version} accepted; proceeding with CSR exchange");
+	} else {
+		return merge_failure_logs(
+			"Edge component did not return a version header; cannot verify compatibility",
+			&log_buffer,
+			&mut log_rx,
+		);
+	}
 
-    let mut response = response_with_metadata.into_inner();
-    let log_reader_task = tokio::spawn(async move {
-        loop {
-            match response.message().await {
-                Ok(Some(entry)) => {
-                    let formatted = format_component_log(
-                        &entry.timestamp,
-                        &entry.level,
-                        &entry.target,
-                        &entry.message,
-                    );
-                    if log_tx.send(formatted).is_err() {
-                        break;
-                    }
-                }
-                Ok(None) => break,
-                Err(err) => {
-                    let _ = log_tx.send(format!("Error reading log: {err}"));
-                    break;
-                }
-            }
-        }
-    });
-    let _log_task_guard = TaskGuard(log_reader_task);
+	let mut response = response_with_metadata.into_inner();
+	let spawn_log_buffer = Arc::clone(&log_buffer);
+	let log_reader_task = tokio::spawn(scope_setup_logs(spawn_log_buffer, async move {
+		loop {
+			match response.message().await {
+				Ok(Some(entry)) => {
+					let formatted = format_component_log(
+						&entry.timestamp,
+						&entry.level,
+						&entry.target,
+						&entry.message,
+					);
+					if log_tx.send(formatted).is_err() {
+						break;
+					}
+				}
+				Ok(None) => break,
+				Err(err) => {
+					let _ = log_tx.send(format!("Error reading log: {err}"));
+					break;
+				}
+			}
+		}
+	}));
+	let _log_task_guard = TaskGuard(log_reader_task);
 
-    let Some(hostname) = url.host_str() else {
-        return adoption_failure_with_logs(
-            format!("Failed to extract hostname from edge/proxy URL: {url}"),
-            &mut log_rx,
-        );
-    };
+	let Some(hostname) = url.host_str() else {
+		return merge_failure_logs(
+			format!("Failed to extract hostname from edge/proxy URL: {url}"),
+			&log_buffer,
+			&mut log_rx,
+		);
+	};
 
     debug!("Requesting CSR from proxy hostname={hostname}");
     let csr_response = match client
@@ -334,67 +405,76 @@ async fn run_edge_adoption_attempt(
             cert_hostname: hostname.to_string(),
         })
         .await
-    {
-        Ok(response) => response.into_inner(),
-        Err(err) => {
-            return adoption_failure_with_logs(
-                format!("Failed to get CSR from proxy: {err}"),
-                &mut log_rx,
-            );
-        }
-    };
+	{
+		Ok(response) => response.into_inner(),
+		Err(err) => {
+			return merge_failure_logs(
+				format!("Failed to get CSR from proxy: {err}"),
+				&log_buffer,
+				&mut log_rx,
+			);
+		}
+	};
     debug!("CSR received from proxy hostname={hostname}");
 
-    let csr = match Csr::from_der(&csr_response.der_data) {
-        Ok(csr) => csr,
-        Err(err) => {
-            return adoption_failure_with_logs(
-                format!("Failed to parse CSR from proxy: {err}"),
-                &mut log_rx,
-            );
-        }
-    };
+	let csr = match Csr::from_der(&csr_response.der_data) {
+		Ok(csr) => csr,
+		Err(err) => {
+			return merge_failure_logs(
+				format!("Failed to parse CSR from proxy: {err}"),
+				&log_buffer,
+				&mut log_rx,
+			);
+		}
+	};
 
-    let ca = match CertificateAuthority::from_cert_der_key_pair(&ca_cert_der, &ca_key_der) {
-        Ok(ca) => ca,
-        Err(err) => {
-            return adoption_failure(format!("Failed to build certificate authority: {err}"));
-        }
-    };
+	let ca = match CertificateAuthority::from_cert_der_key_pair(&ca_cert_der, &ca_key_der) {
+		Ok(ca) => ca,
+		Err(err) => {
+			return merge_failure_logs(
+				format!("Failed to build certificate authority: {err}"),
+				&log_buffer,
+				&mut log_rx,
+			);
+		}
+	};
 
-    let cert = match ca.sign_csr(&csr) {
-        Ok(cert) => cert,
-        Err(err) => {
-            return adoption_failure_with_logs(
-                format!("Failed to sign CSR for proxy: {err}"),
-                &mut log_rx,
-            );
-        }
-    };
+	let cert = match ca.sign_csr(&csr) {
+		Ok(cert) => cert,
+		Err(err) => {
+			return merge_failure_logs(
+				format!("Failed to sign CSR for proxy: {err}"),
+				&log_buffer,
+				&mut log_rx,
+			);
+		}
+	};
     debug!("CSR signed for proxy hostname={hostname}; sending certificate");
 
     if let Err(err) = client
         .send_cert(ProxyDerPayload {
             der_data: cert.der().to_vec(),
         })
-        .await
-    {
-        return adoption_failure_with_logs(
-            format!("Failed to send certificate to proxy: {err}"),
-            &mut log_rx,
-        );
-    }
+		.await
+	{
+		return merge_failure_logs(
+			format!("Failed to send certificate to proxy: {err}"),
+			&log_buffer,
+			&mut log_rx,
+		);
+	}
     debug!("Certificate delivered to proxy hostname={hostname}");
 
-    let cert_info = match CertificateInfo::from_der(cert.der()) {
-        Ok(info) => info,
-        Err(err) => {
-            return adoption_failure_with_logs(
-                format!("Failed to parse certificate info from proxy cert: {err}"),
-                &mut log_rx,
-            );
-        }
-    };
+	let cert_info = match CertificateInfo::from_der(cert.der()) {
+		Ok(info) => info,
+		Err(err) => {
+			return merge_failure_logs(
+				format!("Failed to parse certificate info from proxy cert: {err}"),
+				&log_buffer,
+				&mut log_rx,
+			);
+		}
+	};
     debug!(
         "Edge adoption handshake complete hostname={hostname} cert_serial={} expires={}",
         cert_info.serial, cert_info.not_after
@@ -409,39 +489,69 @@ async fn run_edge_adoption_attempt(
 }
 
 async fn run_gateway_adoption_attempt(
-    host: &str,
-    port: u16,
+	host: &str,
+	port: u16,
 ) -> (bool, Vec<String>, Option<CertificateInfo>) {
-    debug!("Starting gateway adoption attempt host={host} port={port}");
-    let (log_tx, mut log_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+	let log_buffer = Arc::new(Mutex::new(VecDeque::new()));
+	scope_setup_logs(Arc::clone(&log_buffer), async move {
+		run_gateway_adoption_attempt_scoped(host, port, log_buffer).await
+	})
+	.await
+}
 
-    let settings = Settings::get_current_settings();
-    let Some(ca_cert_der) = settings.ca_cert_der else {
-        return adoption_failure("CA certificate not found in settings");
-    };
-    let Some(ca_key_der) = settings.ca_key_der else {
-        return adoption_failure(
-            "CA private key not found in settings. Uploading CA cert without key cannot auto-adopt.",
-        );
-    };
+async fn run_gateway_adoption_attempt_scoped(
+	host: &str,
+	port: u16,
+	log_buffer: SetupLogBuffer,
+) -> (bool, Vec<String>, Option<CertificateInfo>) {
+	debug!("Starting gateway adoption attempt host={host} port={port}");
+	let (log_tx, mut log_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
 
-    let endpoint_str = format!("http://{host}:{port}");
-    let url = match Url::parse(&endpoint_str) {
-        Ok(url) => url,
-        Err(err) => return adoption_failure(format!("Invalid gateway endpoint URL: {err}")),
-    };
+	let settings = Settings::get_current_settings();
+	let Some(ca_cert_der) = settings.ca_cert_der else {
+		return merge_failure_logs("CA certificate not found in settings", &log_buffer, &mut log_rx);
+	};
+	let Some(ca_key_der) = settings.ca_key_der else {
+		return merge_failure_logs(
+			"CA private key not found in settings. Uploading CA cert without key cannot auto-adopt.",
+			&log_buffer,
+			&mut log_rx,
+		);
+	};
 
-    let cert_pem = match der_to_pem(&ca_cert_der, PemLabel::Certificate) {
-        Ok(pem) => pem,
-        Err(err) => {
-            return adoption_failure(format!("Failed to convert CA certificate to PEM: {err}"));
-        }
-    };
+	let endpoint_str = format!("http://{host}:{port}");
+	let url = match Url::parse(&endpoint_str) {
+		Ok(url) => url,
+		Err(err) => {
+			return merge_failure_logs(
+				format!("Invalid gateway endpoint URL: {err}"),
+				&log_buffer,
+				&mut log_rx,
+			)
+		}
+	};
 
-    let base_endpoint = match Endpoint::from_shared(endpoint_str.clone()) {
-        Ok(endpoint) => endpoint,
-        Err(err) => return adoption_failure(format!("Failed to build gateway endpoint: {err}")),
-    };
+	let cert_pem = match der_to_pem(&ca_cert_der, PemLabel::Certificate) {
+		Ok(pem) => pem,
+		Err(err) => {
+			return merge_failure_logs(
+				format!("Failed to convert CA certificate to PEM: {err}"),
+				&log_buffer,
+				&mut log_rx,
+			);
+		}
+	};
+
+	let base_endpoint = match Endpoint::from_shared(endpoint_str.clone()) {
+		Ok(endpoint) => endpoint,
+		Err(err) => {
+			return merge_failure_logs(
+				format!("Failed to build gateway endpoint: {err}"),
+				&log_buffer,
+				&mut log_rx,
+			)
+		}
+	};
 
     let base_endpoint = base_endpoint
         .http2_keep_alive_interval(KEEPALIVE_INTERVAL_SECONDS)
@@ -449,31 +559,45 @@ async fn run_gateway_adoption_attempt(
         .keep_alive_while_idle(true);
 
     let tls = ClientTlsConfig::new().ca_certificate(Certificate::from_pem(cert_pem));
-    let endpoint = match base_endpoint.tls_config(tls) {
-        Ok(endpoint) => endpoint,
-        Err(err) => {
-            return adoption_failure(format!(
-                "Failed to configure TLS for gateway endpoint: {err}"
-            ));
-        }
-    };
+	let endpoint = match base_endpoint.tls_config(tls) {
+		Ok(endpoint) => endpoint,
+		Err(err) => {
+			return merge_failure_logs(
+				format!("Failed to configure TLS for gateway endpoint: {err}"),
+				&log_buffer,
+				&mut log_rx,
+			);
+		}
+	};
 
-    let core_version = match Version::parse(VERSION) {
-        Ok(version) => version,
-        Err(err) => return adoption_failure(format!("Failed to parse core version: {err}")),
-    };
+	let core_version = match Version::parse(VERSION) {
+		Ok(version) => version,
+		Err(err) => {
+			return merge_failure_logs(
+				format!("Failed to parse core version: {err}"),
+				&log_buffer,
+				&mut log_rx,
+			)
+		}
+	};
 
     let token = match Claims::new(
         ClaimsType::Gateway,
         url.to_string(),
         TOKEN_CLIENT_ID.to_string(),
         u32::MAX.into(),
-    )
-    .to_jwt()
-    {
-        Ok(token) => token,
-        Err(err) => return adoption_failure(format!("Failed to generate setup token: {err}")),
-    };
+	)
+	.to_jwt()
+	{
+		Ok(token) => token,
+		Err(err) => {
+			return merge_failure_logs(
+				format!("Failed to generate setup token: {err}"),
+				&log_buffer,
+				&mut log_rx,
+			)
+		}
+	};
 
     let version_interceptor = ClientVersionInterceptor::new(core_version.clone());
     let auth_interceptor = AuthInterceptor::new(token);
@@ -486,19 +610,27 @@ async fn run_gateway_adoption_attempt(
         },
     );
 
-    let response_with_metadata =
-        match tokio::time::timeout(STARTUP_ADOPTION_TIMEOUT, client.start(())).await {
-            Ok(Ok(response)) => response,
-            Ok(Err(err)) => {
-                return adoption_failure(format!("Failed to start gateway setup stream: {err}"));
-            }
-            Err(_) => {
-                return adoption_failure(format!(
-                    "Timed out connecting to gateway setup endpoint after {} seconds",
-                    STARTUP_ADOPTION_TIMEOUT.as_secs()
-                ));
-            }
-        };
+	let response_with_metadata =
+		match tokio::time::timeout(STARTUP_ADOPTION_TIMEOUT, client.start(())).await {
+			Ok(Ok(response)) => response,
+			Ok(Err(err)) => {
+				return merge_failure_logs(
+					format!("Failed to start gateway setup stream: {err}"),
+					&log_buffer,
+					&mut log_rx,
+				);
+			}
+			Err(_) => {
+				return merge_failure_logs(
+					format!(
+					"Timed out connecting to gateway setup endpoint after {} seconds",
+					STARTUP_ADOPTION_TIMEOUT.as_secs()
+					),
+					&log_buffer,
+					&mut log_rx,
+				);
+			}
+		};
 
     let gateway_version = response_with_metadata
         .metadata()
@@ -508,54 +640,58 @@ async fn run_gateway_adoption_attempt(
         .transpose()
         .unwrap_or(None);
 
-    if let Some(gateway_version) = gateway_version {
-        if gateway_version < MIN_GATEWAY_VERSION {
-            return adoption_failure_with_logs(
-                format!(
-                    "Gateway version {gateway_version} is below minimum required {MIN_GATEWAY_VERSION}; aborting adoption"
-                ),
-                &mut log_rx,
-            );
-        }
-        debug!("Gateway version {gateway_version} accepted; proceeding with CSR exchange");
-    } else {
-        return adoption_failure_with_logs(
-            "Gateway component did not return a version header; cannot verify compatibility",
-            &mut log_rx,
-        );
-    }
+	if let Some(gateway_version) = gateway_version {
+		if gateway_version < MIN_GATEWAY_VERSION {
+			return merge_failure_logs(
+				format!(
+					"Gateway version {gateway_version} is below minimum required {MIN_GATEWAY_VERSION}; aborting adoption"
+				),
+				&log_buffer,
+				&mut log_rx,
+			);
+		}
+		debug!("Gateway version {gateway_version} accepted; proceeding with CSR exchange");
+	} else {
+		return merge_failure_logs(
+			"Gateway component did not return a version header; cannot verify compatibility",
+			&log_buffer,
+			&mut log_rx,
+		);
+	}
 
-    let mut response = response_with_metadata.into_inner();
-    let log_reader_task = tokio::spawn(async move {
-        loop {
-            match response.message().await {
-                Ok(Some(entry)) => {
-                    let formatted = format_component_log(
-                        &entry.timestamp,
-                        &entry.level,
-                        &entry.target,
-                        &entry.message,
-                    );
-                    if log_tx.send(formatted).is_err() {
-                        break;
-                    }
-                }
-                Ok(None) => break,
-                Err(err) => {
-                    let _ = log_tx.send(format!("Error reading log: {err}"));
-                    break;
-                }
-            }
-        }
-    });
-    let _log_task_guard = TaskGuard(log_reader_task);
+	let mut response = response_with_metadata.into_inner();
+	let spawn_log_buffer = Arc::clone(&log_buffer);
+	let log_reader_task = tokio::spawn(scope_setup_logs(spawn_log_buffer, async move {
+		loop {
+			match response.message().await {
+				Ok(Some(entry)) => {
+					let formatted = format_component_log(
+						&entry.timestamp,
+						&entry.level,
+						&entry.target,
+						&entry.message,
+					);
+					if log_tx.send(formatted).is_err() {
+						break;
+					}
+				}
+				Ok(None) => break,
+				Err(err) => {
+					let _ = log_tx.send(format!("Error reading log: {err}"));
+					break;
+				}
+			}
+		}
+	}));
+	let _log_task_guard = TaskGuard(log_reader_task);
 
-    let Some(hostname) = url.host_str() else {
-        return adoption_failure_with_logs(
-            format!("Failed to extract hostname from gateway URL: {url}"),
-            &mut log_rx,
-        );
-    };
+	let Some(hostname) = url.host_str() else {
+		return merge_failure_logs(
+			format!("Failed to extract hostname from gateway URL: {url}"),
+			&log_buffer,
+			&mut log_rx,
+		);
+	};
 
     debug!("Requesting CSR from gateway hostname={hostname}");
     let csr_response = match client
@@ -563,67 +699,76 @@ async fn run_gateway_adoption_attempt(
             cert_hostname: hostname.to_string(),
         })
         .await
-    {
-        Ok(response) => response.into_inner(),
-        Err(err) => {
-            return adoption_failure_with_logs(
-                format!("Failed to get CSR from gateway: {err}"),
-                &mut log_rx,
-            );
-        }
-    };
+	{
+		Ok(response) => response.into_inner(),
+		Err(err) => {
+			return merge_failure_logs(
+				format!("Failed to get CSR from gateway: {err}"),
+				&log_buffer,
+				&mut log_rx,
+			);
+		}
+	};
     debug!("CSR received from gateway hostname={hostname}");
 
-    let csr = match Csr::from_der(&csr_response.der_data) {
-        Ok(csr) => csr,
-        Err(err) => {
-            return adoption_failure_with_logs(
-                format!("Failed to parse CSR from gateway: {err}"),
-                &mut log_rx,
-            );
-        }
-    };
+	let csr = match Csr::from_der(&csr_response.der_data) {
+		Ok(csr) => csr,
+		Err(err) => {
+			return merge_failure_logs(
+				format!("Failed to parse CSR from gateway: {err}"),
+				&log_buffer,
+				&mut log_rx,
+			);
+		}
+	};
 
-    let ca = match CertificateAuthority::from_cert_der_key_pair(&ca_cert_der, &ca_key_der) {
-        Ok(ca) => ca,
-        Err(err) => {
-            return adoption_failure(format!("Failed to build certificate authority: {err}"));
-        }
-    };
+	let ca = match CertificateAuthority::from_cert_der_key_pair(&ca_cert_der, &ca_key_der) {
+		Ok(ca) => ca,
+		Err(err) => {
+			return merge_failure_logs(
+				format!("Failed to build certificate authority: {err}"),
+				&log_buffer,
+				&mut log_rx,
+			);
+		}
+	};
 
-    let cert = match ca.sign_csr(&csr) {
-        Ok(cert) => cert,
-        Err(err) => {
-            return adoption_failure_with_logs(
-                format!("Failed to sign CSR for gateway: {err}"),
-                &mut log_rx,
-            );
-        }
-    };
+	let cert = match ca.sign_csr(&csr) {
+		Ok(cert) => cert,
+		Err(err) => {
+			return merge_failure_logs(
+				format!("Failed to sign CSR for gateway: {err}"),
+				&log_buffer,
+				&mut log_rx,
+			);
+		}
+	};
     debug!("CSR signed for gateway hostname={hostname}; sending certificate");
 
     if let Err(err) = client
         .send_cert(GatewayDerPayload {
             der_data: cert.der().to_vec(),
         })
-        .await
-    {
-        return adoption_failure_with_logs(
-            format!("Failed to send certificate to gateway: {err}"),
-            &mut log_rx,
-        );
-    }
+		.await
+	{
+		return merge_failure_logs(
+			format!("Failed to send certificate to gateway: {err}"),
+			&log_buffer,
+			&mut log_rx,
+		);
+	}
     debug!("Certificate delivered to gateway hostname={hostname}");
 
-    let cert_info = match CertificateInfo::from_der(cert.der()) {
-        Ok(info) => info,
-        Err(err) => {
-            return adoption_failure_with_logs(
-                format!("Failed to parse certificate info from gateway cert: {err}"),
-                &mut log_rx,
-            );
-        }
-    };
+	let cert_info = match CertificateInfo::from_der(cert.der()) {
+		Ok(info) => info,
+		Err(err) => {
+			return merge_failure_logs(
+				format!("Failed to parse certificate info from gateway cert: {err}"),
+				&log_buffer,
+				&mut log_rx,
+			);
+		}
+	};
     debug!(
         "Gateway adoption handshake complete hostname={hostname} cert_serial={} expires={}",
         cert_info.serial, cert_info.not_after

--- a/crates/defguard_setup/src/auto_adoption.rs
+++ b/crates/defguard_setup/src/auto_adoption.rs
@@ -198,6 +198,10 @@ fn merge_failure_logs(
     (false, logs, None)
 }
 
+fn logs_to_persist(success: bool, logs: Vec<String>) -> Vec<String> {
+    if success { Vec::new() } else { logs }
+}
+
 async fn run_edge_adoption_attempt(
     _pool: &PgPool,
     host: &str,
@@ -859,7 +863,7 @@ async fn process_startup_auto_adoption(
         component,
         AutoAdoptionComponentResult {
             success: status,
-            logs: logs.clone(),
+            logs: logs_to_persist(status, logs),
             updated_at: chrono::Utc::now().naive_utc(),
         },
     );

--- a/crates/defguard_setup/src/auto_adoption.rs
+++ b/crates/defguard_setup/src/auto_adoption.rs
@@ -1,7 +1,7 @@
 use std::{
-	collections::VecDeque,
-	sync::{Arc, Mutex},
-	time::Duration,
+    collections::VecDeque,
+    sync::{Arc, Mutex},
+    time::Duration,
 };
 
 use anyhow::Context;
@@ -21,8 +21,10 @@ use defguard_common::{
         wireguard::{LocationMfaMode, ServiceLocationMode},
     },
 };
-use defguard_core::version::{MIN_GATEWAY_VERSION, MIN_PROXY_VERSION};
-use defguard_core::setup_logs::scope_setup_logs;
+use defguard_core::{
+    setup_logs::scope_setup_logs,
+    version::{MIN_GATEWAY_VERSION, MIN_PROXY_VERSION},
+};
 use defguard_proto::{
     gateway::{
         CertificateInfo as GatewayCertificateInfo, DerPayload as GatewayDerPayload,
@@ -167,150 +169,154 @@ fn format_component_log(timestamp: &str, level: &str, target: &str, message: &st
 }
 
 fn collect_stream_logs(log_rx: &mut UnboundedReceiver<String>) -> Vec<String> {
-	let mut logs = Vec::new();
-	while let Ok(log) = log_rx.try_recv() {
-		logs.push(log);
-	}
-	logs
+    let mut logs = Vec::new();
+    while let Ok(log) = log_rx.try_recv() {
+        logs.push(log);
+    }
+    logs
 }
 
 fn collect_core_logs(log_buffer: &SetupLogBuffer) -> Vec<String> {
-	let mut guard = log_buffer
-		.lock()
-		.unwrap_or_else(std::sync::PoisonError::into_inner);
-	std::mem::take(&mut *guard).into_iter().collect()
+    let mut guard = log_buffer
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    std::mem::take(&mut *guard).into_iter().collect()
 }
 
 fn merge_failure_logs(
-	message: impl Into<String>,
-	log_buffer: &SetupLogBuffer,
-	log_rx: &mut UnboundedReceiver<String>,
+    message: impl Into<String>,
+    log_buffer: &SetupLogBuffer,
+    log_rx: &mut UnboundedReceiver<String>,
 ) -> (bool, Vec<String>, Option<CertificateInfo>) {
-	let msg = message.into();
-	error!("{msg}");
-	let mut logs = collect_core_logs(log_buffer);
-	logs.extend(collect_stream_logs(log_rx));
-	if !logs.iter().any(|line| line.contains(&msg)) {
-		logs.push(msg);
-	}
-	(false, logs, None)
+    let msg = message.into();
+    error!("{msg}");
+    let mut logs = collect_core_logs(log_buffer);
+    logs.extend(collect_stream_logs(log_rx));
+    if !logs.iter().any(|line| line.contains(&msg)) {
+        logs.push(msg);
+    }
+    (false, logs, None)
 }
 
 async fn run_edge_adoption_attempt(
-	_pool: &PgPool,
-	host: &str,
-	port: u16,
+    _pool: &PgPool,
+    host: &str,
+    port: u16,
 ) -> (bool, Vec<String>, Option<CertificateInfo>) {
-	let log_buffer = Arc::new(Mutex::new(VecDeque::new()));
-	scope_setup_logs(Arc::clone(&log_buffer), async move {
-		run_edge_adoption_attempt_scoped(host, port, log_buffer).await
-	})
-	.await
+    let log_buffer = Arc::new(Mutex::new(VecDeque::new()));
+    scope_setup_logs(Arc::clone(&log_buffer), async move {
+        run_edge_adoption_attempt_scoped(host, port, log_buffer).await
+    })
+    .await
 }
 
 async fn run_edge_adoption_attempt_scoped(
-	host: &str,
-	port: u16,
-	log_buffer: SetupLogBuffer,
+    host: &str,
+    port: u16,
+    log_buffer: SetupLogBuffer,
 ) -> (bool, Vec<String>, Option<CertificateInfo>) {
-	debug!("Starting edge adoption attempt host={host} port={port}");
-	let (log_tx, mut log_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+    debug!("Starting edge adoption attempt host={host} port={port}");
+    let (log_tx, mut log_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
 
-	let settings = Settings::get_current_settings();
-	let Some(ca_cert_der) = settings.ca_cert_der else {
-		return merge_failure_logs("CA certificate not found in settings", &log_buffer, &mut log_rx);
-	};
-	let Some(ca_key_der) = settings.ca_key_der else {
-		return merge_failure_logs(
-			"CA private key not found in settings. Uploading CA cert without key cannot auto-adopt.",
-			&log_buffer,
-			&mut log_rx,
-		);
-	};
-	let endpoint_str = format!("http://{host}:{port}");
-	let url = match Url::parse(&endpoint_str) {
-		Ok(url) => url,
-		Err(err) => {
-			return merge_failure_logs(
-				format!("Invalid edge endpoint URL: {err}"),
-				&log_buffer,
-				&mut log_rx,
-			)
-		}
-	};
-	debug!("Successfully validated Edge address: {endpoint_str}");
+    let settings = Settings::get_current_settings();
+    let Some(ca_cert_der) = settings.ca_cert_der else {
+        return merge_failure_logs(
+            "CA certificate not found in settings",
+            &log_buffer,
+            &mut log_rx,
+        );
+    };
+    let Some(ca_key_der) = settings.ca_key_der else {
+        return merge_failure_logs(
+            "CA private key not found in settings. Uploading CA cert without key cannot auto-adopt.",
+            &log_buffer,
+            &mut log_rx,
+        );
+    };
+    let endpoint_str = format!("http://{host}:{port}");
+    let url = match Url::parse(&endpoint_str) {
+        Ok(url) => url,
+        Err(err) => {
+            return merge_failure_logs(
+                format!("Invalid edge endpoint URL: {err}"),
+                &log_buffer,
+                &mut log_rx,
+            );
+        }
+    };
+    debug!("Successfully validated Edge address: {endpoint_str}");
 
-	let cert_pem = match der_to_pem(&ca_cert_der, PemLabel::Certificate) {
-		Ok(pem) => pem,
-		Err(err) => {
-			return merge_failure_logs(
-				format!("Failed to convert CA certificate to PEM: {err}"),
-				&log_buffer,
-				&mut log_rx,
-			);
-		}
-	};
-	debug!("Loaded CA certificate for secure Edge communication");
+    let cert_pem = match der_to_pem(&ca_cert_der, PemLabel::Certificate) {
+        Ok(pem) => pem,
+        Err(err) => {
+            return merge_failure_logs(
+                format!("Failed to convert CA certificate to PEM: {err}"),
+                &log_buffer,
+                &mut log_rx,
+            );
+        }
+    };
+    debug!("Loaded CA certificate for secure Edge communication");
 
-	let base_endpoint = match Endpoint::from_shared(endpoint_str.clone()) {
-		Ok(endpoint) => endpoint,
-		Err(err) => {
-			return merge_failure_logs(
-				format!("Failed to build edge endpoint: {err}"),
-				&log_buffer,
-				&mut log_rx,
-			)
-		}
-	};
+    let base_endpoint = match Endpoint::from_shared(endpoint_str.clone()) {
+        Ok(endpoint) => endpoint,
+        Err(err) => {
+            return merge_failure_logs(
+                format!("Failed to build edge endpoint: {err}"),
+                &log_buffer,
+                &mut log_rx,
+            );
+        }
+    };
 
     let base_endpoint = base_endpoint
         .http2_keep_alive_interval(KEEPALIVE_INTERVAL_SECONDS)
         .tcp_keepalive(Some(KEEPALIVE_INTERVAL_SECONDS))
         .keep_alive_while_idle(true);
 
-	let tls = ClientTlsConfig::new().ca_certificate(Certificate::from_pem(cert_pem));
-	let endpoint = match base_endpoint.tls_config(tls) {
-		Ok(endpoint) => endpoint,
-		Err(err) => {
-			return merge_failure_logs(
-				format!("Failed to configure TLS for edge endpoint: {err}"),
-				&log_buffer,
-				&mut log_rx,
-			);
-		}
-	};
-	debug!("Prepared secure connection endpoint for Edge at {host}:{port}");
+    let tls = ClientTlsConfig::new().ca_certificate(Certificate::from_pem(cert_pem));
+    let endpoint = match base_endpoint.tls_config(tls) {
+        Ok(endpoint) => endpoint,
+        Err(err) => {
+            return merge_failure_logs(
+                format!("Failed to configure TLS for edge endpoint: {err}"),
+                &log_buffer,
+                &mut log_rx,
+            );
+        }
+    };
+    debug!("Prepared secure connection endpoint for Edge at {host}:{port}");
 
-	let core_version = match Version::parse(VERSION) {
-		Ok(version) => version,
-		Err(err) => {
-			return merge_failure_logs(
-				format!("Failed to parse core version: {err}"),
-				&log_buffer,
-				&mut log_rx,
-			)
-		}
-	};
-	debug!("Parsed Core version {core_version} for Edge auto-adoption");
+    let core_version = match Version::parse(VERSION) {
+        Ok(version) => version,
+        Err(err) => {
+            return merge_failure_logs(
+                format!("Failed to parse core version: {err}"),
+                &log_buffer,
+                &mut log_rx,
+            );
+        }
+    };
+    debug!("Parsed Core version {core_version} for Edge auto-adoption");
 
     let token = match Claims::new(
         ClaimsType::Gateway,
         url.to_string(),
         TOKEN_CLIENT_ID.to_string(),
         u32::MAX.into(),
-	)
-	.to_jwt()
-	{
-		Ok(token) => token,
-		Err(err) => {
-			return merge_failure_logs(
-				format!("Failed to generate setup token: {err}"),
-				&log_buffer,
-				&mut log_rx,
-			)
-		}
-	};
-	debug!("Generated secure setup token for Edge authentication");
+    )
+    .to_jwt()
+    {
+        Ok(token) => token,
+        Err(err) => {
+            return merge_failure_logs(
+                format!("Failed to generate setup token: {err}"),
+                &log_buffer,
+                &mut log_rx,
+            );
+        }
+    };
+    debug!("Generated secure setup token for Edge authentication");
 
     let version_interceptor = ClientVersionInterceptor::new(core_version.clone());
     let auth_interceptor = AuthInterceptor::new(token);
@@ -321,28 +327,28 @@ async fn run_edge_adoption_attempt_scoped(
             auth_interceptor.clone().call(req)
         });
 
-	let response_with_metadata =
-		match tokio::time::timeout(STARTUP_ADOPTION_TIMEOUT, client.start(())).await {
-			Ok(Ok(response)) => response,
-			Ok(Err(err)) => {
-				return merge_failure_logs(
-					format!("Failed to start edge setup stream: {err}"),
-					&log_buffer,
-					&mut log_rx,
-				);
-			}
-			Err(_) => {
-				return merge_failure_logs(
-					format!(
-					"Timed out connecting to edge setup endpoint after {} seconds",
-					STARTUP_ADOPTION_TIMEOUT.as_secs()
-					),
-					&log_buffer,
-					&mut log_rx,
-				);
-			}
-		};
-	debug!("Successfully connected to Edge setup stream");
+    let response_with_metadata =
+        match tokio::time::timeout(STARTUP_ADOPTION_TIMEOUT, client.start(())).await {
+            Ok(Ok(response)) => response,
+            Ok(Err(err)) => {
+                return merge_failure_logs(
+                    format!("Failed to start edge setup stream: {err}"),
+                    &log_buffer,
+                    &mut log_rx,
+                );
+            }
+            Err(_) => {
+                return merge_failure_logs(
+                    format!(
+                        "Timed out connecting to edge setup endpoint after {} seconds",
+                        STARTUP_ADOPTION_TIMEOUT.as_secs()
+                    ),
+                    &log_buffer,
+                    &mut log_rx,
+                );
+            }
+        };
+    debug!("Successfully connected to Edge setup stream");
 
     let edge_version = response_with_metadata
         .metadata()
@@ -352,58 +358,58 @@ async fn run_edge_adoption_attempt_scoped(
         .transpose()
         .unwrap_or(None);
 
-	if let Some(edge_version) = edge_version {
-		if edge_version < MIN_PROXY_VERSION {
-			return merge_failure_logs(
-				format!(
-					"Edge version {edge_version} is below minimum required {MIN_PROXY_VERSION}; aborting adoption"
-				),
-				&log_buffer,
-				&mut log_rx,
-			);
-		}
-		debug!("Edge version {edge_version} accepted; proceeding with CSR exchange");
-	} else {
-		return merge_failure_logs(
-			"Edge component did not return a version header; cannot verify compatibility",
-			&log_buffer,
-			&mut log_rx,
-		);
-	}
+    if let Some(edge_version) = edge_version {
+        if edge_version < MIN_PROXY_VERSION {
+            return merge_failure_logs(
+                format!(
+                    "Edge version {edge_version} is below minimum required {MIN_PROXY_VERSION}; aborting adoption"
+                ),
+                &log_buffer,
+                &mut log_rx,
+            );
+        }
+        debug!("Edge version {edge_version} accepted; proceeding with CSR exchange");
+    } else {
+        return merge_failure_logs(
+            "Edge component did not return a version header; cannot verify compatibility",
+            &log_buffer,
+            &mut log_rx,
+        );
+    }
 
-	let mut response = response_with_metadata.into_inner();
-	let spawn_log_buffer = Arc::clone(&log_buffer);
-	let log_reader_task = tokio::spawn(scope_setup_logs(spawn_log_buffer, async move {
-		loop {
-			match response.message().await {
-				Ok(Some(entry)) => {
-					let formatted = format_component_log(
-						&entry.timestamp,
-						&entry.level,
-						&entry.target,
-						&entry.message,
-					);
-					if log_tx.send(formatted).is_err() {
-						break;
-					}
-				}
-				Ok(None) => break,
-				Err(err) => {
-					let _ = log_tx.send(format!("Error reading log: {err}"));
-					break;
-				}
-			}
-		}
-	}));
-	let _log_task_guard = TaskGuard(log_reader_task);
+    let mut response = response_with_metadata.into_inner();
+    let spawn_log_buffer = Arc::clone(&log_buffer);
+    let log_reader_task = tokio::spawn(scope_setup_logs(spawn_log_buffer, async move {
+        loop {
+            match response.message().await {
+                Ok(Some(entry)) => {
+                    let formatted = format_component_log(
+                        &entry.timestamp,
+                        &entry.level,
+                        &entry.target,
+                        &entry.message,
+                    );
+                    if log_tx.send(formatted).is_err() {
+                        break;
+                    }
+                }
+                Ok(None) => break,
+                Err(err) => {
+                    let _ = log_tx.send(format!("Error reading log: {err}"));
+                    break;
+                }
+            }
+        }
+    }));
+    let _log_task_guard = TaskGuard(log_reader_task);
 
-	let Some(hostname) = url.host_str() else {
-		return merge_failure_logs(
-			format!("Failed to extract hostname from edge/proxy URL: {url}"),
-			&log_buffer,
-			&mut log_rx,
-		);
-	};
+    let Some(hostname) = url.host_str() else {
+        return merge_failure_logs(
+            format!("Failed to extract hostname from edge/proxy URL: {url}"),
+            &log_buffer,
+            &mut log_rx,
+        );
+    };
 
     debug!("Requesting CSR from proxy hostname={hostname}");
     let csr_response = match client
@@ -411,76 +417,76 @@ async fn run_edge_adoption_attempt_scoped(
             cert_hostname: hostname.to_string(),
         })
         .await
-	{
-		Ok(response) => response.into_inner(),
-		Err(err) => {
-			return merge_failure_logs(
-				format!("Failed to get CSR from proxy: {err}"),
-				&log_buffer,
-				&mut log_rx,
-			);
-		}
-	};
+    {
+        Ok(response) => response.into_inner(),
+        Err(err) => {
+            return merge_failure_logs(
+                format!("Failed to get CSR from proxy: {err}"),
+                &log_buffer,
+                &mut log_rx,
+            );
+        }
+    };
     debug!("CSR received from proxy hostname={hostname}");
 
-	let csr = match Csr::from_der(&csr_response.der_data) {
-		Ok(csr) => csr,
-		Err(err) => {
-			return merge_failure_logs(
-				format!("Failed to parse CSR from proxy: {err}"),
-				&log_buffer,
-				&mut log_rx,
-			);
-		}
-	};
+    let csr = match Csr::from_der(&csr_response.der_data) {
+        Ok(csr) => csr,
+        Err(err) => {
+            return merge_failure_logs(
+                format!("Failed to parse CSR from proxy: {err}"),
+                &log_buffer,
+                &mut log_rx,
+            );
+        }
+    };
 
-	let ca = match CertificateAuthority::from_cert_der_key_pair(&ca_cert_der, &ca_key_der) {
-		Ok(ca) => ca,
-		Err(err) => {
-			return merge_failure_logs(
-				format!("Failed to build certificate authority: {err}"),
-				&log_buffer,
-				&mut log_rx,
-			);
-		}
-	};
+    let ca = match CertificateAuthority::from_cert_der_key_pair(&ca_cert_der, &ca_key_der) {
+        Ok(ca) => ca,
+        Err(err) => {
+            return merge_failure_logs(
+                format!("Failed to build certificate authority: {err}"),
+                &log_buffer,
+                &mut log_rx,
+            );
+        }
+    };
 
-	let cert = match ca.sign_csr(&csr) {
-		Ok(cert) => cert,
-		Err(err) => {
-			return merge_failure_logs(
-				format!("Failed to sign CSR for proxy: {err}"),
-				&log_buffer,
-				&mut log_rx,
-			);
-		}
-	};
+    let cert = match ca.sign_csr(&csr) {
+        Ok(cert) => cert,
+        Err(err) => {
+            return merge_failure_logs(
+                format!("Failed to sign CSR for proxy: {err}"),
+                &log_buffer,
+                &mut log_rx,
+            );
+        }
+    };
     debug!("CSR signed for proxy hostname={hostname}; sending certificate");
 
     if let Err(err) = client
         .send_cert(ProxyDerPayload {
             der_data: cert.der().to_vec(),
         })
-		.await
-	{
-		return merge_failure_logs(
-			format!("Failed to send certificate to proxy: {err}"),
-			&log_buffer,
-			&mut log_rx,
-		);
-	}
+        .await
+    {
+        return merge_failure_logs(
+            format!("Failed to send certificate to proxy: {err}"),
+            &log_buffer,
+            &mut log_rx,
+        );
+    }
     debug!("Certificate delivered to proxy hostname={hostname}");
 
-	let cert_info = match CertificateInfo::from_der(cert.der()) {
-		Ok(info) => info,
-		Err(err) => {
-			return merge_failure_logs(
-				format!("Failed to parse certificate info from proxy cert: {err}"),
-				&log_buffer,
-				&mut log_rx,
-			);
-		}
-	};
+    let cert_info = match CertificateInfo::from_der(cert.der()) {
+        Ok(info) => info,
+        Err(err) => {
+            return merge_failure_logs(
+                format!("Failed to parse certificate info from proxy cert: {err}"),
+                &log_buffer,
+                &mut log_rx,
+            );
+        }
+    };
     debug!(
         "Edge adoption handshake complete hostname={hostname} cert_serial={} expires={}",
         cert_info.serial, cert_info.not_after
@@ -495,71 +501,75 @@ async fn run_edge_adoption_attempt_scoped(
 }
 
 async fn run_gateway_adoption_attempt(
-	host: &str,
-	port: u16,
+    host: &str,
+    port: u16,
 ) -> (bool, Vec<String>, Option<CertificateInfo>) {
-	let log_buffer = Arc::new(Mutex::new(VecDeque::new()));
-	scope_setup_logs(Arc::clone(&log_buffer), async move {
-		run_gateway_adoption_attempt_scoped(host, port, log_buffer).await
-	})
-	.await
+    let log_buffer = Arc::new(Mutex::new(VecDeque::new()));
+    scope_setup_logs(Arc::clone(&log_buffer), async move {
+        run_gateway_adoption_attempt_scoped(host, port, log_buffer).await
+    })
+    .await
 }
 
 async fn run_gateway_adoption_attempt_scoped(
-	host: &str,
-	port: u16,
-	log_buffer: SetupLogBuffer,
+    host: &str,
+    port: u16,
+    log_buffer: SetupLogBuffer,
 ) -> (bool, Vec<String>, Option<CertificateInfo>) {
-	debug!("Starting gateway adoption attempt host={host} port={port}");
-	let (log_tx, mut log_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+    debug!("Starting gateway adoption attempt host={host} port={port}");
+    let (log_tx, mut log_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
 
-	let settings = Settings::get_current_settings();
-	let Some(ca_cert_der) = settings.ca_cert_der else {
-		return merge_failure_logs("CA certificate not found in settings", &log_buffer, &mut log_rx);
-	};
-	let Some(ca_key_der) = settings.ca_key_der else {
-		return merge_failure_logs(
-			"CA private key not found in settings. Uploading CA cert without key cannot auto-adopt.",
-			&log_buffer,
-			&mut log_rx,
-		);
-	};
+    let settings = Settings::get_current_settings();
+    let Some(ca_cert_der) = settings.ca_cert_der else {
+        return merge_failure_logs(
+            "CA certificate not found in settings",
+            &log_buffer,
+            &mut log_rx,
+        );
+    };
+    let Some(ca_key_der) = settings.ca_key_der else {
+        return merge_failure_logs(
+            "CA private key not found in settings. Uploading CA cert without key cannot auto-adopt.",
+            &log_buffer,
+            &mut log_rx,
+        );
+    };
 
-	let endpoint_str = format!("http://{host}:{port}");
-	let url = match Url::parse(&endpoint_str) {
-		Ok(url) => url,
-		Err(err) => {
-			return merge_failure_logs(
-				format!("Invalid gateway endpoint URL: {err}"),
-				&log_buffer,
-				&mut log_rx,
-			)
-		}
-	};
-	debug!("Successfully validated Gateway address: {endpoint_str}");
+    let endpoint_str = format!("http://{host}:{port}");
+    let url = match Url::parse(&endpoint_str) {
+        Ok(url) => url,
+        Err(err) => {
+            return merge_failure_logs(
+                format!("Invalid gateway endpoint URL: {err}"),
+                &log_buffer,
+                &mut log_rx,
+            );
+        }
+    };
+    debug!("Successfully validated Gateway address: {endpoint_str}");
 
-	let cert_pem = match der_to_pem(&ca_cert_der, PemLabel::Certificate) {
-		Ok(pem) => pem,
-		Err(err) => {
-			return merge_failure_logs(
-				format!("Failed to convert CA certificate to PEM: {err}"),
-				&log_buffer,
-				&mut log_rx,
-			);
-		}
-	};
-	debug!("Loaded CA certificate for secure Gateway communication");
+    let cert_pem = match der_to_pem(&ca_cert_der, PemLabel::Certificate) {
+        Ok(pem) => pem,
+        Err(err) => {
+            return merge_failure_logs(
+                format!("Failed to convert CA certificate to PEM: {err}"),
+                &log_buffer,
+                &mut log_rx,
+            );
+        }
+    };
+    debug!("Loaded CA certificate for secure Gateway communication");
 
-	let base_endpoint = match Endpoint::from_shared(endpoint_str.clone()) {
-		Ok(endpoint) => endpoint,
-		Err(err) => {
-			return merge_failure_logs(
-				format!("Failed to build gateway endpoint: {err}"),
-				&log_buffer,
-				&mut log_rx,
-			)
-		}
-	};
+    let base_endpoint = match Endpoint::from_shared(endpoint_str.clone()) {
+        Ok(endpoint) => endpoint,
+        Err(err) => {
+            return merge_failure_logs(
+                format!("Failed to build gateway endpoint: {err}"),
+                &log_buffer,
+                &mut log_rx,
+            );
+        }
+    };
 
     let base_endpoint = base_endpoint
         .http2_keep_alive_interval(KEEPALIVE_INTERVAL_SECONDS)
@@ -567,48 +577,48 @@ async fn run_gateway_adoption_attempt_scoped(
         .keep_alive_while_idle(true);
 
     let tls = ClientTlsConfig::new().ca_certificate(Certificate::from_pem(cert_pem));
-	let endpoint = match base_endpoint.tls_config(tls) {
-		Ok(endpoint) => endpoint,
-		Err(err) => {
-			return merge_failure_logs(
-				format!("Failed to configure TLS for gateway endpoint: {err}"),
-				&log_buffer,
-				&mut log_rx,
-			);
-		}
-	};
-	debug!("Prepared secure connection endpoint for Gateway at {host}:{port}");
+    let endpoint = match base_endpoint.tls_config(tls) {
+        Ok(endpoint) => endpoint,
+        Err(err) => {
+            return merge_failure_logs(
+                format!("Failed to configure TLS for gateway endpoint: {err}"),
+                &log_buffer,
+                &mut log_rx,
+            );
+        }
+    };
+    debug!("Prepared secure connection endpoint for Gateway at {host}:{port}");
 
-	let core_version = match Version::parse(VERSION) {
-		Ok(version) => version,
-		Err(err) => {
-			return merge_failure_logs(
-				format!("Failed to parse core version: {err}"),
-				&log_buffer,
-				&mut log_rx,
-			)
-		}
-	};
-	debug!("Parsed Core version {core_version} for Gateway auto-adoption");
+    let core_version = match Version::parse(VERSION) {
+        Ok(version) => version,
+        Err(err) => {
+            return merge_failure_logs(
+                format!("Failed to parse core version: {err}"),
+                &log_buffer,
+                &mut log_rx,
+            );
+        }
+    };
+    debug!("Parsed Core version {core_version} for Gateway auto-adoption");
 
     let token = match Claims::new(
         ClaimsType::Gateway,
         url.to_string(),
         TOKEN_CLIENT_ID.to_string(),
         u32::MAX.into(),
-	)
-	.to_jwt()
-	{
-		Ok(token) => token,
-		Err(err) => {
-			return merge_failure_logs(
-				format!("Failed to generate setup token: {err}"),
-				&log_buffer,
-				&mut log_rx,
-			)
-		}
-	};
-	debug!("Generated secure setup token for Gateway authentication");
+    )
+    .to_jwt()
+    {
+        Ok(token) => token,
+        Err(err) => {
+            return merge_failure_logs(
+                format!("Failed to generate setup token: {err}"),
+                &log_buffer,
+                &mut log_rx,
+            );
+        }
+    };
+    debug!("Generated secure setup token for Gateway authentication");
 
     let version_interceptor = ClientVersionInterceptor::new(core_version.clone());
     let auth_interceptor = AuthInterceptor::new(token);
@@ -621,28 +631,28 @@ async fn run_gateway_adoption_attempt_scoped(
         },
     );
 
-	let response_with_metadata =
-		match tokio::time::timeout(STARTUP_ADOPTION_TIMEOUT, client.start(())).await {
-			Ok(Ok(response)) => response,
-			Ok(Err(err)) => {
-				return merge_failure_logs(
-					format!("Failed to start gateway setup stream: {err}"),
-					&log_buffer,
-					&mut log_rx,
-				);
-			}
-			Err(_) => {
-				return merge_failure_logs(
-					format!(
-					"Timed out connecting to gateway setup endpoint after {} seconds",
-					STARTUP_ADOPTION_TIMEOUT.as_secs()
-					),
-					&log_buffer,
-					&mut log_rx,
-				);
-			}
-		};
-	debug!("Successfully connected to Gateway setup stream");
+    let response_with_metadata =
+        match tokio::time::timeout(STARTUP_ADOPTION_TIMEOUT, client.start(())).await {
+            Ok(Ok(response)) => response,
+            Ok(Err(err)) => {
+                return merge_failure_logs(
+                    format!("Failed to start gateway setup stream: {err}"),
+                    &log_buffer,
+                    &mut log_rx,
+                );
+            }
+            Err(_) => {
+                return merge_failure_logs(
+                    format!(
+                        "Timed out connecting to gateway setup endpoint after {} seconds",
+                        STARTUP_ADOPTION_TIMEOUT.as_secs()
+                    ),
+                    &log_buffer,
+                    &mut log_rx,
+                );
+            }
+        };
+    debug!("Successfully connected to Gateway setup stream");
 
     let gateway_version = response_with_metadata
         .metadata()
@@ -652,58 +662,58 @@ async fn run_gateway_adoption_attempt_scoped(
         .transpose()
         .unwrap_or(None);
 
-	if let Some(gateway_version) = gateway_version {
-		if gateway_version < MIN_GATEWAY_VERSION {
-			return merge_failure_logs(
-				format!(
-					"Gateway version {gateway_version} is below minimum required {MIN_GATEWAY_VERSION}; aborting adoption"
-				),
-				&log_buffer,
-				&mut log_rx,
-			);
-		}
-		debug!("Gateway version {gateway_version} accepted; proceeding with CSR exchange");
-	} else {
-		return merge_failure_logs(
-			"Gateway component did not return a version header; cannot verify compatibility",
-			&log_buffer,
-			&mut log_rx,
-		);
-	}
+    if let Some(gateway_version) = gateway_version {
+        if gateway_version < MIN_GATEWAY_VERSION {
+            return merge_failure_logs(
+                format!(
+                    "Gateway version {gateway_version} is below minimum required {MIN_GATEWAY_VERSION}; aborting adoption"
+                ),
+                &log_buffer,
+                &mut log_rx,
+            );
+        }
+        debug!("Gateway version {gateway_version} accepted; proceeding with CSR exchange");
+    } else {
+        return merge_failure_logs(
+            "Gateway component did not return a version header; cannot verify compatibility",
+            &log_buffer,
+            &mut log_rx,
+        );
+    }
 
-	let mut response = response_with_metadata.into_inner();
-	let spawn_log_buffer = Arc::clone(&log_buffer);
-	let log_reader_task = tokio::spawn(scope_setup_logs(spawn_log_buffer, async move {
-		loop {
-			match response.message().await {
-				Ok(Some(entry)) => {
-					let formatted = format_component_log(
-						&entry.timestamp,
-						&entry.level,
-						&entry.target,
-						&entry.message,
-					);
-					if log_tx.send(formatted).is_err() {
-						break;
-					}
-				}
-				Ok(None) => break,
-				Err(err) => {
-					let _ = log_tx.send(format!("Error reading log: {err}"));
-					break;
-				}
-			}
-		}
-	}));
-	let _log_task_guard = TaskGuard(log_reader_task);
+    let mut response = response_with_metadata.into_inner();
+    let spawn_log_buffer = Arc::clone(&log_buffer);
+    let log_reader_task = tokio::spawn(scope_setup_logs(spawn_log_buffer, async move {
+        loop {
+            match response.message().await {
+                Ok(Some(entry)) => {
+                    let formatted = format_component_log(
+                        &entry.timestamp,
+                        &entry.level,
+                        &entry.target,
+                        &entry.message,
+                    );
+                    if log_tx.send(formatted).is_err() {
+                        break;
+                    }
+                }
+                Ok(None) => break,
+                Err(err) => {
+                    let _ = log_tx.send(format!("Error reading log: {err}"));
+                    break;
+                }
+            }
+        }
+    }));
+    let _log_task_guard = TaskGuard(log_reader_task);
 
-	let Some(hostname) = url.host_str() else {
-		return merge_failure_logs(
-			format!("Failed to extract hostname from gateway URL: {url}"),
-			&log_buffer,
-			&mut log_rx,
-		);
-	};
+    let Some(hostname) = url.host_str() else {
+        return merge_failure_logs(
+            format!("Failed to extract hostname from gateway URL: {url}"),
+            &log_buffer,
+            &mut log_rx,
+        );
+    };
 
     debug!("Requesting CSR from gateway hostname={hostname}");
     let csr_response = match client
@@ -711,76 +721,76 @@ async fn run_gateway_adoption_attempt_scoped(
             cert_hostname: hostname.to_string(),
         })
         .await
-	{
-		Ok(response) => response.into_inner(),
-		Err(err) => {
-			return merge_failure_logs(
-				format!("Failed to get CSR from gateway: {err}"),
-				&log_buffer,
-				&mut log_rx,
-			);
-		}
-	};
+    {
+        Ok(response) => response.into_inner(),
+        Err(err) => {
+            return merge_failure_logs(
+                format!("Failed to get CSR from gateway: {err}"),
+                &log_buffer,
+                &mut log_rx,
+            );
+        }
+    };
     debug!("CSR received from gateway hostname={hostname}");
 
-	let csr = match Csr::from_der(&csr_response.der_data) {
-		Ok(csr) => csr,
-		Err(err) => {
-			return merge_failure_logs(
-				format!("Failed to parse CSR from gateway: {err}"),
-				&log_buffer,
-				&mut log_rx,
-			);
-		}
-	};
+    let csr = match Csr::from_der(&csr_response.der_data) {
+        Ok(csr) => csr,
+        Err(err) => {
+            return merge_failure_logs(
+                format!("Failed to parse CSR from gateway: {err}"),
+                &log_buffer,
+                &mut log_rx,
+            );
+        }
+    };
 
-	let ca = match CertificateAuthority::from_cert_der_key_pair(&ca_cert_der, &ca_key_der) {
-		Ok(ca) => ca,
-		Err(err) => {
-			return merge_failure_logs(
-				format!("Failed to build certificate authority: {err}"),
-				&log_buffer,
-				&mut log_rx,
-			);
-		}
-	};
+    let ca = match CertificateAuthority::from_cert_der_key_pair(&ca_cert_der, &ca_key_der) {
+        Ok(ca) => ca,
+        Err(err) => {
+            return merge_failure_logs(
+                format!("Failed to build certificate authority: {err}"),
+                &log_buffer,
+                &mut log_rx,
+            );
+        }
+    };
 
-	let cert = match ca.sign_csr(&csr) {
-		Ok(cert) => cert,
-		Err(err) => {
-			return merge_failure_logs(
-				format!("Failed to sign CSR for gateway: {err}"),
-				&log_buffer,
-				&mut log_rx,
-			);
-		}
-	};
+    let cert = match ca.sign_csr(&csr) {
+        Ok(cert) => cert,
+        Err(err) => {
+            return merge_failure_logs(
+                format!("Failed to sign CSR for gateway: {err}"),
+                &log_buffer,
+                &mut log_rx,
+            );
+        }
+    };
     debug!("CSR signed for gateway hostname={hostname}; sending certificate");
 
     if let Err(err) = client
         .send_cert(GatewayDerPayload {
             der_data: cert.der().to_vec(),
         })
-		.await
-	{
-		return merge_failure_logs(
-			format!("Failed to send certificate to gateway: {err}"),
-			&log_buffer,
-			&mut log_rx,
-		);
-	}
+        .await
+    {
+        return merge_failure_logs(
+            format!("Failed to send certificate to gateway: {err}"),
+            &log_buffer,
+            &mut log_rx,
+        );
+    }
     debug!("Certificate delivered to gateway hostname={hostname}");
 
-	let cert_info = match CertificateInfo::from_der(cert.der()) {
-		Ok(info) => info,
-		Err(err) => {
-			return merge_failure_logs(
-				format!("Failed to parse certificate info from gateway cert: {err}"),
-				&log_buffer,
-				&mut log_rx,
-			);
-		}
-	};
+    let cert_info = match CertificateInfo::from_der(cert.der()) {
+        Ok(info) => info,
+        Err(err) => {
+            return merge_failure_logs(
+                format!("Failed to parse certificate info from gateway cert: {err}"),
+                &log_buffer,
+                &mut log_rx,
+            );
+        }
+    };
     debug!(
         "Gateway adoption handshake complete hostname={hostname} cert_serial={} expires={}",
         cert_info.serial, cert_info.not_after

--- a/crates/defguard_setup/src/auto_adoption.rs
+++ b/crates/defguard_setup/src/auto_adoption.rs
@@ -192,9 +192,6 @@ fn merge_failure_logs(
     error!("{msg}");
     let mut logs = collect_core_logs(log_buffer);
     logs.extend(collect_stream_logs(log_rx));
-    if !logs.iter().any(|line| line.contains(&msg)) {
-        logs.push(msg);
-    }
     (false, logs, None)
 }
 

--- a/crates/defguard_setup/src/auto_adoption.rs
+++ b/crates/defguard_setup/src/auto_adoption.rs
@@ -238,6 +238,7 @@ async fn run_edge_adoption_attempt_scoped(
 			)
 		}
 	};
+	debug!("Successfully validated Edge address: {endpoint_str}");
 
 	let cert_pem = match der_to_pem(&ca_cert_der, PemLabel::Certificate) {
 		Ok(pem) => pem,
@@ -249,6 +250,7 @@ async fn run_edge_adoption_attempt_scoped(
 			);
 		}
 	};
+	debug!("Loaded CA certificate for secure Edge communication");
 
 	let base_endpoint = match Endpoint::from_shared(endpoint_str.clone()) {
 		Ok(endpoint) => endpoint,
@@ -277,6 +279,7 @@ async fn run_edge_adoption_attempt_scoped(
 			);
 		}
 	};
+	debug!("Prepared secure connection endpoint for Edge at {host}:{port}");
 
 	let core_version = match Version::parse(VERSION) {
 		Ok(version) => version,
@@ -288,6 +291,7 @@ async fn run_edge_adoption_attempt_scoped(
 			)
 		}
 	};
+	debug!("Parsed Core version {core_version} for Edge auto-adoption");
 
     let token = match Claims::new(
         ClaimsType::Gateway,
@@ -306,6 +310,7 @@ async fn run_edge_adoption_attempt_scoped(
 			)
 		}
 	};
+	debug!("Generated secure setup token for Edge authentication");
 
     let version_interceptor = ClientVersionInterceptor::new(core_version.clone());
     let auth_interceptor = AuthInterceptor::new(token);
@@ -337,6 +342,7 @@ async fn run_edge_adoption_attempt_scoped(
 				);
 			}
 		};
+	debug!("Successfully connected to Edge setup stream");
 
     let edge_version = response_with_metadata
         .metadata()
@@ -530,6 +536,7 @@ async fn run_gateway_adoption_attempt_scoped(
 			)
 		}
 	};
+	debug!("Successfully validated Gateway address: {endpoint_str}");
 
 	let cert_pem = match der_to_pem(&ca_cert_der, PemLabel::Certificate) {
 		Ok(pem) => pem,
@@ -541,6 +548,7 @@ async fn run_gateway_adoption_attempt_scoped(
 			);
 		}
 	};
+	debug!("Loaded CA certificate for secure Gateway communication");
 
 	let base_endpoint = match Endpoint::from_shared(endpoint_str.clone()) {
 		Ok(endpoint) => endpoint,
@@ -569,6 +577,7 @@ async fn run_gateway_adoption_attempt_scoped(
 			);
 		}
 	};
+	debug!("Prepared secure connection endpoint for Gateway at {host}:{port}");
 
 	let core_version = match Version::parse(VERSION) {
 		Ok(version) => version,
@@ -580,6 +589,7 @@ async fn run_gateway_adoption_attempt_scoped(
 			)
 		}
 	};
+	debug!("Parsed Core version {core_version} for Gateway auto-adoption");
 
     let token = match Claims::new(
         ClaimsType::Gateway,
@@ -598,6 +608,7 @@ async fn run_gateway_adoption_attempt_scoped(
 			)
 		}
 	};
+	debug!("Generated secure setup token for Gateway authentication");
 
     let version_interceptor = ClientVersionInterceptor::new(core_version.clone());
     let auth_interceptor = AuthInterceptor::new(token);
@@ -631,6 +642,7 @@ async fn run_gateway_adoption_attempt_scoped(
 				);
 			}
 		};
+	debug!("Successfully connected to Gateway setup stream");
 
     let gateway_version = response_with_metadata
         .metadata()

--- a/crates/defguard_setup/tests/auto_adoption_wizard.rs
+++ b/crates/defguard_setup/tests/auto_adoption_wizard.rs
@@ -12,6 +12,7 @@ use defguard_common::{
         setup_pool,
     },
 };
+use defguard_core::setup_logs::CoreSetupLogLayer;
 use defguard_setup::auto_adoption::attempt_auto_adoption;
 use ipnetwork::IpNetwork;
 use reqwest::{
@@ -20,11 +21,23 @@ use reqwest::{
 };
 use serde_json::json;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
+use std::sync::Once;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 mod common;
 use common::make_setup_test_client;
 
 const SESSION_COOKIE_NAME: &str = "defguard_session";
+
+fn init_tracing_once() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        tracing_subscriber::registry()
+            .with(CoreSetupLogLayer)
+            .try_init()
+            .ok();
+    });
+}
 
 async fn assert_auto_adoption_step(pool: &sqlx::PgPool, expected: AutoAdoptionWizardStep) {
     let state = AutoAdoptionWizardState::get(pool)
@@ -423,7 +436,121 @@ async fn test_attempt_auto_adoption_requires_both_flags(
     // neither flag
     assert!(
         attempt_auto_adoption(&pool, &config_with_flags(None, None))
-            .await
-            .is_err()
+        .await
+        .is_err()
+    );
+}
+
+#[sqlx::test]
+async fn test_attempt_auto_adoption_persists_actionable_edge_failure_logs(
+    _: PgPoolOptions,
+    options: PgConnectOptions,
+) {
+    init_tracing_once();
+
+    let pool = defguard_common::db::setup_pool(options).await;
+    initialize_current_settings(&pool)
+        .await
+        .expect("Failed to initialize settings");
+
+    Wizard::init(&pool, true)
+        .await
+        .expect("Failed to init wizard");
+
+    attempt_auto_adoption(
+        &pool,
+        &config_with_flags(Some("bad host:50051"), Some("127.0.0.1:50052")),
+    )
+    .await
+    .expect("Auto-adoption should store per-component failures instead of erroring");
+
+    let state = AutoAdoptionWizardState::get(&pool)
+        .await
+        .expect("Failed to fetch auto-adoption state")
+        .expect("Expected auto-adoption state to exist");
+
+    let edge_result = state
+        .adoption_result
+        .get(&defguard_common::db::models::setup_auto_adoption::SetupAutoAdoptionComponent::Edge)
+        .expect("Expected edge adoption result");
+
+    assert!(!edge_result.success, "Edge auto-adoption should fail");
+    assert!(
+        edge_result.logs.len() >= 2,
+        "Expected multiple actionable log lines, got {:?}",
+        edge_result.logs
+    );
+    assert!(
+        edge_result
+            .logs
+            .iter()
+            .any(|line| line.contains("Invalid edge endpoint URL")),
+        "Expected explicit edge failure message in logs: {:?}",
+        edge_result.logs
+    );
+    assert!(
+        edge_result.logs.iter().any(|line| {
+            line.contains("DEBUG defguard_setup::auto_adoption")
+                && line.contains("Starting edge adoption attempt")
+        }),
+        "Expected captured Core debug log in edge logs: {:?}",
+        edge_result.logs
+    );
+}
+
+#[sqlx::test]
+async fn test_attempt_auto_adoption_persists_actionable_gateway_failure_logs(
+    _: PgPoolOptions,
+    options: PgConnectOptions,
+) {
+    init_tracing_once();
+
+    let pool = defguard_common::db::setup_pool(options).await;
+    initialize_current_settings(&pool)
+        .await
+        .expect("Failed to initialize settings");
+
+    Wizard::init(&pool, true)
+        .await
+        .expect("Failed to init wizard");
+
+    attempt_auto_adoption(
+        &pool,
+        &config_with_flags(Some("127.0.0.1:50051"), Some("bad host:50052")),
+    )
+    .await
+    .expect("Auto-adoption should store per-component failures instead of erroring");
+
+    let state = AutoAdoptionWizardState::get(&pool)
+        .await
+        .expect("Failed to fetch auto-adoption state")
+        .expect("Expected auto-adoption state to exist");
+
+    let gateway_result = state
+        .adoption_result
+        .get(&defguard_common::db::models::setup_auto_adoption::SetupAutoAdoptionComponent::Gateway)
+        .expect("Expected gateway adoption result");
+
+    assert!(!gateway_result.success, "Gateway auto-adoption should fail");
+    assert!(
+        gateway_result.logs.len() >= 2,
+        "Expected multiple actionable log lines, got {:?}",
+        gateway_result.logs
+    );
+    assert!(
+        gateway_result
+            .logs
+            .iter()
+            .any(|line| line.contains("Invalid gateway endpoint URL")),
+        "Expected explicit gateway failure message in logs: {:?}",
+        gateway_result.logs
+    );
+    assert!(
+        gateway_result.logs.iter().any(|line| {
+            line.contains("DEBUG defguard_setup::auto_adoption")
+                && line.contains("Starting gateway adoption attempt")
+        }),
+        "Expected captured Core debug log in gateway logs: {:?}",
+        gateway_result.logs
     );
 }

--- a/crates/defguard_setup/tests/auto_adoption_wizard.rs
+++ b/crates/defguard_setup/tests/auto_adoption_wizard.rs
@@ -436,8 +436,8 @@ async fn test_attempt_auto_adoption_requires_both_flags(
     // neither flag
     assert!(
         attempt_auto_adoption(&pool, &config_with_flags(None, None))
-        .await
-        .is_err()
+            .await
+            .is_err()
     );
 }
 


### PR DESCRIPTION
- add scoped log buffering to auto-adoption attempts
- merge persisted failure logs from Core and component streams
- use existing wizard.auto_adoption_state.adoption_result[component].logs persistence
- enable debug-level tracing for defguard_setup::auto_adoption
- cleanup previous logs on successful adoption