### PR TITLE
add workflow to tag image as latest on release publish

### DIFF
--- a/.github/workflows/publish-docker-latest.yml
+++ b/.github/workflows/publish-docker-latest.yml
@@ -1,0 +1,54 @@
+name: Publish Docker latest tag
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  tag-docker-latest:
+    # Only run when the release is marked as "Latest release" in the GitHub UI
+    if: github.event.release.make_latest == 'true'
+    runs-on: [self-hosted, Linux]
+
+    env:
+      GHCR_REPO: ghcr.io/defguard/defguard
+
+    permissions:
+      packages: write
+      id-token: write # needed for Cosign keyless signing
+
+    steps:
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.1.0
+
+      - name: Login to GitHub container registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Derive semver tag
+        run: |
+          # Strip the leading 'v' from the release tag name (e.g. v1.2.3 -> 1.2.3)
+          VERSION="${{ github.event.release.tag_name }}"
+          echo "VERSION=${VERSION#v}" >> $GITHUB_ENV
+
+      - name: Tag image as latest
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ env.GHCR_REPO }}:latest \
+            ${{ env.GHCR_REPO }}:${{ env.VERSION }}
+
+      - name: Sign the latest tag with GitHub OIDC Token
+        run: cosign sign --yes ${{ env.GHCR_REPO }}:latest
+
+      - name: Verify image signature
+        run: |
+          cosign verify ${{ env.GHCR_REPO }}:latest \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            --certificate-identity-regexp="https://github.com/DefGuard/defguard" \
+            -o text

--- a/.github/workflows/publish-docker-latest.yml
+++ b/.github/workflows/publish-docker-latest.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.1.0
+        uses: sigstore/cosign-installer@v4.1.1
 
       - name: Login to GitHub container registry
         uses: docker/login-action@v4


### PR DESCRIPTION
Tag docker image as `latest` only if the release itself is marked as latest.

Related to https://github.com/DefGuard/internal/issues/35