### PR TITLE
add missing non-default table sorting functions

### DIFF
--- a/web/src/pages/EdgesPage/EdgesTable.tsx
+++ b/web/src/pages/EdgesPage/EdgesTable.tsx
@@ -28,6 +28,7 @@ import { isPresent } from '../../shared/defguard-ui/utils/isPresent';
 import { openModal } from '../../shared/hooks/modalControls/modalsSubjects';
 import { ModalName } from '../../shared/hooks/modalControls/modalTypes';
 import { getEdgesQueryOptions, getLicenseInfoQueryOptions } from '../../shared/query';
+import { tableSortingFns } from '../../shared/utils/dateSortingFn';
 import { displayDate } from '../../shared/utils/displayDate';
 import { canUseEnterpriseFeature, licenseActionCheck } from '../../shared/utils/license';
 
@@ -168,6 +169,8 @@ export const EdgesTable = () => {
         minSize: 175,
         header: m.edges_col_last_modified(),
         enableSorting: true,
+        // @ts-expect-error
+        sortingFn: 'dateIso',
         cell: (info) => (
           <TableCell>
             <span>{displayDate(info.getValue())}</span>
@@ -269,6 +272,7 @@ export const EdgesTable = () => {
         },
       ],
     },
+    sortingFns: tableSortingFns,
     columns,
     data: transformedData,
     enableRowSelection: false,

--- a/web/src/pages/LocationsPage/components/GatewaysTable.tsx
+++ b/web/src/pages/LocationsPage/components/GatewaysTable.tsx
@@ -23,6 +23,7 @@ import { Snackbar } from '../../../shared/defguard-ui/providers/snackbar/snackba
 import { openModal } from '../../../shared/hooks/modalControls/modalsSubjects';
 import { ModalName } from '../../../shared/hooks/modalControls/modalTypes';
 import { getGatewaysQueryOptions } from '../../../shared/query';
+import { tableSortingFns } from '../../../shared/utils/dateSortingFn';
 import { displayDate } from '../../../shared/utils/displayDate';
 
 type RowData = GatewayInfo;
@@ -155,6 +156,8 @@ export const GatewaysTable = () => {
         minSize: 175,
         header: m.edges_col_last_modified(),
         enableSorting: true,
+        // @ts-expect-error
+        sortingFn: 'dateIso',
         cell: (info) => (
           <TableCell>
             <span>{displayDate(info.getValue())}</span>
@@ -177,6 +180,7 @@ export const GatewaysTable = () => {
         header: m.gateway_col_used_in_location(),
         size: 220,
         minSize: 200,
+        sortingFn: 'text',
         meta: {
           flex: true,
         },
@@ -263,6 +267,7 @@ export const GatewaysTable = () => {
         },
       ],
     },
+    sortingFns: tableSortingFns,
     columns,
     data: transformedData,
     enableRowSelection: false,

--- a/web/src/pages/LocationsPage/components/LocationsTable.tsx
+++ b/web/src/pages/LocationsPage/components/LocationsTable.tsx
@@ -140,6 +140,7 @@ export const LocationsTable = () => {
       columnHelper.accessor('location_mfa_mode', {
         header: m.location_col_mfa(),
         minSize: 100,
+        sortingFn: 'text',
         cell: (info) => {
           switch (info.getValue()) {
             case 'disabled':

--- a/web/src/pages/NetworkDevicesPage/NetworkDevicesTable.tsx
+++ b/web/src/pages/NetworkDevicesPage/NetworkDevicesTable.tsx
@@ -124,6 +124,7 @@ export const NetworkDevicesTable = ({ networkDevices }: Props) => {
         header: m.form_label_location(),
         size: 225,
         minSize: 175,
+        sortingFn: 'text',
         cell: (info) => (
           <TableCell>
             <span>{info.getValue()}</span>
@@ -143,6 +144,7 @@ export const NetworkDevicesTable = ({ networkDevices }: Props) => {
         header: m.form_label_description(),
         size: 300,
         minSize: 250,
+        sortingFn: 'text',
         cell: (info) => (
           <TableCell>
             <span>{info.getValue()}</span>
@@ -153,6 +155,7 @@ export const NetworkDevicesTable = ({ networkDevices }: Props) => {
         header: m.network_devices_col_added_by(),
         size: 140,
         minSize: 100,
+        sortingFn: 'text',
         cell: (info) => (
           <TableCell>
             <span>{info.getValue()}</span>

--- a/web/src/pages/RulesPage/RulesTable.tsx
+++ b/web/src/pages/RulesPage/RulesTable.tsx
@@ -41,6 +41,7 @@ import { TableTop } from '../../shared/defguard-ui/components/table/TableTop/Tab
 import { Snackbar } from '../../shared/defguard-ui/providers/snackbar/snackbar';
 import { displayDate } from '../../shared/utils/displayDate';
 import { canUseBusinessFeature, licenseActionCheck } from '../../shared/utils/license';
+import { tableSortingFns } from '../../shared/utils/dateSortingFn';
 
 type RowData = AclRule;
 
@@ -245,6 +246,8 @@ export const RulesTable = ({
         minSize: 175,
         header: m.edges_col_last_modified(),
         enableSorting: true,
+        // @ts-expect-error
+        sortingFn: 'dateIso',
         cell: (info) => (
           <TableCell>
             <span>{displayDate(info.getValue())}</span>
@@ -396,6 +399,7 @@ export const RulesTable = ({
         },
       ],
     },
+    sortingFns: tableSortingFns,
     columns,
     data: visibleRules,
     enableRowSelection: false,

--- a/web/src/pages/RulesPage/RulesTable.tsx
+++ b/web/src/pages/RulesPage/RulesTable.tsx
@@ -39,9 +39,9 @@ import { TableCell } from '../../shared/defguard-ui/components/table/TableCell/T
 import { TableEditCell } from '../../shared/defguard-ui/components/table/TableEditCell/TableEditCell';
 import { TableTop } from '../../shared/defguard-ui/components/table/TableTop/TableTop';
 import { Snackbar } from '../../shared/defguard-ui/providers/snackbar/snackbar';
+import { tableSortingFns } from '../../shared/utils/dateSortingFn';
 import { displayDate } from '../../shared/utils/displayDate';
 import { canUseBusinessFeature, licenseActionCheck } from '../../shared/utils/license';
-import { tableSortingFns } from '../../shared/utils/dateSortingFn';
 
 type RowData = AclRule;
 

--- a/web/src/pages/user-profile/UserProfilePage/tabs/ProfileApiTokensTab/components/ProfileApiTokensTable/ProfileApiTokensTable.tsx
+++ b/web/src/pages/user-profile/UserProfilePage/tabs/ProfileApiTokensTab/components/ProfileApiTokensTable/ProfileApiTokensTable.tsx
@@ -31,6 +31,7 @@ export const ProfileApiTokensTable = () => {
     () => [
       columnHelper.accessor('name', {
         enableSorting: true,
+        sortingFn: 'text',
         header: m.profile_api_tokens_col_name(),
         minSize: 300,
         meta: {

--- a/web/src/pages/user-profile/UserProfilePage/tabs/ProfileAuthKeysTab/ProfileAuthKeysTable.tsx
+++ b/web/src/pages/user-profile/UserProfilePage/tabs/ProfileAuthKeysTab/ProfileAuthKeysTable.tsx
@@ -89,6 +89,7 @@ export const ProfileAuthKeysTable = () => {
       columnHelper.accessor('name', {
         header: m.profile_auth_keys_table_col_name(),
         enableSorting: true,
+        sortingFn: 'text',
         minSize: 200,
         size: 200,
         meta: {

--- a/web/src/pages/user-profile/UserProfilePage/tabs/ProfileDevicesTab/components/ProfileDevicesTable/ProfileDevicesTable.tsx
+++ b/web/src/pages/user-profile/UserProfilePage/tabs/ProfileDevicesTab/components/ProfileDevicesTable/ProfileDevicesTable.tsx
@@ -197,6 +197,7 @@ const DevicesTable = ({ rowData }: { rowData: RowData[] }) => {
         size: 300,
         minSize: 300,
         enableSorting: true,
+        sortingFn: 'text',
         meta: {
           flex: true,
         },


### PR DESCRIPTION
By default sortingFn falls back to alphanumeric, leading to unexpected results in some cases.
This sets the correct sorting function for some timestamp and text columns.

Closes https://github.com/DefGuard/defguard/issues/2603