### PR TITLE
decouple business logic modules in defguard_core from WebError

### DIFF
--- a/crates/defguard_core/src/cert_settings.rs
+++ b/crates/defguard_core/src/cert_settings.rs
@@ -8,17 +8,41 @@ use defguard_common::db::models::{
 };
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
+use thiserror::Error;
 use utoipa::ToSchema;
 
-use crate::error::WebError;
+/// Errors arising from certificate settings operations.
+#[derive(Debug, Error)]
+pub enum CertSettingsError {
+    #[error("Invalid certificate: {0}")]
+    InvalidCert(String),
+    #[error("Certificate error: {0}")]
+    Cert(#[from] defguard_certs::CertificateError),
+    #[error("URL parse error: {0}")]
+    Url(String),
+    #[error("Database error: {0}")]
+    Db(#[from] sqlx::Error),
+    #[error("Settings error: {0}")]
+    Settings(String),
+    #[error("Not found: {0}")]
+    NotFound(String),
+}
+
+impl From<defguard_common::db::models::settings::SettingsSaveError> for CertSettingsError {
+    fn from(err: defguard_common::db::models::settings::SettingsSaveError) -> Self {
+        CertSettingsError::Settings(err.to_string())
+    }
+}
 
 /// Parses an uploaded certificate, validates its key pair, and rejects invalid validity windows.
-async fn parse_cert(cert_pem: &str, key_pem: &str) -> Result<CertificateInfo, WebError> {
+async fn parse_cert(cert_pem: &str, key_pem: &str) -> Result<CertificateInfo, CertSettingsError> {
     let _ = rustls::crypto::ring::default_provider().install_default();
 
     RustlsConfig::from_pem(cert_pem.as_bytes().to_vec(), key_pem.as_bytes().to_vec())
         .await
-        .map_err(|_| WebError::BadRequest("Invalid certificate or private key PEM".to_owned()))?;
+        .map_err(|_| {
+            CertSettingsError::InvalidCert("Invalid certificate or private key PEM".to_owned())
+        })?;
 
     let cert_der = parse_pem_certificate(cert_pem)?;
     let info = CertificateInfo::from_der(cert_der.as_ref())?;
@@ -27,17 +51,19 @@ async fn parse_cert(cert_pem: &str, key_pem: &str) -> Result<CertificateInfo, We
     let now = chrono::Utc::now().naive_utc();
 
     if info.not_after <= info.not_before {
-        return Err(WebError::BadRequest(
+        return Err(CertSettingsError::InvalidCert(
             "Certificate validity period is invalid".to_owned(),
         ));
     }
 
     if info.not_after <= now {
-        return Err(WebError::BadRequest("Certificate has expired".to_owned()));
+        return Err(CertSettingsError::InvalidCert(
+            "Certificate has expired".to_owned(),
+        ));
     }
 
     if info.not_before > now {
-        return Err(WebError::BadRequest(
+        return Err(CertSettingsError::InvalidCert(
             "Certificate is not valid yet".to_owned(),
         ));
     }
@@ -45,14 +71,14 @@ async fn parse_cert(cert_pem: &str, key_pem: &str) -> Result<CertificateInfo, We
     Ok(info)
 }
 
-/// Extract a non-empty hostname from `url`, returning a [`WebError`] on failure.
-fn extract_hostname(url: &str, label: &str) -> Result<String, WebError> {
+/// Extract a non-empty hostname from `url`, returning a [`CertSettingsError`] on failure.
+fn extract_hostname(url: &str, label: &str) -> Result<String, CertSettingsError> {
     reqwest::Url::parse(url)
-        .map_err(|e| WebError::BadRequest(format!("Invalid {label}: {e}")))?
+        .map_err(|e| CertSettingsError::Url(format!("Invalid {label}: {e}")))?
         .host_str()
         .filter(|h| !h.is_empty())
         .map(str::to_owned)
-        .ok_or_else(|| WebError::BadRequest(format!("{label} has no hostname")))
+        .ok_or_else(|| CertSettingsError::Url(format!("{label} has no hostname")))
 }
 
 /// SSL configuration type for Defguard's internal (core) web server.
@@ -118,7 +144,7 @@ pub async fn apply_internal_url_settings(
     pool: &PgPool,
     defguard_url: &str,
     config: InternalUrlSettingsConfig,
-) -> Result<Option<CertInfoResponse>, WebError> {
+) -> Result<Option<CertInfoResponse>, CertSettingsError> {
     debug!(
         "Internal URL certificate settings received: defguard_url={}, ssl_type={:?}",
         defguard_url, config.ssl_type,
@@ -136,7 +162,7 @@ pub async fn apply_internal_url_settings(
 
     let mut certs = Certificates::get_or_default(&mut *transaction)
         .await
-        .map_err(WebError::from)?;
+        .map_err(CertSettingsError::from)?;
 
     let cert_info = match config.ssl_type {
         InternalSslType::None => {
@@ -147,7 +173,7 @@ pub async fn apply_internal_url_settings(
             certs
                 .save(&mut *transaction)
                 .await
-                .map_err(WebError::from)?;
+                .map_err(CertSettingsError::from)?;
             None
         }
         InternalSslType::DefguardCa => {
@@ -174,7 +200,7 @@ pub async fn apply_internal_url_settings(
             certs
                 .save(&mut *transaction)
                 .await
-                .map_err(WebError::from)?;
+                .map_err(CertSettingsError::from)?;
 
             Some(CertInfoResponse {
                 common_name: info.subject_common_name,
@@ -185,10 +211,10 @@ pub async fn apply_internal_url_settings(
         }
         InternalSslType::OwnCert => {
             let cert_pem_str = config.cert_pem.ok_or_else(|| {
-                WebError::BadRequest("cert_pem is required for own_cert".to_owned())
+                CertSettingsError::InvalidCert("cert_pem is required for own_cert".to_owned())
             })?;
             let key_pem_str = config.key_pem.ok_or_else(|| {
-                WebError::BadRequest("key_pem is required for own_cert".to_owned())
+                CertSettingsError::InvalidCert("key_pem is required for own_cert".to_owned())
             })?;
 
             let info = parse_cert(&cert_pem_str, &key_pem_str).await?;
@@ -202,7 +228,7 @@ pub async fn apply_internal_url_settings(
             certs
                 .save(&mut *transaction)
                 .await
-                .map_err(WebError::from)?;
+                .map_err(CertSettingsError::from)?;
 
             Some(CertInfoResponse {
                 common_name: info.subject_common_name,
@@ -223,7 +249,7 @@ pub async fn apply_external_url_settings(
     pool: &PgPool,
     public_proxy_url: &str,
     config: ExternalUrlSettingsConfig,
-) -> Result<Option<CertInfoResponse>, WebError> {
+) -> Result<Option<CertInfoResponse>, CertSettingsError> {
     debug!(
         "External URL certificate settings received: public_proxy_url={}, ssl_type={:?}",
         public_proxy_url, config.ssl_type,
@@ -232,7 +258,7 @@ pub async fn apply_external_url_settings(
     let mut transaction = pool.begin().await?;
     let mut certs = Certificates::get_or_default(&mut *transaction)
         .await
-        .map_err(WebError::from)?;
+        .map_err(CertSettingsError::from)?;
 
     // Modify url schema if necessary
     let mut settings = Settings::get_current_settings();
@@ -247,7 +273,7 @@ pub async fn apply_external_url_settings(
         ExternalSslType::DefguardCa | ExternalSslType::LetsEncrypt => {
             let url = public_proxy_url.trim();
             if url.is_empty() {
-                return Err(WebError::BadRequest(
+                return Err(CertSettingsError::Url(
                     "Public proxy URL is not configured".to_owned(),
                 ));
             }
@@ -267,7 +293,7 @@ pub async fn apply_external_url_settings(
             certs
                 .save(&mut *transaction)
                 .await
-                .map_err(WebError::from)?;
+                .map_err(CertSettingsError::from)?;
             None
         }
         ExternalSslType::LetsEncrypt => {
@@ -300,7 +326,7 @@ pub async fn apply_external_url_settings(
             certs
                 .save(&mut *transaction)
                 .await
-                .map_err(WebError::from)?;
+                .map_err(CertSettingsError::from)?;
 
             Some(CertInfoResponse {
                 common_name: info.subject_common_name,
@@ -311,10 +337,10 @@ pub async fn apply_external_url_settings(
         }
         ExternalSslType::OwnCert => {
             let cert_pem_str = config.cert_pem.ok_or_else(|| {
-                WebError::BadRequest("cert_pem is required for own_cert".to_owned())
+                CertSettingsError::InvalidCert("cert_pem is required for own_cert".to_owned())
             })?;
             let key_pem_str = config.key_pem.ok_or_else(|| {
-                WebError::BadRequest("key_pem is required for own_cert".to_owned())
+                CertSettingsError::InvalidCert("key_pem is required for own_cert".to_owned())
             })?;
 
             let info = parse_cert(&cert_pem_str, &key_pem_str).await?;
@@ -329,7 +355,7 @@ pub async fn apply_external_url_settings(
             certs
                 .save(&mut *transaction)
                 .await
-                .map_err(WebError::from)?;
+                .map_err(CertSettingsError::from)?;
 
             Some(CertInfoResponse {
                 common_name: info.subject_common_name,
@@ -348,13 +374,13 @@ pub async fn apply_external_url_settings(
 /// Returns `(cert_pem, key_pem, expiry)` on success.
 pub(crate) async fn refresh_core_self_signed_cert(
     pool: &PgPool,
-) -> Result<(String, String, NaiveDateTime), WebError> {
+) -> Result<(String, String, NaiveDateTime), CertSettingsError> {
     let settings = Settings::get_current_settings();
     let hostname = extract_hostname(&settings.defguard_url, "defguard URL")?;
 
     let mut certs = Certificates::get_or_default(pool)
         .await
-        .map_err(WebError::from)?;
+        .map_err(CertSettingsError::from)?;
 
     let ca = certs.certificate_authority()?;
     let key_pair = generate_key_pair()?;
@@ -373,7 +399,7 @@ pub(crate) async fn refresh_core_self_signed_cert(
     certs.core_http_cert_pem = Some(cert_pem.clone());
     certs.core_http_cert_key_pem = Some(key_pem.clone());
     certs.core_http_cert_expiry = Some(expiry);
-    certs.save(pool).await.map_err(WebError::from)?;
+    certs.save(pool).await.map_err(CertSettingsError::from)?;
 
     Ok((cert_pem, key_pem, expiry))
 }
@@ -382,13 +408,13 @@ pub(crate) async fn refresh_core_self_signed_cert(
 /// Returns `(cert_pem, key_pem, expiry)` on success.
 pub(crate) async fn refresh_proxy_self_signed_cert(
     pool: &PgPool,
-) -> Result<(String, String, NaiveDateTime), WebError> {
+) -> Result<(String, String, NaiveDateTime), CertSettingsError> {
     let settings = Settings::get_current_settings();
     let hostname = extract_hostname(&settings.public_proxy_url, "public proxy URL")?;
 
     let mut certs = Certificates::get_or_default(pool)
         .await
-        .map_err(WebError::from)?;
+        .map_err(CertSettingsError::from)?;
 
     let ca = certs.certificate_authority()?;
     let key_pair = generate_key_pair()?;
@@ -408,7 +434,7 @@ pub(crate) async fn refresh_proxy_self_signed_cert(
     certs.proxy_http_cert_pem = Some(cert_pem.clone());
     certs.proxy_http_cert_key_pem = Some(key_pem.clone());
     certs.proxy_http_cert_expiry = Some(expiry);
-    certs.save(pool).await.map_err(WebError::from)?;
+    certs.save(pool).await.map_err(CertSettingsError::from)?;
 
     Ok((cert_pem, key_pem, expiry))
 }
@@ -426,8 +452,8 @@ mod tests {
     };
     use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 
+    use super::CertSettingsError;
     use super::{extract_hostname, refresh_core_self_signed_cert, refresh_proxy_self_signed_cert};
-    use crate::error::WebError;
 
     fn make_ca() -> CertificateAuthority<'static> {
         CertificateAuthority::new("Test CA", "test@example.com", 365).expect("failed to create CA")
@@ -471,7 +497,7 @@ mod tests {
     #[test]
     fn extract_hostname_invalid_url() {
         let err = extract_hostname("not-a-url", "defguard URL").unwrap_err();
-        assert!(matches!(err, WebError::BadRequest(_)));
+        assert!(matches!(err, CertSettingsError::Url(_)));
         let msg = err.to_string();
         assert!(
             msg.contains("Invalid defguard URL"),
@@ -482,7 +508,7 @@ mod tests {
     #[test]
     fn extract_hostname_missing_host() {
         let err = extract_hostname("mailto:test@example.com", "public proxy URL").unwrap_err();
-        assert!(matches!(err, WebError::BadRequest(_)));
+        assert!(matches!(err, CertSettingsError::Url(_)));
         let msg = err.to_string();
         assert!(
             msg.contains("public proxy URL has no hostname"),
@@ -493,7 +519,7 @@ mod tests {
     #[test]
     fn extract_hostname_empty_string() {
         let err = extract_hostname("", "defguard URL").unwrap_err();
-        assert!(matches!(err, WebError::BadRequest(_)));
+        assert!(matches!(err, CertSettingsError::Url(_)));
         let msg = err.to_string();
         assert!(
             msg.contains("Invalid defguard URL"),

--- a/crates/defguard_core/src/cert_settings.rs
+++ b/crates/defguard_core/src/cert_settings.rs
@@ -1,10 +1,12 @@
 use axum_server::tls_rustls::RustlsConfig;
-use chrono::NaiveDateTime;
+use chrono::{NaiveDateTime, Utc};
 use defguard_certs::{
-    CertificateInfo, Csr, DnType, PemLabel, der_to_pem, generate_key_pair, parse_pem_certificate,
+    CertificateError, CertificateInfo, Csr, DnType, PemLabel, der_to_pem, generate_key_pair,
+    parse_pem_certificate,
 };
 use defguard_common::db::models::{
-    Certificates, CoreCertSource, ProxyCertSource, Settings, settings::update_current_settings,
+    Certificates, CoreCertSource, ProxyCertSource, Settings,
+    settings::{SettingsSaveError, update_current_settings},
 };
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
@@ -17,21 +19,15 @@ pub enum CertSettingsError {
     #[error("Invalid certificate: {0}")]
     InvalidCert(String),
     #[error("Certificate error: {0}")]
-    Cert(#[from] defguard_certs::CertificateError),
+    Cert(#[from] CertificateError),
     #[error("URL parse error: {0}")]
     Url(String),
     #[error("Database error: {0}")]
     Db(#[from] sqlx::Error),
     #[error("Settings error: {0}")]
-    Settings(String),
+    Settings(#[from] SettingsSaveError),
     #[error("Not found: {0}")]
     NotFound(String),
-}
-
-impl From<defguard_common::db::models::settings::SettingsSaveError> for CertSettingsError {
-    fn from(err: defguard_common::db::models::settings::SettingsSaveError) -> Self {
-        CertSettingsError::Settings(err.to_string())
-    }
 }
 
 /// Parses an uploaded certificate, validates its key pair, and rejects invalid validity windows.
@@ -48,7 +44,7 @@ async fn parse_cert(cert_pem: &str, key_pem: &str) -> Result<CertificateInfo, Ce
     let info = CertificateInfo::from_der(cert_der.as_ref())?;
 
     // Validate cert dates
-    let now = chrono::Utc::now().naive_utc();
+    let now = Utc::now().naive_utc();
 
     if info.not_after <= info.not_before {
         return Err(CertSettingsError::InvalidCert(

--- a/crates/defguard_core/src/error.rs
+++ b/crates/defguard_core/src/error.rs
@@ -22,7 +22,7 @@ use crate::{
         firewall::FirewallError, license::LicenseError,
     },
     events::ApiEvent,
-    handlers::{openid_flow::OidcFlowError, user::UserPasswordError},
+    handlers::{openid_flow::OidcFlowError, user::ValidationError},
     location_management::LocationManagementError,
     user_management::UserManagementError,
 };
@@ -232,12 +232,23 @@ impl From<LocationManagementError> for WebError {
 
 impl From<UserManagementError> for WebError {
     fn from(err: UserManagementError) -> Self {
-        error!("{err}");
         match err {
-            UserManagementError::Db(e) => WebError::DbError(e.to_string()),
-            UserManagementError::Model(e) => WebError::ModelError(e.to_string()),
-            UserManagementError::Network(e) => WebError::from(e),
-            UserManagementError::Firewall(e) => WebError::FirewallError(e),
+            UserManagementError::Db(e) => {
+                error!("Database error: {e}");
+                WebError::DbError(e.to_string())
+            }
+            UserManagementError::Model(e) => {
+                error!("Model error: {e}");
+                WebError::ModelError(e.to_string())
+            }
+            UserManagementError::Network(e) => {
+                error!("WireGuard network error: {e}");
+                WebError::from(e)
+            }
+            UserManagementError::Firewall(e) => {
+                error!("Firewall error: {e}");
+                WebError::FirewallError(e)
+            }
         }
     }
 }
@@ -256,8 +267,8 @@ impl From<CertSettingsError> for WebError {
     }
 }
 
-impl From<UserPasswordError> for WebError {
-    fn from(err: UserPasswordError) -> Self {
+impl From<ValidationError> for WebError {
+    fn from(err: ValidationError) -> Self {
         WebError::BadRequest(err.0)
     }
 }

--- a/crates/defguard_core/src/error.rs
+++ b/crates/defguard_core/src/error.rs
@@ -15,13 +15,16 @@ use utoipa::ToSchema;
 
 use crate::{
     auth::failed_login::FailedLoginError,
+    cert_settings::CertSettingsError,
     db::models::enrollment::TokenError,
     enterprise::{
         activity_log_stream::error::ActivityLogStreamError, db::models::acl::AclError,
         firewall::FirewallError, license::LicenseError,
     },
     events::ApiEvent,
+    handlers::{openid_flow::OidcFlowError, user::UserPasswordError},
     location_management::LocationManagementError,
+    user_management::UserManagementError,
 };
 
 /// Represents kinds of error that occurred
@@ -223,6 +226,50 @@ impl From<LocationManagementError> for WebError {
                 wireguard_network_error.into()
             }
             LocationManagementError::ModelError(model_error) => model_error.into(),
+        }
+    }
+}
+
+impl From<UserManagementError> for WebError {
+    fn from(err: UserManagementError) -> Self {
+        error!("{err}");
+        match err {
+            UserManagementError::Db(e) => WebError::DbError(e.to_string()),
+            UserManagementError::Model(e) => WebError::ModelError(e.to_string()),
+            UserManagementError::Network(e) => WebError::from(e),
+            UserManagementError::Firewall(e) => WebError::FirewallError(e),
+        }
+    }
+}
+
+impl From<CertSettingsError> for WebError {
+    fn from(err: CertSettingsError) -> Self {
+        error!("{err}");
+        match err {
+            CertSettingsError::InvalidCert(msg) => WebError::BadRequest(msg),
+            CertSettingsError::Cert(e) => WebError::CertificateError(e),
+            CertSettingsError::Url(e) => WebError::BadRequest(e),
+            CertSettingsError::Settings(e) => WebError::BadRequest(e),
+            CertSettingsError::Db(e) => WebError::DbError(e.to_string()),
+            CertSettingsError::NotFound(msg) => WebError::ObjectNotFound(msg),
+        }
+    }
+}
+
+impl From<UserPasswordError> for WebError {
+    fn from(err: UserPasswordError) -> Self {
+        WebError::BadRequest(err.0)
+    }
+}
+
+impl From<OidcFlowError> for WebError {
+    fn from(err: OidcFlowError) -> Self {
+        match err {
+            OidcFlowError::SigningKey(_msg) => WebError::Http(StatusCode::INTERNAL_SERVER_ERROR),
+            OidcFlowError::InvalidRedirectUri => WebError::Http(StatusCode::BAD_REQUEST),
+            OidcFlowError::Internal(_msg) => WebError::Http(StatusCode::INTERNAL_SERVER_ERROR),
+            OidcFlowError::Db(e) => WebError::DbError(e.to_string()),
+            OidcFlowError::Url(_e) => WebError::Http(StatusCode::INTERNAL_SERVER_ERROR),
         }
     }
 }

--- a/crates/defguard_core/src/error.rs
+++ b/crates/defguard_core/src/error.rs
@@ -260,7 +260,7 @@ impl From<CertSettingsError> for WebError {
             CertSettingsError::InvalidCert(msg) => WebError::BadRequest(msg),
             CertSettingsError::Cert(e) => WebError::CertificateError(e),
             CertSettingsError::Url(e) => WebError::BadRequest(e),
-            CertSettingsError::Settings(e) => WebError::BadRequest(e),
+            CertSettingsError::Settings(e) => WebError::BadRequest(e.to_string()),
             CertSettingsError::Db(e) => WebError::DbError(e.to_string()),
             CertSettingsError::NotFound(msg) => WebError::ObjectNotFound(msg),
         }

--- a/crates/defguard_core/src/handlers/mail.rs
+++ b/crates/defguard_core/src/handlers/mail.rs
@@ -11,6 +11,7 @@ use defguard_mail::{
 use serde_json::json;
 use sqlx::query_scalar;
 use tera::Context;
+use thiserror::Error;
 use tokio::fs::read_to_string;
 
 use super::{ApiResponse, ApiResult};
@@ -18,7 +19,6 @@ use crate::{
     PgPool,
     appstate::AppState,
     auth::{AdminRole, SessionInfo},
-    error::WebError,
     server_config,
     support::dump_config,
 };
@@ -128,12 +128,21 @@ pub async fn send_support_data(
     })
 }
 
+/// Errors arising from automated mail operations.
+#[derive(Debug, Error)]
+pub enum MailError {
+    #[error("Database error: {0}")]
+    Db(#[from] sqlx::Error),
+    #[error("Template error: {0}")]
+    Template(#[from] defguard_mail::templates::TemplateError),
+}
+
 pub async fn send_gateway_disconnected_email(
     gateway_name: String,
     network_name: String,
     gateway_adress: &str,
     pool: &PgPool,
-) -> Result<(), WebError> {
+) -> Result<(), MailError> {
     debug!("Sending Gateway disconnected mail to all admin users");
     let mut conn = pool.begin().await?;
     let admin_users = User::find_admins(&mut *conn).await?;
@@ -156,7 +165,7 @@ pub async fn send_gateway_reconnected_email(
     network_name: String,
     gateway_adress: &str,
     pool: &PgPool,
-) -> Result<(), WebError> {
+) -> Result<(), MailError> {
     debug!("Sending Gateway reconnect mail to all admin users");
     let mut conn = pool.begin().await?;
     let admin_users = User::find_admins(&mut *conn).await?;
@@ -186,7 +195,7 @@ pub async fn get_admins_emails(pool: &PgPool) -> Result<Vec<String>, sqlx::Error
     .await
 }
 
-pub async fn send_user_import_blocked_email(pool: &PgPool) -> Result<(), WebError> {
+pub async fn send_user_import_blocked_email(pool: &PgPool) -> Result<(), MailError> {
     debug!("Sending blocked user import mail to all admin users");
     let admin_emails = get_admins_emails(pool).await?;
     let mut conn = pool.acquire().await?;

--- a/crates/defguard_core/src/handlers/openid_flow.rs
+++ b/crates/defguard_core/src/handlers/openid_flow.rs
@@ -43,6 +43,7 @@ use serde::{
     ser::{Serialize, Serializer},
 };
 use sqlx::PgPool;
+use thiserror::Error;
 
 use super::{ApiResponse, ApiResult, SESSION_COOKIE_NAME};
 use crate::{
@@ -114,8 +115,23 @@ pub type DefguardIdTokenFields = IdTokenFields<
 pub type DefguardTokenResponse = StandardTokenResponse<DefguardIdTokenFields, CoreTokenType>;
 pub struct OAuth2ClientExtractor(Option<OAuth2Client<Id>>);
 
+/// Errors arising from OpenID Connect flow helpers.
+#[derive(Debug, Error)]
+pub(crate) enum OidcFlowError {
+    #[error("signing key unavailable: {0}")]
+    SigningKey(String),
+    #[error("invalid redirect URI")]
+    InvalidRedirectUri,
+    #[error("internal error: {0}")]
+    Internal(String),
+    #[error("url error: {0}")]
+    Url(String),
+    #[error("database error: {0}")]
+    Db(#[from] sqlx::Error),
+}
+
 #[allow(deprecated)]
-fn runtime_openid_key() -> Result<Option<CoreRsaPrivateSigningKey>, WebError> {
+fn runtime_openid_key() -> Result<Option<CoreRsaPrivateSigningKey>, OidcFlowError> {
     if server_config().hmac {
         Ok(None)
     } else {
@@ -124,7 +140,7 @@ fn runtime_openid_key() -> Result<Option<CoreRsaPrivateSigningKey>, WebError> {
             .map(Some)
             .map_err(|err| {
                 error!("OpenID signing key is unavailable: {err}");
-                WebError::Http(StatusCode::INTERNAL_SERVER_ERROR)
+                OidcFlowError::SigningKey(err.to_string())
             })
     }
 }
@@ -367,9 +383,8 @@ async fn generate_auth_code_redirect(
     appstate: AppState,
     data: AuthenticationRequest,
     user_id: Id,
-) -> Result<String, WebError> {
-    let mut url =
-        Url::parse(&data.redirect_uri).map_err(|_| WebError::Http(StatusCode::BAD_REQUEST))?;
+) -> Result<String, OidcFlowError> {
+    let mut url = Url::parse(&data.redirect_uri).map_err(|_| OidcFlowError::InvalidRedirectUri)?;
     let auth_code = AuthCode::new(
         user_id,
         data.client_id,
@@ -411,13 +426,13 @@ fn redirect_to<T: AsRef<str>>(
 fn login_redirect(
     data: &AuthenticationRequest,
     private_cookies: PrivateCookieJar,
-) -> Result<(StatusCode, HeaderMap, PrivateCookieJar), WebError> {
+) -> Result<(StatusCode, HeaderMap, PrivateCookieJar), OidcFlowError> {
     let config = server_config();
     let settings = Settings::get_current_settings();
-    let url = Settings::url()?;
+    let url = Settings::url().map_err(|e| OidcFlowError::Url(e.to_string()))?;
     let base_url = url.join("/api/v1/oauth/authorize").map_err(|err| {
         error!("Failed to prepare redirect URL: {err}");
-        WebError::Http(StatusCode::INTERNAL_SERVER_ERROR)
+        OidcFlowError::Internal(err.to_string())
     })?;
     let mut cookie = Cookie::build((
         SIGN_IN_COOKIE_NAME,
@@ -428,9 +443,12 @@ fn login_redirect(
     ))
     .path("/")
     .secure(
-        config
-            .cookie_insecure
-            .map_or(settings.cookie_secure()?, |insecure| !insecure),
+        config.cookie_insecure.map_or(
+            settings
+                .cookie_secure()
+                .map_err(|e| OidcFlowError::Url(e.to_string()))?,
+            |insecure| !insecure,
+        ),
     )
     .same_site(SameSite::Lax)
     .http_only(true)
@@ -510,7 +528,8 @@ pub async fn authorization(
                                             "MFA not verified for user id {}, redirecting to login",
                                             session.user_id
                                         );
-                                        return login_redirect(&data, private_cookies);
+                                        return login_redirect(&data, private_cookies)
+                                            .map_err(WebError::from);
                                     }
 
                                     // If session is present check if app is in user authorized
@@ -588,7 +607,7 @@ pub async fn authorization(
     }
 
     let mut url = if is_redirect_allowed {
-        Url::parse(&data.redirect_uri).map_err(|_| WebError::Http(StatusCode::BAD_REQUEST))?
+        Url::parse(&data.redirect_uri).map_err(|_| OidcFlowError::InvalidRedirectUri)?
     } else {
         // Don't allow open redirects (DG25-17)
         Settings::url()?
@@ -612,7 +631,7 @@ pub struct GroupClaims {
 
 impl AdditionalClaims for GroupClaims {}
 
-async fn get_group_claims(pool: &PgPool, user: &User<Id>) -> Result<GroupClaims, WebError> {
+async fn get_group_claims(pool: &PgPool, user: &User<Id>) -> Result<GroupClaims, OidcFlowError> {
     let groups = user.member_of_names(pool).await?;
     Ok(GroupClaims {
         groups: Some(groups),
@@ -1083,7 +1102,7 @@ pub async fn userinfo(State(appstate): State<AppState>, headers: HeaderMap) -> A
 
 // Must be served under /.well-known/openid-configuration
 pub async fn openid_configuration() -> ApiResult {
-    let url = Settings::url()?;
+    let url = Settings::url().map_err(|e| OidcFlowError::Url(e.to_string()))?;
     let provider_metadata = CoreProviderMetadata::new(
         IssuerUrl::from_url(url.clone()),
         AuthUrl::from_url(url.join("api/v1/oauth/authorize")?),

--- a/crates/defguard_core/src/handlers/user.rs
+++ b/crates/defguard_core/src/handlers/user.rs
@@ -66,13 +66,13 @@ pub(crate) const MAX_USERNAME_CHARS: usize = 64;
 
 #[derive(Debug, Error)]
 #[error("{0}")]
-pub struct UserPasswordError(pub String);
+pub struct ValidationError(pub String);
 
-pub fn check_username(username: &str) -> Result<(), UserPasswordError> {
+pub fn check_username(username: &str) -> Result<(), ValidationError> {
     // check length
     let length = username.len();
     if !(1..MAX_USERNAME_CHARS).contains(&length) {
-        return Err(UserPasswordError(format!(
+        return Err(ValidationError(format!(
             "Username ({username}) has incorrect length"
         )));
     }
@@ -80,7 +80,7 @@ pub fn check_username(username: &str) -> Result<(), UserPasswordError> {
     // check first character is a letter or digit
     if let Some(first_char) = username.chars().next() {
         if !first_char.is_ascii_alphanumeric() {
-            return Err(UserPasswordError(
+            return Err(ValidationError(
                 "Username must not start with a special character".into(),
             ));
         }
@@ -91,32 +91,30 @@ pub fn check_username(username: &str) -> Result<(), UserPasswordError> {
         .chars()
         .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_')
     {
-        return Err(UserPasswordError(
+        return Err(ValidationError(
             "Username contains invalid characters".into(),
         ));
     }
 
     Ok(())
 }
-pub fn check_password_strength(password: &str) -> Result<(), UserPasswordError> {
+pub fn check_password_strength(password: &str) -> Result<(), ValidationError> {
     if !(8..=128).contains(&password.len()) {
-        return Err(UserPasswordError("Incorrect password length".into()));
+        return Err(ValidationError("Incorrect password length".into()));
     }
     if !password.chars().any(|c| c.is_ascii_punctuation()) {
-        return Err(UserPasswordError(
-            "No special characters in password".into(),
-        ));
+        return Err(ValidationError("No special characters in password".into()));
     }
     if !password.chars().any(|c| c.is_ascii_digit()) {
-        return Err(UserPasswordError("No numbers in password".into()));
+        return Err(ValidationError("No numbers in password".into()));
     }
     if !password.chars().any(|c| c.is_ascii_lowercase()) {
-        return Err(UserPasswordError(
+        return Err(ValidationError(
             "No lowercase characters in password".into(),
         ));
     }
     if !password.chars().any(|c| c.is_ascii_uppercase()) {
-        return Err(UserPasswordError(
+        return Err(ValidationError(
             "No uppercase characters in password".into(),
         ));
     }

--- a/crates/defguard_core/src/handlers/user.rs
+++ b/crates/defguard_core/src/handlers/user.rs
@@ -15,6 +15,7 @@ use defguard_mail::templates;
 use humantime::parse_duration;
 use serde_json::json;
 use sqlx::PgPool;
+use thiserror::Error;
 use utoipa::ToSchema;
 
 use super::{
@@ -62,12 +63,16 @@ pub(crate) const MAX_USERNAME_CHARS: usize = 64;
 /// - digits (0-9)
 /// - starts with non-special character
 /// - special characters: . - _
-/// - no whitespaces
-pub fn check_username(username: &str) -> Result<(), WebError> {
+
+#[derive(Debug, Error)]
+#[error("{0}")]
+pub struct UserPasswordError(pub String);
+
+pub fn check_username(username: &str) -> Result<(), UserPasswordError> {
     // check length
     let length = username.len();
     if !(1..MAX_USERNAME_CHARS).contains(&length) {
-        return Err(WebError::Serialization(format!(
+        return Err(UserPasswordError(format!(
             "Username ({username}) has incorrect length"
         )));
     }
@@ -75,7 +80,7 @@ pub fn check_username(username: &str) -> Result<(), WebError> {
     // check first character is a letter or digit
     if let Some(first_char) = username.chars().next() {
         if !first_char.is_ascii_alphanumeric() {
-            return Err(WebError::Serialization(
+            return Err(UserPasswordError(
                 "Username must not start with a special character".into(),
             ));
         }
@@ -86,32 +91,32 @@ pub fn check_username(username: &str) -> Result<(), WebError> {
         .chars()
         .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_')
     {
-        return Err(WebError::Serialization(
+        return Err(UserPasswordError(
             "Username contains invalid characters".into(),
         ));
     }
 
     Ok(())
 }
-pub fn check_password_strength(password: &str) -> Result<(), WebError> {
+pub fn check_password_strength(password: &str) -> Result<(), UserPasswordError> {
     if !(8..=128).contains(&password.len()) {
-        return Err(WebError::Serialization("Incorrect password length".into()));
+        return Err(UserPasswordError("Incorrect password length".into()));
     }
     if !password.chars().any(|c| c.is_ascii_punctuation()) {
-        return Err(WebError::Serialization(
+        return Err(UserPasswordError(
             "No special characters in password".into(),
         ));
     }
     if !password.chars().any(|c| c.is_ascii_digit()) {
-        return Err(WebError::Serialization("No numbers in password".into()));
+        return Err(UserPasswordError("No numbers in password".into()));
     }
     if !password.chars().any(|c| c.is_ascii_lowercase()) {
-        return Err(WebError::Serialization(
+        return Err(UserPasswordError(
             "No lowercase characters in password".into(),
         ));
     }
     if !password.chars().any(|c| c.is_ascii_uppercase()) {
-        return Err(WebError::Serialization(
+        return Err(UserPasswordError(
             "No uppercase characters in password".into(),
         ));
     }

--- a/crates/defguard_core/src/user_management.rs
+++ b/crates/defguard_core/src/user_management.rs
@@ -5,21 +5,37 @@ use defguard_common::db::{
     models::{User, WireguardNetwork, device::DeviceInfo},
 };
 use sqlx::PgConnection;
+use thiserror::Error;
 use tokio::sync::broadcast::Sender;
 
 use crate::{
-    enterprise::{firewall::try_get_location_firewall_config, limits::update_counts},
-    error::WebError,
+    enterprise::{
+        firewall::{FirewallError, try_get_location_firewall_config},
+        limits::update_counts,
+    },
     grpc::{GatewayCommand, send_gateway_command, send_multiple_gateway_commands},
     location_management::sync_allowed_devices_for_user,
 };
+
+/// Errors arising from user management operations.
+#[derive(Debug, Error)]
+pub enum UserManagementError {
+    #[error("Database error: {0}")]
+    Db(#[from] sqlx::Error),
+    #[error("Model error: {0}")]
+    Model(#[from] defguard_common::db::models::ModelError),
+    #[error("WireGuard network error: {0}")]
+    Network(#[from] defguard_common::db::models::WireguardNetworkError),
+    #[error("Firewall error: {0}")]
+    Firewall(#[from] FirewallError),
+}
 
 /// Deletes the user and cleans up his devices from gateways
 pub async fn delete_user_and_cleanup_devices(
     user: User<Id>,
     conn: &mut PgConnection,
     gateway_tx: &Sender<GatewayCommand>,
-) -> Result<(), WebError> {
+) -> Result<(), UserManagementError> {
     let username = user.username.clone();
     debug!("Deleting user {username}, removing his devices from gateways and updating ldap...",);
     let devices = user.devices(&mut *conn).await?;
@@ -70,7 +86,7 @@ pub async fn disable_user(
     user: &mut User<Id>,
     conn: &mut PgConnection,
     gateway_tx: &Sender<GatewayCommand>,
-) -> Result<(), WebError> {
+) -> Result<(), UserManagementError> {
     user.is_active = false;
     user.save(&mut *conn).await?;
     user.logout_all_sessions(&mut *conn).await?;
@@ -83,7 +99,7 @@ pub async fn sync_allowed_user_devices(
     user: &User<Id>,
     conn: &mut PgConnection,
     gateway_tx: &Sender<GatewayCommand>,
-) -> Result<(), WebError> {
+) -> Result<(), UserManagementError> {
     debug!("Syncing allowed devices of user {}", user.username);
     let locations = WireguardNetwork::all(&mut *conn).await?;
     for location in locations {

--- a/crates/defguard_setup/src/handlers/auto_wizard.rs
+++ b/crates/defguard_setup/src/handlers/auto_wizard.rs
@@ -81,6 +81,7 @@ pub(crate) async fn apply_internal_url_settings(
         },
     )
     .await
+    .map_err(WebError::from)
 }
 
 /// Updates internal URL settings and configures SSL for the core web server.
@@ -194,6 +195,7 @@ pub(crate) async fn apply_external_url_settings(
         },
     )
     .await
+    .map_err(WebError::from)
 }
 
 /// Returns external SSL certificate info (for the "Download CA certificate" step).


### PR DESCRIPTION
Decouple modules which implement business logic from WebError, which should be API only.

Continues work from https://github.com/DefGuard/defguard/pull/2965 in order to better organize the core codebase and prepare for splitting it into smaller, more focused (and maintainable) modules in the future.