### PR TITLE
Improve error handling during OIDC enrollment flow

### DIFF
--- a/crates/defguard_core/src/enterprise/handlers/openid_login.rs
+++ b/crates/defguard_core/src/enterprise/handlers/openid_login.rs
@@ -330,12 +330,12 @@ pub async fn user_from_claims(
                     warn!(
                         "User with email address {} is trying to log in through OpenID Connect \
                         for the first time, but the account creation is disabled. An enrollment \
-                        should performed.",
+                        should be performed.",
                         email.as_str()
                     );
                     return Err(WebError::Authorization(
                         "User not found and the automatic account creation is disabled. \
-                        Enable it or create the user."
+                        Create the user or make sure they belong to an allowed LDAP synchronization group."
                             .into(),
                     ));
                 }

--- a/crates/defguard_proxy_manager/src/handler.rs
+++ b/crates/defguard_proxy_manager/src/handler.rs
@@ -30,6 +30,7 @@ use defguard_core::{
         is_business_license_active,
         ldap::utils::ldap_update_user_state,
     },
+    error::WebError,
     grpc::{
         GatewayCommand,
         proxy::client_mfa::{
@@ -921,10 +922,26 @@ impl ProxyHandler {
                                             ))
                                         }
                                         Err(err) => {
-                                            let message = format!("OpenID auth error {err}");
-                                            error!(message);
+                                            error!("OpenID auth error {err}");
+                                            let (status_code, message) = match err {
+                                                WebError::Authorization(message)
+                                                | WebError::ObjectNotFound(message) => {
+                                                    (Code::PermissionDenied as i32, message)
+                                                }
+                                                WebError::Forbidden(message) => (
+                                                    Code::PermissionDenied as i32,
+                                                    message.to_owned(),
+                                                ),
+                                                WebError::BadRequest(message) => {
+                                                    (Code::InvalidArgument as i32, message)
+                                                }
+                                                _ => (
+                                                    Code::Internal as i32,
+                                                    "OpenID authentication failed".to_owned(),
+                                                ),
+                                            };
                                             Some(core_response::Payload::CoreError(CoreError {
-                                                status_code: Code::Internal as i32,
+                                                status_code,
                                                 message,
                                             }))
                                         }

--- a/crates/defguard_proxy_manager/src/handler.rs
+++ b/crates/defguard_proxy_manager/src/handler.rs
@@ -924,9 +924,11 @@ impl ProxyHandler {
                                         Err(err) => {
                                             error!("OpenID auth error {err}");
                                             let (status_code, message) = match err {
-                                                WebError::Authorization(message)
-                                                | WebError::ObjectNotFound(message) => {
+                                                WebError::Authorization(message) => {
                                                     (Code::PermissionDenied as i32, message)
+                                                }
+                                                WebError::ObjectNotFound(message) => {
+                                                    (Code::NotFound as i32, message)
                                                 }
                                                 WebError::Forbidden(message) => (
                                                     Code::PermissionDenied as i32,

--- a/crates/defguard_proxy_manager/src/tests/proxy_manager/handler/oidc.rs
+++ b/crates/defguard_proxy_manager/src/tests/proxy_manager/handler/oidc.rs
@@ -337,8 +337,8 @@ async fn test_auth_callback_requires_oidc_provider(_: PgPoolOptions, options: Pg
     let code = assert_error_response(&response);
     assert_eq!(
         code,
-        tonic::Code::PermissionDenied,
-        "expected PermissionDenied when no OIDC provider is configured"
+        tonic::Code::NotFound,
+        "expected NotFound when no OIDC provider is configured"
     );
 
     context.finish().await.expect_server_finished().await;

--- a/crates/defguard_proxy_manager/src/tests/proxy_manager/handler/oidc.rs
+++ b/crates/defguard_proxy_manager/src/tests/proxy_manager/handler/oidc.rs
@@ -1,4 +1,5 @@
 #![allow(deprecated)]
+use defguard_common::db::models::settings::{Settings, update_current_settings};
 use defguard_core::{
     db::models::enrollment::Token, enterprise::handlers::openid_login::build_state,
 };
@@ -266,6 +267,117 @@ async fn test_auth_info_requires_oidc_provider(_: PgPoolOptions, options: PgConn
     );
 
     clear_test_license();
+    context.finish().await.expect_server_finished().await;
+}
+
+#[sqlx::test]
+async fn test_auth_callback_missing_user_without_account_creation_returns_permission_denied(
+    _: PgPoolOptions,
+    options: PgConnectOptions,
+) {
+    let mut context = HandlerTestContext::new(options).await;
+    complete_proxy_handshake(&mut context).await;
+    set_test_license_business();
+
+    let mock = MockOidcProvider::start().await;
+    let _provider = create_oidc_provider(&context.pool, &mock).await;
+    set_public_proxy_url(&context.pool, &mock.base_url).await;
+
+    let mut settings = Settings::get_current_settings();
+    settings.openid_create_account = false;
+    update_current_settings(&context.pool, settings)
+        .await
+        .expect("failed to disable OpenID account creation");
+
+    let raw_nonce = "test-nonce-account-creation-disabled";
+    let code = make_oidc_code("missing-user-sub", "missing-user@example.com", raw_nonce);
+    context.mock_proxy().send_request(CoreRequest {
+        id: 80,
+        device_info: None,
+        payload: Some(core_request::Payload::AuthCallback(AuthCallbackRequest {
+            code,
+            nonce: raw_nonce.to_owned(),
+        })),
+    });
+
+    let response = context.mock_proxy_mut().recv_outbound().await;
+    let code = assert_error_response(&response);
+    assert_eq!(
+        code,
+        tonic::Code::PermissionDenied,
+        "expected PermissionDenied when account creation is disabled"
+    );
+
+    let mut settings = Settings::get_current_settings();
+    settings.openid_create_account = true;
+    update_current_settings(&context.pool, settings)
+        .await
+        .expect("failed to re-enable OpenID account creation");
+
+    clear_test_license();
+    context.finish().await.expect_server_finished().await;
+}
+
+#[sqlx::test]
+async fn test_auth_callback_requires_oidc_provider(_: PgPoolOptions, options: PgConnectOptions) {
+    let mut context = HandlerTestContext::new(options).await;
+    complete_proxy_handshake(&mut context).await;
+    set_public_proxy_url(&context.pool, "http://proxy.example.com").await;
+
+    context.mock_proxy().send_request(CoreRequest {
+        id: 90,
+        device_info: None,
+        payload: Some(core_request::Payload::AuthCallback(AuthCallbackRequest {
+            code: "code".to_owned(),
+            nonce: "nonce".to_owned(),
+        })),
+    });
+
+    let response = context.mock_proxy_mut().recv_outbound().await;
+    let code = assert_error_response(&response);
+    assert_eq!(
+        code,
+        tonic::Code::PermissionDenied,
+        "expected PermissionDenied when no OIDC provider is configured"
+    );
+
+    context.finish().await.expect_server_finished().await;
+}
+
+#[sqlx::test]
+async fn test_auth_callback_invalid_provider_url_returns_invalid_argument(
+    _: PgPoolOptions,
+    options: PgConnectOptions,
+) {
+    let mut context = HandlerTestContext::new(options).await;
+    complete_proxy_handshake(&mut context).await;
+
+    let mock = MockOidcProvider::start().await;
+    let mut provider = create_oidc_provider(&context.pool, &mock).await;
+    provider.base_url = "not a url".to_owned();
+    provider
+        .save(&context.pool)
+        .await
+        .expect("failed to save invalid OIDC provider URL");
+    set_public_proxy_url(&context.pool, &mock.base_url).await;
+
+    context.mock_proxy().send_request(CoreRequest {
+        id: 100,
+        device_info: None,
+        payload: Some(core_request::Payload::AuthCallback(AuthCallbackRequest {
+            code: "code".to_owned(),
+            nonce: "nonce".to_owned(),
+        })),
+    });
+
+    let response = context.mock_proxy_mut().recv_outbound().await;
+    let code = assert_error_response(&response);
+    assert_eq!(
+        code,
+        tonic::Code::InvalidArgument,
+        "expected InvalidArgument when OIDC provider URL is invalid"
+    );
+
     context.finish().await.expect_server_finished().await;
 }
 


### PR DESCRIPTION
Fixes https://github.com/DefGuard/defguard/issues/2950.

Implement granular error handling in OIDC enrollment callback.