### PR TITLE
Make Microsoft directory sync group filter case-insensitive

### DIFF
--- a/crates/defguard_core/src/enterprise/directory_sync/microsoft.rs
+++ b/crates/defguard_core/src/enterprise/directory_sync/microsoft.rs
@@ -228,6 +228,12 @@ impl MicrosoftDirectorySync {
         result
     }
 
+    fn matches_group_filter(&self, display_name: &str) -> bool {
+        self.group_filter
+            .iter()
+            .any(|filter| filter.eq_ignore_ascii_case(display_name))
+    }
+
     async fn query_test_connection(&self) -> Result<(), DirectorySyncError> {
         let access_token = self
             .access_token
@@ -421,7 +427,7 @@ impl MicrosoftDirectorySync {
             );
             combined_response.value.retain(|group| {
                 if let Some(display_name) = &group.display_name {
-                    self.group_filter.contains(display_name)
+                    self.matches_group_filter(display_name)
                 } else {
                     warn!(
                         "Group with ID {} doesn't have a display name set, skipping its synchronization.",
@@ -727,5 +733,19 @@ mod tests {
         assert_eq!(users.len(), 2);
         assert_eq!(users[0].email, "email@email.com".to_string());
         assert_eq!(users[1].email, "email2@email.com".to_string());
+    }
+
+    #[test]
+    fn test_group_filter_match_is_case_insensitive() {
+        let client = MicrosoftDirectorySync::new(
+            "client_id".to_string(),
+            "client_secret".to_string(),
+            "https://login.microsoftonline.com/tenant/v2.0".to_string(),
+            vec!["developers".to_string()],
+        );
+
+        assert!(client.matches_group_filter("Developers"));
+        assert!(client.matches_group_filter("developers"));
+        assert!(!client.matches_group_filter("Infra"));
     }
 }


### PR DESCRIPTION
## Summary
- make Microsoft directory sync group filter matching case-insensitive for per-user group sync
- keep existing behavior for exact group names while accepting common casing differences like `developers` vs `Developers`
- add a regression test for the filter matcher

## Root cause
Microsoft per-user group sync fetches a user's groups from the `memberOf` endpoint and then applies the configured `directory_sync_group_match` filter locally.

That local filter used `Vec::contains(display_name)`, which is case-sensitive. In practice this meant a configured filter like `developers` would not match a directory group named `Developers`, so the filtered set became empty and later sync logic removed the user's existing local groups.

## Code evidence
- `crates/defguard_core/src/enterprise/directory_sync/microsoft.rs`: per-user group sync filtered with exact `contains`
- `crates/defguard_core/src/enterprise/directory_sync/mod.rs`: later sync removes groups not present in the filtered directory set

## Testing
- added a unit test covering case-insensitive filter matching
- local test execution in this environment was blocked later in the build by a missing `protoc` binary required by another crate, so the patch is code-reviewed but not fully executed here
