### PR TITLE
actually store updated ip and port in migration wizard

### DIFF
--- a/web/src/pages/MigrationWizardPage/steps/MigrationWizardEdgeComponentStep.tsx
+++ b/web/src/pages/MigrationWizardPage/steps/MigrationWizardEdgeComponentStep.tsx
@@ -66,6 +66,10 @@ export const MigrationWizardEdgeComponentStep = () => {
     onSubmit: ({ value }) => {
       useMigrationWizardStore.setState({
         ...value,
+        proxy_url: {
+          domain: value.ip_or_domain,
+          port: value.grpc_port,
+        },
       });
       useMigrationWizardStore.getState().next();
     },


### PR DESCRIPTION
Fix mismatch between storage formats resulting in manually entered ip & port values not being persisted.

Closes https://github.com/DefGuard/defguard/issues/2663