### PR TITLE
location form all groups toggle fix

### DIFF
--- a/crates/defguard_core/src/handlers/wireguard.rs
+++ b/crates/defguard_core/src/handlers/wireguard.rs
@@ -130,6 +130,15 @@ impl WireguardNetworkData {
 
         Ok(())
     }
+
+    pub(crate) fn validate_allowed_groups(&self) -> Result<(), WebError> {
+        if self.allow_all_groups || !self.allowed_groups.is_empty() {
+            return Ok(());
+        }
+        Err(WebError::BadRequest(
+            "At least one group must be specified when allow_all_groups is disabled".into(),
+        ))
+    }
 }
 
 // Used in process of importing network from WireGuard config.
@@ -216,6 +225,7 @@ pub(crate) async fn create_network(
 
     data.validate_peer_disconnect_threshold()?;
     data.validate_location_mfa_mode(&appstate.pool).await?;
+    data.validate_allowed_groups()?;
 
     let allowed_ips = data.parse_allowed_ips();
     let mut network = WireguardNetwork::new(
@@ -325,6 +335,7 @@ pub(crate) async fn modify_network(
 
     data.validate_peer_disconnect_threshold()?;
     data.validate_location_mfa_mode(&appstate.pool).await?;
+    data.validate_allowed_groups()?;
 
     let network = find_network(network_id, &appstate.pool).await?;
     // store network before mods

--- a/crates/defguard_core/src/handlers/wireguard.rs
+++ b/crates/defguard_core/src/handlers/wireguard.rs
@@ -58,7 +58,7 @@ pub(crate) struct LocationsCount {
     count: usize,
 }
 
-#[derive(Deserialize, Serialize, ToSchema)]
+#[derive(Clone, Deserialize, Serialize, ToSchema)]
 pub struct WireguardNetworkData {
     pub name: String,
     pub address: String, // comma-separated list of addresses

--- a/crates/defguard_core/tests/integration/api/wireguard_network_allowed_groups.rs
+++ b/crates/defguard_core/tests/integration/api/wireguard_network_allowed_groups.rs
@@ -6,14 +6,21 @@ use defguard_common::{
     db::{
         Id,
         models::{
-            Device, DeviceType, User, WireguardNetwork, group::Group,
-            wireguard::{DEFAULT_DISCONNECT_THRESHOLD, DEFAULT_KEEPALIVE_INTERVAL, DEFAULT_WIREGUARD_MTU, LocationMfaMode, ServiceLocationMode},
+            Device, DeviceType, User, WireguardNetwork,
+            group::Group,
+            wireguard::{
+                DEFAULT_DISCONNECT_THRESHOLD, DEFAULT_KEEPALIVE_INTERVAL, DEFAULT_WIREGUARD_MTU,
+                LocationMfaMode, ServiceLocationMode,
+            },
         },
     },
 };
 use defguard_core::{
     grpc::GatewayEvent,
-    handlers::{Auth, wireguard::{ImportedNetworkData, WireguardNetworkData}},
+    handlers::{
+        Auth,
+        wireguard::{ImportedNetworkData, WireguardNetworkData},
+    },
     location_management::allowed_peers::get_location_allowed_peers,
 };
 use matches::assert_matches;
@@ -1049,7 +1056,11 @@ async fn test_modify_network_without_groups_rejected(_: PgPoolOptions, options: 
         location_mfa_mode: LocationMfaMode::Disabled,
         service_location_mode: ServiceLocationMode::Disabled,
     };
-    let response = client.post("/api/v1/network").json(&create_data).send().await;
+    let response = client
+        .post("/api/v1/network")
+        .json(&create_data)
+        .send()
+        .await;
     assert_eq!(response.status(), StatusCode::CREATED);
 
     let mut modify_data = create_data.clone();

--- a/crates/defguard_core/tests/integration/api/wireguard_network_allowed_groups.rs
+++ b/crates/defguard_core/tests/integration/api/wireguard_network_allowed_groups.rs
@@ -5,12 +5,15 @@ use defguard_common::{
     csv::AsCsv,
     db::{
         Id,
-        models::{Device, DeviceType, User, WireguardNetwork, group::Group},
+        models::{
+            Device, DeviceType, User, WireguardNetwork, group::Group,
+            wireguard::{DEFAULT_DISCONNECT_THRESHOLD, DEFAULT_KEEPALIVE_INTERVAL, DEFAULT_WIREGUARD_MTU, LocationMfaMode, ServiceLocationMode},
+        },
     },
 };
 use defguard_core::{
     grpc::GatewayEvent,
-    handlers::{Auth, wireguard::ImportedNetworkData},
+    handlers::{Auth, wireguard::{ImportedNetworkData, WireguardNetworkData}},
     location_management::allowed_peers::get_location_allowed_peers,
 };
 use matches::assert_matches;
@@ -21,7 +24,7 @@ use sqlx::{
     postgres::{PgConnectOptions, PgPoolOptions},
 };
 
-use super::common::{fetch_user_details, make_test_client, setup_pool};
+use super::common::{authenticate_admin, fetch_user_details, make_test_client, setup_pool};
 
 // setup user groups, test users and devices
 async fn setup_test_users(pool: &PgPool) -> (Vec<User<Id>>, Vec<Device<Id>>) {
@@ -250,7 +253,7 @@ async fn test_modify_network(_: PgPoolOptions, options: PgConnectOptions) {
     let response = &client.post("/api/v1/auth").json(&auth).send().await;
     assert_eq!(response.status(), StatusCode::OK);
 
-    // create network without allowed groups
+    // create network with one allowed group
     let response = client
         .post("/api/v1/network")
         .json(&json!({
@@ -263,7 +266,7 @@ async fn test_modify_network(_: PgPoolOptions, options: PgConnectOptions) {
             "mtu": 1420,
             "fwmark": 0,
             "allow_all_groups": false,
-            "allowed_groups": [],
+            "allowed_groups": ["allowed group"],
             "keepalive_interval": 25,
             "peer_disconnect_threshold": 300,
             "acl_enabled": false,
@@ -279,12 +282,13 @@ async fn test_modify_network(_: PgPoolOptions, options: PgConnectOptions) {
     let event = wg_rx.try_recv().unwrap();
     assert_matches!(event, GatewayEvent::NetworkCreated(..));
 
-    // network configuration was created only for the admin device
+    // network configuration was created for admin and the allowed group member
     let peers = get_location_allowed_peers(&network, &client_state.pool)
         .await
         .unwrap();
-    assert_eq!(peers.len(), 1);
+    assert_eq!(peers.len(), 2);
     assert_eq!(peers[0].pubkey, devices[0].wireguard_pubkey);
+    assert_eq!(peers[1].pubkey, devices[1].wireguard_pubkey);
 
     // add an allowed group
     let response = client
@@ -385,38 +389,6 @@ async fn test_modify_network(_: PgPoolOptions, options: PgConnectOptions) {
     assert_eq!(new_peers.len(), 2);
     assert_eq!(new_peers[0].pubkey, devices[0].wireguard_pubkey);
     assert_eq!(new_peers[1].pubkey, devices[2].wireguard_pubkey);
-
-    // remove all allowed groups
-    let response = client
-        .put("/api/v1/network/1")
-        .json(&json!({
-            "name": "network",
-            "address": "10.1.1.1/24",
-            "port": 55555,
-            "endpoint": "192.168.4.14",
-            "allowed_ips": "10.1.1.0/24",
-            "dns": "1.1.1.1",
-            "mtu": 1420,
-            "fwmark": 0,
-            "allow_all_groups": false,
-            "allowed_groups": [],
-            "keepalive_interval": 25,
-            "peer_disconnect_threshold": 300,
-            "acl_enabled": false,
-            "acl_default_allow": false,
-            "location_mfa_mode": "disabled",
-            "service_location_mode": "disabled"
-        }))
-        .send()
-        .await;
-    assert_eq!(response.status(), StatusCode::OK);
-    assert_matches!(wg_rx.try_recv().unwrap(), GatewayEvent::NetworkModified(..));
-
-    let new_peers = get_location_allowed_peers(&network, &client_state.pool)
-        .await
-        .unwrap();
-    assert_eq!(new_peers.len(), 1);
-    assert_eq!(new_peers[0].pubkey, devices[0].wireguard_pubkey);
 
     assert_err!(wg_rx.try_recv());
 }
@@ -998,4 +970,116 @@ async fn test_delete_only_allowed_group(_: PgPoolOptions, options: PgConnectOpti
         .unwrap();
     assert_eq!(peers.len(), 1);
     assert_eq!(peers[0].pubkey, devices[0].wireguard_pubkey);
+}
+
+#[sqlx::test]
+async fn test_create_network_without_groups_rejected(_: PgPoolOptions, options: PgConnectOptions) {
+    let pool = setup_pool(options).await;
+    let (mut client, _client_state) = make_test_client(pool).await;
+    authenticate_admin(&mut client).await;
+
+    let base_data = WireguardNetworkData {
+        name: "test_location".into(),
+        address: "10.1.1.1/24".into(),
+        endpoint: "10.1.1.1".parse().unwrap(),
+        port: 55555,
+        allowed_ips: None,
+        dns: None,
+        mtu: DEFAULT_WIREGUARD_MTU,
+        fwmark: 0,
+        allow_all_groups: false,
+        allowed_groups: vec![],
+        keepalive_interval: DEFAULT_KEEPALIVE_INTERVAL,
+        peer_disconnect_threshold: DEFAULT_DISCONNECT_THRESHOLD,
+        acl_enabled: false,
+        acl_default_allow: false,
+        location_mfa_mode: LocationMfaMode::Disabled,
+        service_location_mode: ServiceLocationMode::Disabled,
+    };
+
+    // allow_all_groups=false with no groups should be rejected
+    let response = client.post("/api/v1/network").json(&base_data).send().await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    // allow_all_groups=false with at least one group should be accepted
+    let mut data_with_group = base_data.clone();
+    data_with_group.allowed_groups = vec!["admin".into()];
+    let response = client
+        .post("/api/v1/network")
+        .json(&data_with_group)
+        .send()
+        .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    // allow_all_groups=true with no groups should be accepted
+    let mut data_allow_all = base_data.clone();
+    data_allow_all.name = "test_location_allow_all".into();
+    data_allow_all.address = "10.1.2.1/24".into();
+    data_allow_all.allow_all_groups = true;
+    let response = client
+        .post("/api/v1/network")
+        .json(&data_allow_all)
+        .send()
+        .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+}
+
+#[sqlx::test]
+async fn test_modify_network_without_groups_rejected(_: PgPoolOptions, options: PgConnectOptions) {
+    let pool = setup_pool(options).await;
+    let (mut client, _client_state) = make_test_client(pool).await;
+    authenticate_admin(&mut client).await;
+
+    // create a valid location with allow_all_groups=true
+    let create_data = WireguardNetworkData {
+        name: "test_location".into(),
+        address: "10.1.1.1/24".into(),
+        endpoint: "10.1.1.1".parse().unwrap(),
+        port: 55555,
+        allowed_ips: None,
+        dns: None,
+        mtu: DEFAULT_WIREGUARD_MTU,
+        fwmark: 0,
+        allow_all_groups: true,
+        allowed_groups: vec![],
+        keepalive_interval: DEFAULT_KEEPALIVE_INTERVAL,
+        peer_disconnect_threshold: DEFAULT_DISCONNECT_THRESHOLD,
+        acl_enabled: false,
+        acl_default_allow: false,
+        location_mfa_mode: LocationMfaMode::Disabled,
+        service_location_mode: ServiceLocationMode::Disabled,
+    };
+    let response = client.post("/api/v1/network").json(&create_data).send().await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let mut modify_data = create_data.clone();
+
+    // allow_all_groups=false with no groups should be rejected
+    modify_data.allow_all_groups = false;
+    modify_data.allowed_groups = vec![];
+    let response = client
+        .put("/api/v1/network/1")
+        .json(&modify_data)
+        .send()
+        .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    // allow_all_groups=false with at least one group should be accepted
+    modify_data.allowed_groups = vec!["admin".into()];
+    let response = client
+        .put("/api/v1/network/1")
+        .json(&modify_data)
+        .send()
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // allow_all_groups=true with no groups should be accepted
+    modify_data.allow_all_groups = true;
+    modify_data.allowed_groups = vec![];
+    let response = client
+        .put("/api/v1/network/1")
+        .json(&modify_data)
+        .send()
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
 }

--- a/web/messages/en/location.json
+++ b/web/messages/en/location.json
@@ -95,6 +95,7 @@
   "location_access_selected_group_count_other": "+{count} groups",
   "location_access_edit_groups": "Edit groups",
   "location_access_select_allowed_groups": "Select allowed groups",
+  "location_access_required_groups": "At least one group must be selected",
   "network_device_delete_success": "Network device deleted",
   "network_device_delete_failed": "Failed to delete network device",
   "network_device_add_error": "Failed to load network data for adding device",

--- a/web/src/pages/AddLocationPage/steps/AddLocationAccessStep.tsx
+++ b/web/src/pages/AddLocationPage/steps/AddLocationAccessStep.tsx
@@ -7,6 +7,8 @@ import { SelectionSection } from '../../../shared/components/SelectionSection/Se
 import type { SelectionOption } from '../../../shared/components/SelectionSection/type';
 import { WizardCard } from '../../../shared/components/wizard/WizardCard/WizardCard';
 import { Button } from '../../../shared/defguard-ui/components/Button/Button';
+import { FieldError } from '../../../shared/defguard-ui/components/FieldError/FieldError';
+import { Fold } from '../../../shared/defguard-ui/components/Fold/Fold';
 import { SizedBox } from '../../../shared/defguard-ui/components/SizedBox/SizedBox';
 import { Toggle } from '../../../shared/defguard-ui/components/Toggle/Toggle';
 import { ThemeSpacing } from '../../../shared/defguard-ui/types';
@@ -20,6 +22,7 @@ export const AddLocationAccessStep = () => {
   const [selected, setSelected] = useState<Set<string>>(
     new Set(useAddLocationStore.getState().allowed_groups),
   );
+  const [groupError, setGroupError] = useState<string | undefined>(undefined);
 
   const { data: groups } = useQuery({
     queryFn: api.group.getGroups,
@@ -51,18 +54,21 @@ export const AddLocationAccessStep = () => {
         onClick={() => {
           const value = !allowAllGroups;
           setAllowAllGroups(value);
+          setGroupError(undefined);
         }}
       />
-      {!allowAllGroups && (
-        <>
-          <SizedBox height={ThemeSpacing.Xl} />
-          <SelectionSection
-            options={selectionOptions}
-            selection={selected}
-            onChange={setSelected}
-          />
-        </>
-      )}
+      <Fold open={!allowAllGroups}>
+        <SizedBox height={ThemeSpacing.Xl} />
+        <SelectionSection
+          options={selectionOptions}
+          selection={selected}
+          onChange={(val) => {
+            setSelected(val);
+            if (val.size > 0) setGroupError(undefined);
+          }}
+        />
+        <FieldError error={groupError} />
+      </Fold>
       <Controls>
         <Button
           variant="outlined"
@@ -79,6 +85,10 @@ export const AddLocationAccessStep = () => {
             text={m.controls_continue()}
             testId="acl-continue"
             onClick={() => {
+              if (!allowAllGroups && selected.size === 0) {
+                setGroupError(m.location_access_required_groups());
+                return;
+              }
               saveChanges(selected, allowAllGroups);
               useAddLocationStore.setState({
                 activeStep: AddLocationPageStep.Firewall,

--- a/web/src/pages/AddLocationPage/useAddLocationStore.tsx
+++ b/web/src/pages/AddLocationPage/useAddLocationStore.tsx
@@ -29,7 +29,7 @@ const defaults: StoreValues = {
   keepalive_interval: 25,
   mtu: 1420,
   fwmark: 0,
-  allow_all_groups: false,
+  allow_all_groups: true,
   peer_disconnect_threshold: 300,
   acl_default_allow: true,
   acl_enabled: false,

--- a/web/src/pages/EditLocationPage/EditLocationPage.tsx
+++ b/web/src/pages/EditLocationPage/EditLocationPage.tsx
@@ -154,24 +154,27 @@ const formSchema = z
     firewall: z.enum(LocationFirewall),
   })
   .superRefine((value, context) => {
-    if (value.location_mfa_mode === LocationMfaMode.Disabled) {
-      return;
+    if (value.location_mfa_mode !== LocationMfaMode.Disabled) {
+      if (value.peer_disconnect_threshold === null) {
+        context.addIssue({
+          code: 'custom',
+          path: ['peer_disconnect_threshold'],
+          message: m.form_error_required(),
+        });
+      } else if (value.peer_disconnect_threshold < peerDisconnectThresholdMinimum) {
+        context.addIssue({
+          code: 'custom',
+          path: ['peer_disconnect_threshold'],
+          message: m.form_error_min({ value: peerDisconnectThresholdMinimum }),
+        });
+      }
     }
 
-    if (value.peer_disconnect_threshold === null) {
+    if (!value.allow_all_groups && value.allowed_groups.length === 0) {
       context.addIssue({
         code: 'custom',
-        path: ['peer_disconnect_threshold'],
-        message: m.form_error_required(),
-      });
-      return;
-    }
-
-    if (value.peer_disconnect_threshold < peerDisconnectThresholdMinimum) {
-      context.addIssue({
-        code: 'custom',
-        path: ['peer_disconnect_threshold'],
-        message: m.form_error_min({ value: peerDisconnectThresholdMinimum }),
+        path: ['allowed_groups'],
+        message: m.location_access_required_groups(),
       });
     }
   });

--- a/web/src/shared/components/SelectionSection/SelectionSection.tsx
+++ b/web/src/shared/components/SelectionSection/SelectionSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { Fragment, useCallback, useMemo, useState } from 'react';
 import './style.scss';
 import clsx from 'clsx';
 import { m } from '../../../paraglide/messages';
@@ -146,10 +146,9 @@ export const SelectionSection = <T extends SelectionKey, M = unknown>({
                 handleSelect(option, selected, selection);
               };
               return (
-                <>
+                <Fragment key={option.id}>
                   <div
                     className="item"
-                    key={option.id}
                     style={{
                       minHeight: itemHeight,
                     }}
@@ -175,7 +174,7 @@ export const SelectionSection = <T extends SelectionKey, M = unknown>({
                       <SizedBox height={itemGap} />
                     </>
                   )}
-                </>
+                </Fragment>
               );
             })}
           </div>


### PR DESCRIPTION
Fix "All groups" toggle behavior in location wizard and location edit form:
- default to enabled
- if disabled, require user to select at least one group

Closes https://github.com/DefGuard/defguard/issues/2455