### PR TITLE
properly validate ACL rules which use just Aliases to populate fields

### DIFF
--- a/crates/defguard_core/src/enterprise/db/models/acl.rs
+++ b/crates/defguard_core/src/enterprise/db/models/acl.rs
@@ -316,24 +316,19 @@ impl<I> AclRule<I> {
 impl AclRule {
     /// Creates new [`AclRule`] with all related objects based on [`ApiAclRule`]
     pub(crate) async fn create_from_api(
-        pool: &PgPool,
+        conn: &mut PgConnection,
         api_rule: &EditAclRule,
         actor: &str,
     ) -> Result<ApiAclRule, AclError> {
-        let mut transaction = pool.begin().await?;
-
         // save the rule
         let mut rule: AclRule = api_rule.clone().try_into()?;
         rule.stamp_modified(actor);
-        let rule = rule.save(&mut *transaction).await?;
+        let rule = rule.save(&mut *conn).await?;
 
         // create related objects
-        rule.create_related_objects(&mut transaction, api_rule)
-            .await?;
+        rule.create_related_objects(conn, api_rule).await?;
 
-        let result = ApiAclRule::from(rule.to_info(&mut transaction).await?);
-
-        transaction.commit().await?;
+        let result = ApiAclRule::from(rule.to_info(&mut *conn).await?);
 
         Ok(result)
     }
@@ -355,21 +350,18 @@ impl AclRule {
     /// and performed appropriate operations, only that the next time configuration
     /// is being sent it will include this rule.
     pub(crate) async fn update_from_api(
-        pool: &PgPool,
+        conn: &mut PgConnection,
         id: Id,
         api_rule: &EditAclRule,
         actor: &str,
     ) -> Result<ApiAclRule, AclError> {
         debug!("Updating rule ID {id} with {api_rule:?}");
-        let mut transaction = pool.begin().await?;
 
         // find the existing rule
-        let existing_rule = AclRule::find_by_id(&mut *transaction, id)
-            .await?
-            .ok_or_else(|| {
-                warn!("Update of nonexistent rule ({id}) failed");
-                AclError::RuleNotFoundError(id)
-            })?;
+        let existing_rule = AclRule::find_by_id(&mut *conn, id).await?.ok_or_else(|| {
+            warn!("Update of nonexistent rule ({id}) failed");
+            AclError::RuleNotFoundError(id)
+        })?;
 
         // convert API rule to model
         let mut rule: AclRule<NoId> = api_rule.clone().try_into()?;
@@ -385,7 +377,7 @@ impl AclRule {
                 );
                 // remove old modifications of this rule
                 let result = query!("DELETE FROM aclrule WHERE parent_id = $1", id)
-                    .execute(&mut *transaction)
+                    .execute(&mut *conn)
                     .await?;
                 debug!(
                     "Removed {} old modifications of rule {id}",
@@ -395,11 +387,10 @@ impl AclRule {
                 // save as a new rule with appropriate parent_id and state
                 rule.state = RuleState::Modified;
                 rule.parent_id = Some(id);
-                let rule = rule.save(&mut *transaction).await?;
+                let rule = rule.save(&mut *conn).await?;
 
                 // create related objects
-                rule.create_related_objects(&mut transaction, api_rule)
-                    .await?;
+                rule.create_related_objects(conn, api_rule).await?;
 
                 rule
             }
@@ -416,20 +407,17 @@ impl AclRule {
                 let mut rule = rule.with_id(id);
                 rule.parent_id = existing_rule.parent_id;
                 rule.state = existing_rule.state;
-                rule.save(&mut *transaction).await?;
+                rule.save(&mut *conn).await?;
 
                 // recreate related objects
-                rule.delete_related_objects(&mut transaction).await?;
-                rule.create_related_objects(&mut transaction, api_rule)
-                    .await?;
+                rule.delete_related_objects(conn).await?;
+                rule.create_related_objects(conn, api_rule).await?;
 
                 rule
             }
         };
 
-        let rule_details = rule.to_info(&mut transaction).await?.into();
-
-        transaction.commit().await?;
+        let rule_details = rule.to_info(&mut *conn).await?.into();
 
         info!("Successfully updated rule {rule_details:?}");
         Ok(rule_details)

--- a/crates/defguard_core/src/enterprise/handlers/acl.rs
+++ b/crates/defguard_core/src/enterprise/handlers/acl.rs
@@ -148,7 +148,13 @@ impl EditAclRule {
             } else {
                 let row = query_as::<_, (Option<bool>, Option<bool>, Option<bool>)>(
                     "SELECT \
-                            bool_or(array_length(addresses, 1) > 0), \
+                            bool_or(array_length(addresses, 1) > 0) \
+                                OR EXISTS ( \
+                                    SELECT 1 FROM aclaliasdestinationrange dr \
+                                    JOIN aclalias a ON a.id = dr.alias_id \
+                                    WHERE a.id = ANY($1) \
+                                      AND a.kind = 'component'::aclalias_kind \
+                                ), \
                             bool_or(array_length(ports, 1) > 0), \
                             bool_or(array_length(protocols, 1) > 0) \
                         FROM aclalias WHERE id = ANY($1) AND kind = 'component'::aclalias_kind",
@@ -376,16 +382,15 @@ pub(crate) async fn create_acl_rule(
 ) -> ApiResult {
     debug!("User {} creating ACL rule {data:?}", session.user.username);
 
-    // validate submitted ACL rule
-    let mut conn = appstate.pool.acquire().await?;
-    data.validate(&mut conn).await?;
-
-    let rule = AclRule::create_from_api(&appstate.pool, &data, &session.user.username)
+    let mut tx = appstate.pool.begin().await?;
+    data.validate(&mut tx).await?;
+    let rule = AclRule::create_from_api(&mut tx, &data, &session.user.username)
         .await
         .map_err(|err| {
             error!("Error creating ACL rule {data:?}: {err}");
             err
         })?;
+    tx.commit().await?;
     info!(
         "User {} created ACL rule {}",
         session.user.username, rule.id
@@ -416,16 +421,15 @@ pub(crate) async fn update_acl_rule(
 ) -> ApiResult {
     debug!("User {} updating ACL rule {data:?}", session.user.username);
 
-    // validate submitted ACL rule
-    let mut conn = appstate.pool.acquire().await?;
-    data.validate(&mut conn).await?;
-
-    let rule = AclRule::update_from_api(&appstate.pool, id, &data, &session.user.username)
+    let mut tx = appstate.pool.begin().await?;
+    data.validate(&mut tx).await?;
+    let rule = AclRule::update_from_api(&mut tx, id, &data, &session.user.username)
         .await
         .map_err(|err| {
             error!("Error updating ACL rule {data:?}: {err}");
             err
         })?;
+    tx.commit().await?;
     info!("User {} updated ACL rule", session.user.username);
     Ok(ApiResponse::json(rule, StatusCode::OK))
 }

--- a/crates/defguard_core/src/enterprise/handlers/acl.rs
+++ b/crates/defguard_core/src/enterprise/handlers/acl.rs
@@ -9,7 +9,7 @@ use axum::{
 use chrono::NaiveDateTime;
 use defguard_common::db::Id;
 use serde_json::{Value, json};
-use sqlx::query_as;
+use sqlx::{PgConnection, query_as};
 use utoipa::ToSchema;
 
 use super::LicenseInfo;
@@ -137,17 +137,46 @@ pub struct EditAclRule {
 }
 
 impl EditAclRule {
-    pub fn validate(&self) -> Result<(), WebError> {
-        let manual_configured = self.any_address
-            || self.any_port
-            || self.any_protocol
-            || !self.addresses.trim().is_empty()
-            || !self.ports.trim().is_empty()
-            || !self.protocols.is_empty();
+    pub async fn validate(&self, conn: &mut PgConnection) -> Result<(), WebError> {
         if self.use_manual_destination_settings {
-            if !manual_configured {
+            // Determine what the selected component aliases collectively contribute.
+            // Note: Component-kind aliases always have any_address/any_port/any_protocol = false,
+            // so we only check whether they have non-empty arrays.
+            let (alias_has_address, alias_has_port, alias_has_protocol) =
+                if self.aliases.is_empty() {
+                    (false, false, false)
+                } else {
+                    let row = query_as::<_, (Option<bool>, Option<bool>, Option<bool>)>(
+                        "SELECT \
+                            bool_or(array_length(addresses, 1) > 0), \
+                            bool_or(array_length(ports, 1) > 0), \
+                            bool_or(array_length(protocols, 1) > 0) \
+                        FROM aclalias WHERE id = ANY($1)",
+                    )
+                    .bind(&self.aliases)
+                    .fetch_one(&mut *conn)
+                    .await
+                    .map_err(WebError::from)?;
+                    (
+                        row.0.unwrap_or(false),
+                        row.1.unwrap_or(false),
+                        row.2.unwrap_or(false),
+                    )
+                };
+
+            if !self.any_address && self.addresses.trim().is_empty() && !alias_has_address {
                 return Err(WebError::BadRequest(
-                    "Must provide manual destination settings".to_string(),
+                    "Must provide destination address, or enable any address".to_string(),
+                ));
+            }
+            if !self.any_port && self.ports.trim().is_empty() && !alias_has_port {
+                return Err(WebError::BadRequest(
+                    "Must provide destination port, or enable any port".to_string(),
+                ));
+            }
+            if !self.any_protocol && self.protocols.is_empty() && !alias_has_protocol {
+                return Err(WebError::BadRequest(
+                    "Must provide destination protocol, or enable any protocol".to_string(),
                 ));
             }
         } else if self.destinations.is_empty() {
@@ -348,7 +377,8 @@ pub(crate) async fn create_acl_rule(
     debug!("User {} creating ACL rule {data:?}", session.user.username);
 
     // validate submitted ACL rule
-    data.validate()?;
+    let mut conn = appstate.pool.acquire().await?;
+    data.validate(&mut conn).await?;
 
     let rule = AclRule::create_from_api(&appstate.pool, &data, &session.user.username)
         .await
@@ -387,7 +417,8 @@ pub(crate) async fn update_acl_rule(
     debug!("User {} updating ACL rule {data:?}", session.user.username);
 
     // validate submitted ACL rule
-    data.validate()?;
+    let mut conn = appstate.pool.acquire().await?;
+    data.validate(&mut conn).await?;
 
     let rule = AclRule::update_from_api(&appstate.pool, id, &data, &session.user.username)
         .await

--- a/crates/defguard_core/src/enterprise/handlers/acl.rs
+++ b/crates/defguard_core/src/enterprise/handlers/acl.rs
@@ -142,27 +142,27 @@ impl EditAclRule {
             // Determine what the selected component aliases collectively contribute.
             // Note: Component-kind aliases always have any_address/any_port/any_protocol = false,
             // so we only check whether they have non-empty arrays.
-            let (alias_has_address, alias_has_port, alias_has_protocol) =
-                if self.aliases.is_empty() {
-                    (false, false, false)
-                } else {
-                    let row = query_as::<_, (Option<bool>, Option<bool>, Option<bool>)>(
-                        "SELECT \
+            let (alias_has_address, alias_has_port, alias_has_protocol) = if self.aliases.is_empty()
+            {
+                (false, false, false)
+            } else {
+                let row = query_as::<_, (Option<bool>, Option<bool>, Option<bool>)>(
+                    "SELECT \
                             bool_or(array_length(addresses, 1) > 0), \
                             bool_or(array_length(ports, 1) > 0), \
                             bool_or(array_length(protocols, 1) > 0) \
                         FROM aclalias WHERE id = ANY($1) AND kind = 'component'::aclalias_kind",
-                    )
-                    .bind(&self.aliases)
-                    .fetch_one(&mut *conn)
-                    .await
-                    .map_err(WebError::from)?;
-                    (
-                        row.0.unwrap_or(false),
-                        row.1.unwrap_or(false),
-                        row.2.unwrap_or(false),
-                    )
-                };
+                )
+                .bind(&self.aliases)
+                .fetch_one(&mut *conn)
+                .await
+                .map_err(WebError::from)?;
+                (
+                    row.0.unwrap_or(false),
+                    row.1.unwrap_or(false),
+                    row.2.unwrap_or(false),
+                )
+            };
 
             if !self.any_address && self.addresses.trim().is_empty() && !alias_has_address {
                 return Err(WebError::BadRequest(

--- a/crates/defguard_core/src/enterprise/handlers/acl.rs
+++ b/crates/defguard_core/src/enterprise/handlers/acl.rs
@@ -151,7 +151,7 @@ impl EditAclRule {
                             bool_or(array_length(addresses, 1) > 0), \
                             bool_or(array_length(ports, 1) > 0), \
                             bool_or(array_length(protocols, 1) > 0) \
-                        FROM aclalias WHERE id = ANY($1)",
+                        FROM aclalias WHERE id = ANY($1) AND kind = 'component'::aclalias_kind",
                     )
                     .bind(&self.aliases)
                     .fetch_one(&mut *conn)

--- a/crates/defguard_core/tests/integration/api/acl/mod.rs
+++ b/crates/defguard_core/tests/integration/api/acl/mod.rs
@@ -197,6 +197,12 @@ fn edit_alias_data_into_api_response(
     }
 }
 
+async fn create_alias(client: &mut TestClient, alias: EditAclAlias) -> i64 {
+    let resp = client.post("/api/v1/acl/alias").json(&alias).send().await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    resp.json::<Value>().await["id"].as_i64().unwrap()
+}
+
 fn edit_destination_data_into_api_response(
     data: EditAclDestination,
     id: Id,

--- a/crates/defguard_core/tests/integration/api/acl/rules.rs
+++ b/crates/defguard_core/tests/integration/api/acl/rules.rs
@@ -474,6 +474,8 @@ async fn test_rule_requires_destination_alias_aware(_: PgPoolOptions, options: P
     // The rule should still be accepted because the range satisfies the address requirement.
     let mut range_only_alias = make_alias();
     range_only_alias.addresses = "10.0.0.1-10.0.0.10".to_string();
+    range_only_alias.ports = String::new();
+    range_only_alias.protocols = Vec::new();
     let range_only_id = create_alias(&mut client, range_only_alias).await;
 
     let mut rule = make_rule();

--- a/crates/defguard_core/tests/integration/api/acl/rules.rs
+++ b/crates/defguard_core/tests/integration/api/acl/rules.rs
@@ -226,6 +226,120 @@ async fn test_rule_requires_destination(_: PgPoolOptions, options: PgConnectOpti
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
 
+/// Mirrors `test_destination_requires_any_or_values` for ACL rules.
+/// When `use_manual_destination_settings = true`, each of address / port / protocol
+/// must independently be satisfied by either a non-empty direct value or its `any_*` flag.
+#[sqlx::test]
+async fn test_rule_requires_any_or_values(_: PgPoolOptions, options: PgConnectOptions) {
+    let pool = setup_pool(options).await;
+
+    let (mut client, _) = make_test_client(pool).await;
+    authenticate_admin(&mut client).await;
+
+    // all fields empty, all any_* false → 400
+    let mut rule = make_rule();
+    rule.use_manual_destination_settings = true;
+    rule.addresses = String::new();
+    rule.ports = String::new();
+    rule.protocols = Vec::new();
+    rule.any_address = false;
+    rule.any_port = false;
+    rule.any_protocol = false;
+    let response = client.post("/api/v1/acl/rule").json(&rule).send().await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    // port and protocol set, address missing, any_address false → 400
+    let mut rule = make_rule();
+    rule.use_manual_destination_settings = true;
+    rule.addresses = String::new();
+    rule.ports = "22, 443".to_string();
+    rule.protocols = vec![6];
+    rule.any_address = false;
+    rule.any_port = false;
+    rule.any_protocol = false;
+    let response = client.post("/api/v1/acl/rule").json(&rule).send().await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    // address and protocol set, port missing, any_port false → 400
+    let mut rule = make_rule();
+    rule.use_manual_destination_settings = true;
+    rule.addresses = "10.0.0.1".to_string();
+    rule.ports = String::new();
+    rule.protocols = vec![6];
+    rule.any_address = false;
+    rule.any_port = false;
+    rule.any_protocol = false;
+    let response = client.post("/api/v1/acl/rule").json(&rule).send().await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    // address and port set, protocol missing, any_protocol false → 400
+    let mut rule = make_rule();
+    rule.use_manual_destination_settings = true;
+    rule.addresses = "10.0.0.1".to_string();
+    rule.ports = "80".to_string();
+    rule.protocols = Vec::new();
+    rule.any_address = false;
+    rule.any_port = false;
+    rule.any_protocol = false;
+    let response = client.post("/api/v1/acl/rule").json(&rule).send().await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    // all three direct fields set → 201; capture for update tests
+    let mut rule = make_rule();
+    rule.use_manual_destination_settings = true;
+    rule.addresses = "10.0.0.1".to_string();
+    rule.ports = "80".to_string();
+    rule.protocols = vec![6];
+    rule.any_address = false;
+    rule.any_port = false;
+    rule.any_protocol = false;
+    let response = client.post("/api/v1/acl/rule").json(&rule).send().await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let created_rule: ApiAclRule = response.json().await;
+
+    // update: all fields empty, all any_* false → 400
+    let mut invalid_update = created_rule.clone();
+    invalid_update.addresses = String::new();
+    invalid_update.ports = String::new();
+    invalid_update.protocols = Vec::new();
+    invalid_update.any_address = false;
+    invalid_update.any_port = false;
+    invalid_update.any_protocol = false;
+    let response = client
+        .put(format!("/api/v1/acl/rule/{}", created_rule.id))
+        .json(&invalid_update)
+        .send()
+        .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    // update: address missing, port+protocol set, any_address false → 400
+    let mut invalid_update = created_rule.clone();
+    invalid_update.addresses = String::new();
+    invalid_update.ports = "5432".to_string();
+    invalid_update.protocols = vec![6];
+    invalid_update.any_address = false;
+    invalid_update.any_port = false;
+    invalid_update.any_protocol = false;
+    let response = client
+        .put(format!("/api/v1/acl/rule/{}", created_rule.id))
+        .json(&invalid_update)
+        .send()
+        .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    // all any_* flags true, fields empty → 201
+    let mut rule = make_rule();
+    rule.use_manual_destination_settings = true;
+    rule.addresses = String::new();
+    rule.ports = String::new();
+    rule.protocols = Vec::new();
+    rule.any_address = true;
+    rule.any_port = true;
+    rule.any_protocol = true;
+    let response = client.post("/api/v1/acl/rule").json(&rule).send().await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+}
+
 /// Tests that alias data is taken into account when validating manual destination settings.
 /// Each of address / port / protocol must be satisfied by either the direct field value,
 /// an `any_*` flag, or by at least one selected component alias providing that field.
@@ -426,10 +540,12 @@ async fn test_empty_strings(_: PgPoolOptions, options: PgConnectOptions) {
     let (mut client, _) = make_test_client(pool).await;
     authenticate_admin(&mut client).await;
 
-    // rule
+    // rule — empty address and port strings are parse-safe; use any_* flags so validation passes
     let mut rule = make_rule();
     rule.addresses = String::new();
     rule.ports = String::new();
+    rule.any_address = true;
+    rule.any_port = true;
 
     let response = client.post("/api/v1/acl/rule").json(&rule).send().await;
     assert_eq!(response.status(), StatusCode::CREATED);

--- a/crates/defguard_core/tests/integration/api/acl/rules.rs
+++ b/crates/defguard_core/tests/integration/api/acl/rules.rs
@@ -226,6 +226,154 @@ async fn test_rule_requires_destination(_: PgPoolOptions, options: PgConnectOpti
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
 
+/// Tests that alias data is taken into account when validating manual destination settings.
+/// Each of address / port / protocol must be satisfied by either the direct field value,
+/// an `any_*` flag, or by at least one selected component alias providing that field.
+#[sqlx::test]
+async fn test_rule_requires_destination_alias_aware(
+    _: PgPoolOptions,
+    options: PgConnectOptions,
+) {
+    let pool = setup_pool(options).await;
+
+    let (mut client, _) = make_test_client(pool).await;
+    authenticate_admin(&mut client).await;
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    // Creates an alias via the API and returns its id.
+    // Aliases created via POST /api/v1/acl/alias always land in Applied state.
+    macro_rules! create_alias {
+        ($alias:expr) => {{
+            let resp = client
+                .post("/api/v1/acl/alias")
+                .json(&$alias)
+                .send()
+                .await;
+            assert_eq!(resp.status(), StatusCode::CREATED);
+            resp.json::<Value>().await["id"].as_i64().unwrap()
+        }};
+    }
+
+    // ── Case A ────────────────────────────────────────────────────────────────
+    // Alias provides address only; port and protocol are still unsatisfied → 400.
+    let mut addr_only_alias = make_alias();
+    addr_only_alias.ports = String::new();
+    addr_only_alias.protocols = Vec::new();
+    let addr_only_id = create_alias!(addr_only_alias);
+
+    let mut rule = make_rule();
+    rule.use_manual_destination_settings = true;
+    rule.addresses = String::new();
+    rule.ports = String::new();
+    rule.protocols = Vec::new();
+    rule.any_address = false;
+    rule.any_port = false;
+    rule.any_protocol = false;
+    rule.aliases = vec![addr_only_id];
+    let response = client.post("/api/v1/acl/rule").json(&rule).send().await;
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "alias with address only should not satisfy port+protocol requirements"
+    );
+
+    // ── Case B ────────────────────────────────────────────────────────────────
+    // Alias provides all three fields; direct rule fields are empty → 201.
+    let full_alias_id = create_alias!(make_alias());
+
+    let mut rule = make_rule();
+    rule.use_manual_destination_settings = true;
+    rule.addresses = String::new();
+    rule.ports = String::new();
+    rule.protocols = Vec::new();
+    rule.any_address = false;
+    rule.any_port = false;
+    rule.any_protocol = false;
+    rule.aliases = vec![full_alias_id];
+    let response = client.post("/api/v1/acl/rule").json(&rule).send().await;
+    assert_eq!(
+        response.status(),
+        StatusCode::CREATED,
+        "alias covering all three fields should satisfy manual destination requirements"
+    );
+
+    // ── Case C ────────────────────────────────────────────────────────────────
+    // Two aliases whose union covers all three fields → 201.
+    // alias_ports: ports only.
+    // alias_addrs_proto: addresses + protocols only.
+    let mut alias_ports = make_alias();
+    alias_ports.addresses = String::new();
+    alias_ports.protocols = Vec::new();
+    let alias_ports_id = create_alias!(alias_ports);
+
+    let mut alias_addrs_proto = make_alias();
+    alias_addrs_proto.ports = String::new();
+    let alias_addrs_proto_id = create_alias!(alias_addrs_proto);
+
+    let mut rule = make_rule();
+    rule.use_manual_destination_settings = true;
+    rule.addresses = String::new();
+    rule.ports = String::new();
+    rule.protocols = Vec::new();
+    rule.any_address = false;
+    rule.any_port = false;
+    rule.any_protocol = false;
+    rule.aliases = vec![alias_ports_id, alias_addrs_proto_id];
+    let response = client.post("/api/v1/acl/rule").json(&rule).send().await;
+    assert_eq!(
+        response.status(),
+        StatusCode::CREATED,
+        "union of two aliases that together cover all fields should satisfy requirements"
+    );
+
+    // ── Case D ────────────────────────────────────────────────────────────────
+    // use_manual_destination_settings = false, no destination aliases, only
+    // component aliases → 400. Component aliases do not count as destinations.
+    let mut rule = make_rule();
+    rule.use_manual_destination_settings = false;
+    rule.aliases = vec![full_alias_id];
+    rule.destinations = Vec::new();
+    let response = client.post("/api/v1/acl/rule").json(&rule).send().await;
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "component aliases must not satisfy the destination-alias requirement"
+    );
+
+    // ── Case E ────────────────────────────────────────────────────────────────
+    // Update an existing rule: clear direct fields, attach a full alias → 200.
+    // First create a valid rule with direct fields.
+    let base_rule = make_rule();
+    let create_resp = client
+        .post("/api/v1/acl/rule")
+        .json(&base_rule)
+        .send()
+        .await;
+    assert_eq!(create_resp.status(), StatusCode::CREATED);
+    let created: ApiAclRule = create_resp.json().await;
+
+    // Now update it: remove direct fields, rely solely on the full alias.
+    let mut updated = created.clone();
+    updated.addresses = String::new();
+    updated.ports = String::new();
+    updated.protocols = Vec::new();
+    updated.any_address = false;
+    updated.any_port = false;
+    updated.any_protocol = false;
+    updated.aliases = vec![full_alias_id];
+    let response = client
+        .put(format!("/api/v1/acl/rule/{}", created.id))
+        .json(&updated)
+        .send()
+        .await;
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "updating a rule to rely on alias fields only should succeed"
+    );
+}
+
 #[sqlx::test]
 async fn test_rule_enterprise(_: PgPoolOptions, options: PgConnectOptions) {
     let pool = setup_pool(options).await;

--- a/crates/defguard_core/tests/integration/api/acl/rules.rs
+++ b/crates/defguard_core/tests/integration/api/acl/rules.rs
@@ -344,10 +344,7 @@ async fn test_rule_requires_any_or_values(_: PgPoolOptions, options: PgConnectOp
 /// Each of address / port / protocol must be satisfied by either the direct field value,
 /// an `any_*` flag, or by at least one selected component alias providing that field.
 #[sqlx::test]
-async fn test_rule_requires_destination_alias_aware(
-    _: PgPoolOptions,
-    options: PgConnectOptions,
-) {
+async fn test_rule_requires_destination_alias_aware(_: PgPoolOptions, options: PgConnectOptions) {
     let pool = setup_pool(options).await;
 
     let (mut client, _) = make_test_client(pool).await;
@@ -359,11 +356,7 @@ async fn test_rule_requires_destination_alias_aware(
     // Aliases created via POST /api/v1/acl/alias always land in Applied state.
     macro_rules! create_alias {
         ($alias:expr) => {{
-            let resp = client
-                .post("/api/v1/acl/alias")
-                .json(&$alias)
-                .send()
-                .await;
+            let resp = client.post("/api/v1/acl/alias").json(&$alias).send().await;
             assert_eq!(resp.status(), StatusCode::CREATED);
             resp.json::<Value>().await["id"].as_i64().unwrap()
         }};

--- a/crates/defguard_core/tests/integration/api/acl/rules.rs
+++ b/crates/defguard_core/tests/integration/api/acl/rules.rs
@@ -350,24 +350,12 @@ async fn test_rule_requires_destination_alias_aware(_: PgPoolOptions, options: P
     let (mut client, _) = make_test_client(pool).await;
     authenticate_admin(&mut client).await;
 
-    // ── helpers ──────────────────────────────────────────────────────────────
-
-    // Creates an alias via the API and returns its id.
-    // Aliases created via POST /api/v1/acl/alias always land in Applied state.
-    macro_rules! create_alias {
-        ($alias:expr) => {{
-            let resp = client.post("/api/v1/acl/alias").json(&$alias).send().await;
-            assert_eq!(resp.status(), StatusCode::CREATED);
-            resp.json::<Value>().await["id"].as_i64().unwrap()
-        }};
-    }
-
     // ── Case A ────────────────────────────────────────────────────────────────
     // Alias provides address only; port and protocol are still unsatisfied → 400.
     let mut addr_only_alias = make_alias();
     addr_only_alias.ports = String::new();
     addr_only_alias.protocols = Vec::new();
-    let addr_only_id = create_alias!(addr_only_alias);
+    let addr_only_id = create_alias(&mut client, addr_only_alias).await;
 
     let mut rule = make_rule();
     rule.use_manual_destination_settings = true;
@@ -387,7 +375,7 @@ async fn test_rule_requires_destination_alias_aware(_: PgPoolOptions, options: P
 
     // ── Case B ────────────────────────────────────────────────────────────────
     // Alias provides all three fields; direct rule fields are empty → 201.
-    let full_alias_id = create_alias!(make_alias());
+    let full_alias_id = create_alias(&mut client, make_alias()).await;
 
     let mut rule = make_rule();
     rule.use_manual_destination_settings = true;
@@ -412,11 +400,11 @@ async fn test_rule_requires_destination_alias_aware(_: PgPoolOptions, options: P
     let mut alias_ports = make_alias();
     alias_ports.addresses = String::new();
     alias_ports.protocols = Vec::new();
-    let alias_ports_id = create_alias!(alias_ports);
+    let alias_ports_id = create_alias(&mut client, alias_ports).await;
 
     let mut alias_addrs_proto = make_alias();
     alias_addrs_proto.ports = String::new();
-    let alias_addrs_proto_id = create_alias!(alias_addrs_proto);
+    let alias_addrs_proto_id = create_alias(&mut client, alias_addrs_proto).await;
 
     let mut rule = make_rule();
     rule.use_manual_destination_settings = true;
@@ -478,6 +466,51 @@ async fn test_rule_requires_destination_alias_aware(_: PgPoolOptions, options: P
         response.status(),
         StatusCode::OK,
         "updating a rule to rely on alias fields only should succeed"
+    );
+
+    // ── Case F ────────────────────────────────────────────────────────────────
+    // Alias whose address is expressed as a range only (e.g. "10.0.0.1-10.0.0.10").
+    // Such ranges are stored in aclaliasdestinationrange, not in the addresses array.
+    // The rule should still be accepted because the range satisfies the address requirement.
+    let mut range_only_alias = make_alias();
+    range_only_alias.addresses = "10.0.0.1-10.0.0.10".to_string();
+    let range_only_id = create_alias(&mut client, range_only_alias).await;
+
+    let mut rule = make_rule();
+    rule.use_manual_destination_settings = true;
+    rule.addresses = String::new();
+    rule.ports = String::new();
+    rule.protocols = Vec::new();
+    rule.any_address = false;
+    rule.any_port = false;
+    rule.any_protocol = false;
+    rule.aliases = vec![range_only_id];
+    let response = client.post("/api/v1/acl/rule").json(&rule).send().await;
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "range-only alias covers address but not port+protocol, so rule should be rejected"
+    );
+
+    // Combine the range-only alias (address) with an alias providing port+protocol → 201.
+    let mut port_proto_alias = make_alias();
+    port_proto_alias.addresses = String::new();
+    let port_proto_id = create_alias(&mut client, port_proto_alias).await;
+
+    let mut rule = make_rule();
+    rule.use_manual_destination_settings = true;
+    rule.addresses = String::new();
+    rule.ports = String::new();
+    rule.protocols = Vec::new();
+    rule.any_address = false;
+    rule.any_port = false;
+    rule.any_protocol = false;
+    rule.aliases = vec![range_only_id, port_proto_id];
+    let response = client.post("/api/v1/acl/rule").json(&rule).send().await;
+    assert_eq!(
+        response.status(),
+        StatusCode::CREATED,
+        "range-only alias + port+protocol alias should together satisfy all requirements"
     );
 }
 

--- a/web/messages/en/components.json
+++ b/web/messages/en/components.json
@@ -85,7 +85,7 @@
   "acl_aliases_search_empty_subtitle": "Try different search.",
   "acl_destination_col_name": "Destination name",
   "acl_destination_col_addresses": "IPv4/IPv6 CIDR ranges or addresses",
-  "acl_destination_any_address": "Any",
+  "acl_destination_any_address": "Any address",
   "acl_destination_any_port": "Any port",
   "acl_destination_any_protocol": "Any protocol",
   "acl_alias_delete_success": "Alias deleted",

--- a/web/src/pages/CEDestinationPage/CEDestinationPage.tsx
+++ b/web/src/pages/CEDestinationPage/CEDestinationPage.tsx
@@ -141,9 +141,6 @@ export const CEDestinationPage = ({ destination, tab }: Props) => {
     },
     onSubmit: async ({ value }) => {
       const toSend = cloneDeep(value);
-      if (toSend.any_address) toSend.addresses = '';
-      if (toSend.any_port) toSend.ports = '';
-      if (toSend.any_protocol) toSend.protocols = new Set();
 
       const payload = {
         ...toSend,

--- a/web/src/pages/CERulePage/CERulePage.tsx
+++ b/web/src/pages/CERulePage/CERulePage.tsx
@@ -485,22 +485,14 @@ const Content = ({ rule: initialRule, tab }: Props) => {
                 message,
               });
             }
-            if (
-              !vals.any_port &&
-              vals.ports.trim().length === 0 &&
-              !aliasHasPort
-            ) {
+            if (!vals.any_port && vals.ports.trim().length === 0 && !aliasHasPort) {
               ctx.addIssue({
                 path: ['ports'],
                 code: 'custom',
                 message,
               });
             }
-            if (
-              !vals.any_protocol &&
-              vals.protocols.size === 0 &&
-              !aliasHasProtocol
-            ) {
+            if (!vals.any_protocol && vals.protocols.size === 0 && !aliasHasProtocol) {
               ctx.addIssue({
                 path: ['protocols'],
                 code: 'custom',

--- a/web/src/pages/CERulePage/CERulePage.tsx
+++ b/web/src/pages/CERulePage/CERulePage.tsx
@@ -462,21 +462,45 @@ const Content = ({ rule: initialRule, tab }: Props) => {
 
           if (vals.use_manual_destination_settings) {
             const message = m.acl_rule_error_manual_destination_required();
-            if (!vals.any_address && vals.addresses.trim().length === 0) {
+            const selectedAliasesList = (aliases ?? []).filter((a) =>
+              vals.aliases.has(a.id),
+            );
+            const aliasHasAddress = selectedAliasesList.some(
+              (a) => a.addresses.trim().length > 0,
+            );
+            const aliasHasPort = selectedAliasesList.some(
+              (a) => a.ports.trim().length > 0,
+            );
+            const aliasHasProtocol = selectedAliasesList.some(
+              (a) => a.protocols.length > 0,
+            );
+            if (
+              !vals.any_address &&
+              vals.addresses.trim().length === 0 &&
+              !aliasHasAddress
+            ) {
               ctx.addIssue({
                 path: ['addresses'],
                 code: 'custom',
                 message,
               });
             }
-            if (!vals.any_port && vals.ports.trim().length === 0) {
+            if (
+              !vals.any_port &&
+              vals.ports.trim().length === 0 &&
+              !aliasHasPort
+            ) {
               ctx.addIssue({
                 path: ['ports'],
                 code: 'custom',
                 message,
               });
             }
-            if (!vals.any_protocol && vals.protocols.size === 0) {
+            if (
+              !vals.any_protocol &&
+              vals.protocols.size === 0 &&
+              !aliasHasProtocol
+            ) {
               ctx.addIssue({
                 path: ['protocols'],
                 code: 'custom',
@@ -499,7 +523,7 @@ const Content = ({ rule: initialRule, tab }: Props) => {
             });
           }
         }),
-    [hasPredefinedDestinations, restrictDevices, restrictGroups, restrictUsers],
+    [hasPredefinedDestinations, restrictDevices, restrictGroups, restrictUsers, aliases],
   );
 
   type FormFields = z.infer<typeof formSchema>;

--- a/web/src/pages/CERulePage/CERulePage.tsx
+++ b/web/src/pages/CERulePage/CERulePage.tsx
@@ -106,11 +106,14 @@ const renderDestinationSelectionItem: SelectionSectionCustomRender<
     {isPresent(option.meta) && (
       <DestinationLabel
         name={option.meta.name}
-        ips={option.meta.addresses}
+        addresses={option.meta.addresses}
         ports={option.meta.ports}
         protocols={option.meta.protocols
           .map((protocol) => AclProtocolName[protocol])
           .join(',')}
+        anyAddress={option.meta.any_address}
+        anyPort={option.meta.any_port}
+        anyProtocol={option.meta.any_protocol}
       />
     )}
   </div>
@@ -709,11 +712,14 @@ const Content = ({ rule: initialRule, tab }: Props) => {
                             <DestinationDismissibleBox
                               key={destination.id}
                               name={destination.name}
-                              ips={destination.addresses}
+                              addresses={destination.addresses}
                               ports={destination.ports}
                               protocols={destination.protocols
                                 .map((p) => AclProtocolName[p])
                                 .join(',')}
+                              anyAddress={destination.any_address}
+                              anyPort={destination.any_port}
+                              anyProtocol={destination.any_protocol}
                               onClick={() => {
                                 const newValue = new Set(field.state.value);
                                 newValue.delete(destination.id);

--- a/web/src/pages/PlaygroundPage/PlaygroundPage.tsx
+++ b/web/src/pages/PlaygroundPage/PlaygroundPage.tsx
@@ -234,7 +234,7 @@ export const PlaygroundPage = () => {
       <Card>
         <DestinationLabel
           name="Scanner_Brother-Warsaw-office"
-          ips="192.168.1.12, 192.168.1.12, 192.168.1.12 192.168.1.129 192.168.1.12,"
+          addresses="192.168.1.12, 192.168.1.12, 192.168.1.12 192.168.1.129 192.168.1.12,"
           ports="All ports"
           protocols="UPD, ICMP"
         />
@@ -246,7 +246,7 @@ export const PlaygroundPage = () => {
             Snackbar.default('Clicked');
           }}
           name="Scanner_Brother-Warsaw-office"
-          ips="192.168.1.12, 192.168.1.12, 192.168.1.12 192.168.1.129 192.168.1.12,"
+          addresses="192.168.1.12, 192.168.1.12, 192.168.1.12 192.168.1.129 192.168.1.12,"
           ports="All ports"
           protocols="UPD, ICMP"
         />

--- a/web/src/pages/RulesPage/RulesTable.tsx
+++ b/web/src/pages/RulesPage/RulesTable.tsx
@@ -202,7 +202,11 @@ export const RulesTable = ({
 
           return (
             <TableCell>
-              {row.any_address ? <span>{m.acl_destination_any_address()}</span> : hasManualAddresses && <span>{manualAddresses}</span>}
+              {row.any_address ? (
+                <span>{m.acl_destination_any_address()}</span>
+              ) : (
+                hasManualAddresses && <span>{manualAddresses}</span>
+              )}
               {row.aliases.map((aliasId) => {
                 const alias = aliases[aliasId];
                 if (!alias) return null;

--- a/web/src/pages/RulesPage/RulesTable.tsx
+++ b/web/src/pages/RulesPage/RulesTable.tsx
@@ -202,7 +202,7 @@ export const RulesTable = ({
 
           return (
             <TableCell>
-              {hasManualAddresses && <span>{manualAddresses}</span>}
+              {row.any_address ? <span>{m.acl_destination_any_address()}</span> : hasManualAddresses && <span>{manualAddresses}</span>}
               {row.aliases.map((aliasId) => {
                 const alias = aliases[aliasId];
                 if (!alias) return null;

--- a/web/src/shared/components/DestinationLabel/DestinationLabel.tsx
+++ b/web/src/shared/components/DestinationLabel/DestinationLabel.tsx
@@ -1,10 +1,10 @@
 import { isPresent } from '../../defguard-ui/utils/isPresent';
 import './style.scss';
+import { m } from '../../../paraglide/messages';
 import { Icon } from '../../defguard-ui/components/Icon';
 import { SizedBox } from '../../defguard-ui/components/SizedBox/SizedBox';
 import { ThemeSpacing } from '../../defguard-ui/types';
 import type { DestinationLabelProps } from './types';
-import { m } from '../../../paraglide/messages';
 
 export const DestinationLabel = ({
   name,
@@ -43,7 +43,9 @@ export const DestinationLabel = ({
         <>
           <Icon icon="ip-suggest" />
           <SizedBox height={1} width={ThemeSpacing.Xs} />
-          <span className="info wrap">{anyAddress ? m.acl_destination_any_address() : addresses}</span>
+          <span className="info wrap">
+            {anyAddress ? m.acl_destination_any_address() : addresses}
+          </span>
         </>
       )}
     </div>

--- a/web/src/shared/components/DestinationLabel/DestinationLabel.tsx
+++ b/web/src/shared/components/DestinationLabel/DestinationLabel.tsx
@@ -4,12 +4,16 @@ import { Icon } from '../../defguard-ui/components/Icon';
 import { SizedBox } from '../../defguard-ui/components/SizedBox/SizedBox';
 import { ThemeSpacing } from '../../defguard-ui/types';
 import type { DestinationLabelProps } from './types';
+import { m } from '../../../paraglide/messages';
 
 export const DestinationLabel = ({
   name,
-  ips,
+  addresses,
   ports,
   protocols,
+  anyAddress,
+  anyPort,
+  anyProtocol,
 }: DestinationLabelProps) => {
   return (
     <div className="destination-label">
@@ -17,29 +21,29 @@ export const DestinationLabel = ({
       <SizedBox height={1} width={ThemeSpacing.Sm} />
       <span className="separator">{`•`}</span>
       <SizedBox height={1} width={ThemeSpacing.Sm} />
-      {isPresent(ports) && (
+      {(isPresent(ports) || anyPort) && (
         <>
           <Icon icon="globe" />
           <SizedBox height={1} width={ThemeSpacing.Xs} />
-          <span className="info">{ports.length > 0 ? ports : `All ports`}</span>
+          <span className="info">{anyPort ? m.acl_destination_any_port() : ports}</span>
           <SizedBox height={1} width={ThemeSpacing.Md} />
         </>
       )}
-      {isPresent(protocols) && (
+      {(isPresent(protocols) || anyProtocol) && (
         <>
           <Icon icon="activity-notes" />
           <SizedBox height={1} width={ThemeSpacing.Xs} />
           <span className="info">
-            {protocols.length > 0 ? protocols : `All protocols`}
+            {anyProtocol ? m.acl_destination_any_protocol() : protocols}
           </span>
           <SizedBox height={1} width={ThemeSpacing.Md} />
         </>
       )}
-      {isPresent(ips) && (
+      {(isPresent(addresses) || anyAddress) && (
         <>
           <Icon icon="ip-suggest" />
           <SizedBox height={1} width={ThemeSpacing.Xs} />
-          <span className="info wrap">{ips.length > 0 ? ips : `Any IP address`}</span>
+          <span className="info wrap">{anyAddress ? m.acl_destination_any_address() : addresses}</span>
         </>
       )}
     </div>

--- a/web/src/shared/components/DestinationLabel/types.ts
+++ b/web/src/shared/components/DestinationLabel/types.ts
@@ -1,6 +1,9 @@
 export interface DestinationLabelProps {
   name: string;
-  protocols?: string;
+  addresses?: string;
   ports?: string;
-  ips?: string;
+  protocols?: string;
+  anyAddress?: boolean;
+  anyPort?: boolean;
+  anyProtocol?: boolean;
 }


### PR DESCRIPTION
Allow creating ACL rules with manually specified destination in which values for specific fields (addresses, ports, protocols) come just from Aliases.

Closes https://github.com/DefGuard/defguard/issues/2508