### PR TITLE
update trivyingore with unpatched CVEs

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -36,6 +36,9 @@ jobs:
 
       - name: Create SBOM with Trivy
         uses: aquasecurity/trivy-action@v0.36.0
+        env:
+          TRIVY_SHOW_SUPPRESSED: 1
+          TRIVY_IGNOREFILE: "./.trivyignore.yaml"
         with:
           scan-type: 'fs'
           format: 'spdx-json'
@@ -47,6 +50,9 @@ jobs:
 
       - name: Create Docker image SBOM with Trivy
         uses: aquasecurity/trivy-action@v0.36.0
+        env:
+          TRIVY_SHOW_SUPPRESSED: 1
+          TRIVY_IGNOREFILE: "./.trivyignore.yaml"
         with:
           image-ref: "ghcr.io/defguard/defguard:${{ steps.vars.outputs.VERSION }}"
           scan-type: 'image'
@@ -57,6 +63,9 @@ jobs:
 
       - name: Create security advisory file with Trivy
         uses: aquasecurity/trivy-action@v0.36.0
+        env:
+          TRIVY_SHOW_SUPPRESSED: 1
+          TRIVY_IGNOREFILE: "./.trivyignore.yaml"
         with:
           scan-type: 'fs'
           format: 'json'
@@ -68,6 +77,9 @@ jobs:
 
       - name: Create docker image security advisory file with Trivy
         uses: aquasecurity/trivy-action@v0.36.0
+        env:
+          TRIVY_SHOW_SUPPRESSED: 1
+          TRIVY_IGNOREFILE: "./.trivyignore.yaml"
         with:
           image-ref: "ghcr.io/defguard/defguard:${{ steps.vars.outputs.VERSION }}"
           scan-type: 'image'

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -5,3 +5,9 @@ vulnerabilities:
 - id: GHSA-w5hq-g745-h8pq
   expired_at: 2026-05-23
   statement: "Waiting for upstream patch in paraglide"
+- id: CVE-2026-29111
+  expired_at: 2026-05-31
+  statement: "No fixed version available in debian:13-slim - waiting for Debian to backport systemd patch"
+- id: CVE-2025-69720
+  expired_at: 2026-05-31
+  statement: "No fixed version available in debian:13-slim - waiting for Debian to release ncurses patch"


### PR DESCRIPTION
Add entries for vulnerabilities which are unpatched in the upstream Debian image with no fixed version available yet.