### PR TITLE
decouple AppState from non-API modules

### DIFF
--- a/crates/defguard_core/src/enterprise/db/models/acl.rs
+++ b/crates/defguard_core/src/enterprise/db/models/acl.rs
@@ -17,17 +17,17 @@ use sqlx::{
     query, query_as, query_scalar,
 };
 use thiserror::Error;
+use tokio::sync::broadcast::Sender;
 use utoipa::ToSchema;
 
 use crate::{
-    appstate::AppState,
     enterprise::{
         firewall::{FirewallError, try_get_location_firewall_config},
         handlers::acl::{
             ApiAclRule, EditAclRule, alias::EditAclAlias, destination::EditAclDestination,
         },
     },
-    grpc::GatewayCommand,
+    grpc::{GatewayCommand, send_gateway_command},
 };
 
 #[derive(Debug, Error)]
@@ -515,10 +515,11 @@ impl AclRule {
     pub async fn apply_rules(
         rules: &[Id],
         actor: &str,
-        appstate: &AppState,
+        pool: &PgPool,
+        gateway_tx: &Sender<GatewayCommand>,
     ) -> Result<(), AclError> {
         debug!("Applying {} ACL rules: {rules:?}", rules.len());
-        let mut transaction = appstate.pool.begin().await?;
+        let mut transaction = pool.begin().await?;
 
         // prepare variable for collecting affected locations
         let mut affected_locations = HashSet::new();
@@ -547,10 +548,10 @@ impl AclRule {
             match try_get_location_firewall_config(&location, &mut transaction).await? {
                 Some(firewall_config) => {
                     debug!("Sending firewall update event for location {location}");
-                    appstate.send_gateway_command(GatewayCommand::FirewallConfigChanged(
-                        location.id,
-                        firewall_config,
-                    ));
+                    send_gateway_command(
+                        GatewayCommand::FirewallConfigChanged(location.id, firewall_config),
+                        gateway_tx,
+                    );
                 }
                 None => {
                     debug!(
@@ -1777,13 +1778,14 @@ impl AclAlias {
         aliases: &[Id],
         kind: AliasKind,
         actor: &str,
-        appstate: &AppState,
+        pool: &PgPool,
+        gateway_tx: &Sender<GatewayCommand>,
     ) -> Result<(), AclError> {
         debug!(
             "Applying {} ACL aliases of kind {kind:?}: {aliases:?}",
             aliases.len(),
         );
-        let mut transaction = appstate.pool.begin().await?;
+        let mut transaction = pool.begin().await?;
 
         // prepare variable for collecting affected rules
         // we are unable to use `HashSet` because `PgRange` does not implement `Hash` trait
@@ -1828,10 +1830,10 @@ impl AclAlias {
             match try_get_location_firewall_config(&location, &mut transaction).await? {
                 Some(firewall_config) => {
                     debug!("Sending firewall update event for location {location}");
-                    appstate.send_gateway_command(GatewayCommand::FirewallConfigChanged(
-                        location.id,
-                        firewall_config,
-                    ));
+                    send_gateway_command(
+                        GatewayCommand::FirewallConfigChanged(location.id, firewall_config),
+                        gateway_tx,
+                    );
                 }
                 None => {
                     debug!(

--- a/crates/defguard_core/src/enterprise/handlers/acl.rs
+++ b/crates/defguard_core/src/enterprise/handlers/acl.rs
@@ -484,12 +484,17 @@ pub(crate) async fn apply_acl_rules(
         "User {} applying ACL rules: {:?}",
         session.user.username, data.rules
     );
-    AclRule::apply_rules(&data.rules, &session.user.username, &appstate)
-        .await
-        .map_err(|err| {
-            error!("Error applying ACL rules {data:?}: {err}");
-            err
-        })?;
+    AclRule::apply_rules(
+        &data.rules,
+        &session.user.username,
+        &appstate.pool,
+        &appstate.gateway_tx,
+    )
+    .await
+    .map_err(|err| {
+        error!("Error applying ACL rules {data:?}: {err}");
+        err
+    })?;
     info!(
         "User {} applied ACL rules: {:?}",
         session.user.username, data.rules

--- a/crates/defguard_core/src/enterprise/handlers/acl/alias.rs
+++ b/crates/defguard_core/src/enterprise/handlers/acl/alias.rs
@@ -411,7 +411,8 @@ pub(crate) async fn apply_acl_aliases(
         &data.aliases,
         AliasKind::Component,
         &session.user.username,
-        &appstate,
+        &appstate.pool,
+        &appstate.gateway_tx,
     )
     .await
     .map_err(|err| {

--- a/crates/defguard_core/src/enterprise/handlers/acl/destination.rs
+++ b/crates/defguard_core/src/enterprise/handlers/acl/destination.rs
@@ -448,7 +448,8 @@ pub(crate) async fn apply_acl_destinations(
         &data.destinations,
         AliasKind::Destination,
         &session.user.username,
-        &appstate,
+        &appstate.pool,
+        &appstate.gateway_tx,
     )
     .await
     .map_err(|err| {


### PR DESCRIPTION
Removes remaining references to AppState from non-API modules.

Continues refactoring effort from https://github.com/DefGuard/defguard/pull/2984