### PR TITLE
Respect users-only directory sync target on OIDC login

### DIFF
--- a/crates/defguard_core/src/enterprise/directory_sync/mod.rs
+++ b/crates/defguard_core/src/enterprise/directory_sync/mod.rs
@@ -418,6 +418,18 @@ pub(crate) async fn sync_user_groups_if_configured(
         debug!("Directory sync is disabled, skipping syncing user groups");
         return Ok(());
     }
+    let sync_target = provider
+        .ok_or(DirectorySyncError::NotConfigured)?
+        .directory_sync_target;
+    if !matches!(
+        sync_target,
+        DirectorySyncTarget::All | DirectorySyncTarget::Groups
+    ) {
+        debug!(
+            "Directory sync target is {sync_target}, skipping syncing user groups"
+        );
+        return Ok(());
+    }
 
     match DirectorySyncClient::build(pool).await {
         Ok(mut dir_sync) => {

--- a/crates/defguard_core/src/enterprise/directory_sync/tests.rs
+++ b/crates/defguard_core/src/enterprise/directory_sync/tests.rs
@@ -620,6 +620,36 @@ mod test {
     }
 
     #[sqlx::test]
+    async fn test_sync_user_groups_if_configured_skips_for_users_target(
+        _: PgPoolOptions,
+        options: PgConnectOptions,
+    ) {
+        let pool = setup_pool(options).await;
+
+        let config = DefGuardConfig::new_test_config();
+        let _ = SERVER_CONFIG.set(config.clone());
+        let (wg_tx, _) = broadcast::channel::<GatewayEvent>(16);
+        make_test_provider(
+            &pool,
+            DirectorySyncUserBehavior::Delete,
+            DirectorySyncUserBehavior::Delete,
+            DirectorySyncTarget::Users,
+            false,
+        )
+        .await;
+        let user = make_test_user_and_device("testuser", &pool).await;
+        let user_groups = user.member_of(&pool).await.unwrap();
+        assert_eq!(user_groups.len(), 0);
+
+        sync_user_groups_if_configured(&user, &pool, &wg_tx)
+            .await
+            .unwrap();
+
+        let user_groups = user.member_of(&pool).await.unwrap();
+        assert_eq!(user_groups.len(), 0);
+    }
+
+    #[sqlx::test]
     async fn test_sync_target_all(_: PgPoolOptions, options: PgConnectOptions) {
         let pool = setup_pool(options).await;
 


### PR DESCRIPTION
## Summary
- respect `directory_sync_target=users` during external OIDC login
- stop per-login group synchronization from overriding local group membership
- add a regression test for the users-only target path

## Root cause
Periodic directory sync already respects the configured target and only syncs groups for `all` or `groups`.

However, the external OIDC callback unconditionally called `sync_user_groups_if_configured`, and that helper only checked whether directory sync was enabled, not which target was selected. As a result, logins through an external provider still rewrote group membership even when the provider was configured for `users` only.

## Code evidence
- `crates/defguard_core/src/enterprise/handlers/openid_login.rs`: OIDC callback calls `sync_user_groups_if_configured`
- `crates/defguard_core/src/enterprise/directory_sync/mod.rs`: periodic `do_directory_sync` respects `directory_sync_target`
- this patch makes `sync_user_groups_if_configured` do the same

## Testing
- added regression test for `sync_user_groups_if_configured` with `DirectorySyncTarget::Users`
- local test execution in this environment was blocked by `protoc` toolchain resolution during build, so the patch is code-reviewed but not fully executed here
