### PR TITLE
adjust no_group user filter semantics

### DIFF
--- a/crates/defguard_core/src/handlers/user.rs
+++ b/crates/defguard_core/src/handlers/user.rs
@@ -217,7 +217,8 @@ pub struct UserFilterParams {
     /// Filter users by group membership (OR logic - user in any listed group).
     #[serde(default)]
     pub groups: Vec<String>,
-    /// Filter users with no group memberships. Takes precedence over `groups`.
+    /// Filter users with no group memberships. When combined with `groups`, returns the union
+    /// (users in the specified groups OR users with no groups).
     #[serde(default)]
     pub no_group: bool,
     /// Free-text search across username, first_name, last_name, and email.
@@ -235,7 +236,7 @@ pub struct UserFilterParams {
     path = "/api/v1/user",
     params(
         ("groups" = Option<Vec<String>>, Query, description = "Filter users by group names (OR logic - returns users in any of the specified groups)"),
-        ("no_group" = Option<bool>, Query, description = "Filter users with no group memberships (takes precedence over groups)"),
+        ("no_group" = Option<bool>, Query, description = "Filter users with no group memberships. When combined with groups, returns the union (users in specified groups OR users with no groups)."),
         ("search" = Option<String>, Query, description = "Free-text search across username, first name, last name, and email"),
         ("sort_by" = Option<SortKey>, Query, description = "Sort key: name (default), username, or email"),
         ("sort_order" = Option<SortOrder>, Query, description = "Sort direction: asc or desc (default)"),
@@ -335,12 +336,25 @@ pub(crate) async fn list_users(
 fn apply_filters(query_builder: &mut QueryBuilder<Postgres>, filters: &UserFilterParams) {
     debug!("Applying query filters: {filters:?}");
 
-    if filters.no_group {
+    let has_no_group = filters.no_group;
+    let has_groups = !filters.groups.is_empty();
+
+    if has_no_group && has_groups {
+        query_builder.push(
+            " AND (NOT EXISTS (SELECT 1 FROM group_user \
+            WHERE group_user.user_id = u.id) \
+            OR EXISTS (SELECT 1 FROM group_user gu \
+            INNER JOIN \"group\" g ON gu.group_id = g.id \
+            WHERE gu.user_id = u.id AND g.name = ANY(",
+        );
+        query_builder.push_bind(filters.groups.clone());
+        query_builder.push("))) ");
+    } else if has_no_group {
         query_builder.push(
             " AND NOT EXISTS (SELECT 1 FROM group_user \
             WHERE group_user.user_id = u.id) ",
         );
-    } else if !filters.groups.is_empty() {
+    } else if has_groups {
         query_builder.push(
             " AND EXISTS (SELECT 1 FROM group_user gu \
             INNER JOIN \"group\" g ON gu.group_id = g.id \

--- a/crates/defguard_core/tests/integration/api/user.rs
+++ b/crates/defguard_core/tests/integration/api/user.rs
@@ -378,20 +378,22 @@ async fn test_list_users_no_group_filter(_: PgPoolOptions, options: PgConnectOpt
         .collect();
     assert_eq!(usernames, vec!["admin"]);
 
-    // Conflict: no_group=true with groups=admin - no_group wins, only ungrouped
+    // Combined: no_group=true with groups=admin - returns union (ungrouped + in group)
     let response = client
         .get("/api/v1/user?no_group=true&groups=admin")
         .send()
         .await;
     assert_eq!(response.status(), StatusCode::OK);
     let body: serde_json::Value = response.json().await;
-    let usernames: Vec<&str> = body["data"]
+    let mut usernames: Vec<&str> = body["data"]
         .as_array()
         .unwrap()
         .iter()
         .map(|u| u["username"].as_str().unwrap())
         .collect();
-    assert_eq!(usernames, vec!["hpotter"]);
+    usernames.sort();
+    assert_eq!(usernames, vec!["admin", "hpotter"]);
+    assert_eq!(body["pagination"]["total_items"].as_u64().unwrap(), 2);
 
     // Unauthorized access
     client.login_user("hpotter", "pass123").await;

--- a/crates/defguard_core/tests/integration/api/user.rs
+++ b/crates/defguard_core/tests/integration/api/user.rs
@@ -404,6 +404,56 @@ async fn test_list_users_no_group_filter(_: PgPoolOptions, options: PgConnectOpt
 }
 
 #[sqlx::test]
+async fn test_list_users_no_group_multi_group_filter(_: PgPoolOptions, options: PgConnectOptions) {
+    let pool = setup_pool(options).await;
+    let (mut client, pool) = make_client_with_db(pool).await;
+
+    // Create a "qa" group and a new user rweasley assigned to it.
+    // Existing state: admin is in "admin" group, hpotter is ungrouped.
+    let qa = Group::new("qa").save(&pool).await.unwrap();
+    let rweasley = User::new(
+        "rweasley",
+        Some("pass123"),
+        "Weasley",
+        "Ron",
+        "r.weasley@hogwart.edu.uk",
+        None,
+    )
+    .save(&pool)
+    .await
+    .unwrap();
+    sqlx::query("INSERT INTO group_user (group_id, user_id) VALUES ($1, $2)")
+        .bind(qa.id)
+        .bind(rweasley.id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    // Admin login
+    client.login_user("admin", "pass123").await;
+
+    // Combined no_group + multiple groups: should return users in admin, users in qa,
+    // and users with no group (hpotter).
+    let response = client
+        .get("/api/v1/user?no_group=true&groups=admin&groups=qa")
+        .send()
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: serde_json::Value = response.json().await;
+    let mut usernames: Vec<&str> = body["data"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|u| u["username"].as_str().unwrap())
+        .collect();
+    usernames.sort();
+    assert_eq!(usernames, vec!["admin", "hpotter", "rweasley"]);
+    assert_eq!(body["pagination"]["total_items"].as_u64().unwrap(), 3);
+
+    client.assert_event_queue_is_empty();
+}
+
+#[sqlx::test]
 async fn test_list_users_search(_: PgPoolOptions, options: PgConnectOptions) {
     let pool = setup_pool(options).await;
     let mut client = make_client(pool).await;


### PR DESCRIPTION
When `no_group` AND `groups` filter are both provided return both users belonging to specified groups and users not assigned to any group.

Related https://github.com/DefGuard/defguard/issues/2973