### PR TITLE
fix MFA configured email subject

### DIFF
--- a/crates/defguard_mail/src/mail.rs
+++ b/crates/defguard_mail/src/mail.rs
@@ -1,7 +1,7 @@
 use std::{str::FromStr, time::Duration};
 
 use defguard_common::db::models::{
-    Settings,
+    MFAMethod, Settings,
     settings::{SmtpEncryption, defaults::WELCOME_EMAIL_SUBJECT},
 };
 use lettre::{
@@ -290,7 +290,9 @@ pub enum MailMessage {
     GatewayReconnect,
     /// MFA activated.
     MFAActivation,
-    MFAConfigured,
+    MFAConfigured {
+        method: MFAMethod,
+    },
     /// MFA code.
     MFACode,
     PasswordReset,
@@ -311,25 +313,26 @@ impl MailMessage {
             }
         }
         match self {
-            Self::Test => "Defguard: Test message",
-            Self::Welcome => WELCOME_EMAIL_SUBJECT,
-            Self::SupportData => "Defguard: Support data",
-            Self::DesktopStart => "Defguard: Desktop client configuration",
-            Self::NewAccount => "Defguard: User enrollment",
-            Self::NewDevice => "Defguard: new device added to your account",
-            Self::NewDeviceLogin => "Defguard: New device logged in to your account",
-            Self::NewDeviceOIDCLogin => "New login to OIDC application",
-            Self::GatewayDisconnect => "Defguard: Gateway disconnected",
-            Self::GatewayReconnect => "Defguard: Gateway reconnected",
-            Self::MFAActivation => "Multi-Factor Authentication activation",
-            Self::MFAConfigured => "Multi-Factor Authentication {method} has been activated",
-            Self::MFACode => "Defguard: Multi-Factor Authentication code for login",
-            Self::PasswordReset => "Defguard: Password reset",
-            Self::PasswordResetDone => "Defguard: Password reset success",
-            Self::UserImportBlocked => "User import blocked",
-            Self::EnrollmentNotification => "Defguard: User enrollment completed",
+            Self::Test => "Defguard: Test message".to_string(),
+            Self::Welcome => WELCOME_EMAIL_SUBJECT.to_string(),
+            Self::SupportData => "Defguard: Support data".to_string(),
+            Self::DesktopStart => "Defguard: Desktop client configuration".to_string(),
+            Self::NewAccount => "Defguard: User enrollment".to_string(),
+            Self::NewDevice => "Defguard: new device added to your account".to_string(),
+            Self::NewDeviceLogin => "Defguard: New device logged in to your account".to_string(),
+            Self::NewDeviceOIDCLogin => "New login to OIDC application".to_string(),
+            Self::GatewayDisconnect => "Defguard: Gateway disconnected".to_string(),
+            Self::GatewayReconnect => "Defguard: Gateway reconnected".to_string(),
+            Self::MFAActivation => "Multi-Factor Authentication activation".to_string(),
+            Self::MFAConfigured { method } => {
+                format!("Multi-Factor Authentication {method} has been activated")
+            }
+            Self::MFACode => "Defguard: Multi-Factor Authentication code for login".to_string(),
+            Self::PasswordReset => "Defguard: Password reset".to_string(),
+            Self::PasswordResetDone => "Defguard: Password reset success".to_string(),
+            Self::UserImportBlocked => "User import blocked".to_string(),
+            Self::EnrollmentNotification => "Defguard: User enrollment completed".to_string(),
         }
-        .to_string()
     }
 
     pub(crate) const fn template_name(&self) -> &str {
@@ -345,7 +348,7 @@ impl MailMessage {
             Self::GatewayDisconnect => "gateway-disconnect",
             Self::GatewayReconnect => "gateway-reconnect",
             Self::MFAActivation => "mfa-activation",
-            Self::MFAConfigured => "mfa-configured",
+            Self::MFAConfigured { method: _ } => "mfa-configured",
             Self::MFACode => "mfa-code",
             Self::PasswordReset => "password-reset",
             Self::PasswordResetDone => "password-reset-done",
@@ -367,7 +370,7 @@ impl MailMessage {
             Self::GatewayDisconnect => include_str!("../templates/gateway-disconnected.mjml"),
             Self::GatewayReconnect => include_str!("../templates/gateway-reconnected.mjml"),
             Self::MFAActivation => include_str!("../templates/mfa-activation.mjml"),
-            Self::MFAConfigured => include_str!("../templates/mfa-configured.mjml"),
+            Self::MFAConfigured { method: _ } => include_str!("../templates/mfa-configured.mjml"),
             Self::MFACode => include_str!("../templates/mfa-code.mjml"),
             Self::PasswordReset => include_str!("../templates/password-reset.mjml"),
             Self::PasswordResetDone => include_str!("../templates/password-reset-done.mjml"),
@@ -391,7 +394,7 @@ impl MailMessage {
             Self::GatewayDisconnect => include_str!("../templates/gateway-disconnected.text"),
             Self::GatewayReconnect => include_str!("../templates/gateway-reconnected.text"),
             Self::MFAActivation => include_str!("../templates/mfa-activation.text"),
-            Self::MFAConfigured => include_str!("../templates/mfa-configured.text"),
+            Self::MFAConfigured { method: _ } => include_str!("../templates/mfa-configured.text"),
             Self::MFACode => include_str!("../templates/mfa-code.text"),
             Self::PasswordReset => include_str!("../templates/password-reset.text"),
             Self::PasswordResetDone => include_str!("../templates/password-reset-done.text"),

--- a/crates/defguard_mail/src/templates.rs
+++ b/crates/defguard_mail/src/templates.rs
@@ -296,7 +296,9 @@ pub async fn mfa_configured_mail(
 
     context.insert("mfa_method", &method);
 
-    let message = MailMessage::MFAConfigured;
+    let message = MailMessage::MFAConfigured {
+        method: method.clone(),
+    };
     message.fill_context(conn, &mut context).await?;
     message.mail(&mut tera, &context, to)?.send_and_forget();
 

--- a/crates/defguard_mail/src/tests.rs
+++ b/crates/defguard_mail/src/tests.rs
@@ -19,7 +19,7 @@ use sqlx::{
 };
 use tera::Context;
 
-use super::{Attachment, templates};
+use super::{Attachment, mail::MailMessage, templates};
 
 #[test]
 fn dg25_8_server_side_template_injection() {
@@ -390,4 +390,37 @@ fn send_enrollment_welcome_mail(_: PgPoolOptions, options: PgConnectOptions) {
 
     // Delay, so send_and_forget() can process the message.
     tokio::time::sleep(Duration::from_secs(2)).await;
+}
+
+#[test]
+fn test_mfa_configured_subject_totp() {
+    // TOTP
+    let subject = MailMessage::MFAConfigured {
+        method: MFAMethod::OneTimePassword,
+    }
+    .subject();
+    assert!(
+        subject.contains("TOTP"),
+        "MFAConfigured subject for OneTimePassword must mention \"TOTP\", got: {subject:?}"
+    );
+
+    // WebAuthn
+    let subject = MailMessage::MFAConfigured {
+        method: MFAMethod::Webauthn,
+    }
+    .subject();
+    assert!(
+        subject.contains("WebAuthn"),
+        "MFAConfigured subject for Webauthn must mention \"WebAuthn\", got: {subject:?}"
+    );
+
+    // email
+    let subject = MailMessage::MFAConfigured {
+        method: MFAMethod::Email,
+    }
+    .subject();
+    assert!(
+        subject.contains("Email"),
+        "MFAConfigured subject for Email must mention \"Email\", got: {subject:?}"
+    );
 }


### PR DESCRIPTION
Actually include MFA method in the subject instead of just a template placeholder.

Closes https://github.com/DefGuard/defguard/issues/2611