### PR TITLE
Add "Any version" options to all posture version inputs

### DIFF
--- a/web/messages/en/postures.json
+++ b/web/messages/en/postures.json
@@ -26,6 +26,7 @@
   "posture_checks_wizard_summary_linux_version": "Kernel {version} and higher",
   "posture_checks_wizard_summary_ios_version": "iOS {version} and higher",
   "posture_checks_wizard_summary_android_version": "Android {version} and higher",
+  "posture_checks_version_any": "Any version",
   "posture_checks_wizard_step_client_version": "Defguard client version",
   "posture_checks_wizard_step_client_version_description": "Define what version of the Defguard client you would like to support",
   "posture_checks_wizard_client_version_note": "\u201cDefguard versions\u201d includes major releases as well as all subsequent patch updates with fixes and improvements.",

--- a/web/src/pages/AddPostureCheckWizardPage/summary.ts
+++ b/web/src/pages/AddPostureCheckWizardPage/summary.ts
@@ -45,6 +45,10 @@ const getOperatingSystemVersionLabel = (
   operatingSystem: PostureCheckOsValue,
   version: PostureCheckOsVersionValue,
 ) => {
+  if (version === null) {
+    return m.posture_checks_version_any();
+  }
+
   switch (operatingSystem) {
     case PostureCheckOs.Windows:
       return m.posture_checks_wizard_client_version_option({ version });
@@ -63,14 +67,12 @@ export const buildOperatingSystemSummarySection = (
   operatingSystem: PostureCheckOsValue,
   details: OperatingSystemFormState,
 ): SummarySection => {
-  const lines: SummaryLine[] = [];
-
-  if (details.version !== null) {
-    lines.push({
+  const lines: SummaryLine[] = [
+    {
       text: getOperatingSystemVersionLabel(operatingSystem, details.version),
       emphasized: true,
-    });
-  }
+    },
+  ];
 
   if (
     operatingSystem === PostureCheckOs.Windows &&
@@ -102,9 +104,12 @@ export const buildClientSummarySection = (
 ): SummarySection => {
   const lines: SummaryLine[] = [
     {
-      text: m.posture_checks_wizard_summary_defguard_version({
-        version: minimumClientVersion,
-      }),
+      text:
+        minimumClientVersion === null
+          ? m.posture_checks_version_any()
+          : m.posture_checks_wizard_summary_defguard_version({
+              version: minimumClientVersion,
+            }),
       emphasized: true,
     },
   ];

--- a/web/src/pages/AddPostureCheckWizardPage/useAddPostureCheckWizardStore.ts
+++ b/web/src/pages/AddPostureCheckWizardPage/useAddPostureCheckWizardStore.ts
@@ -26,15 +26,19 @@ export type OperatingSystemFormState = {
   version: PostureCheckOsVersionValue | null;
 };
 
-const getCurrentOrLatestVersion = <T extends string | number>(
+const getCurrentVersionOrAny = <T extends string | number>(
   values: readonly T[],
   currentValue?: T | null,
 ): T | null => {
-  if (isPresent(currentValue) && values.includes(currentValue)) {
+  if (!isPresent(currentValue)) {
+    return null;
+  }
+
+  if (values.includes(currentValue)) {
     return currentValue;
   }
 
-  return values[values.length - 1] ?? currentValue ?? null;
+  return null;
 };
 
 const emptyPostureCheckVersionValues: PostureCheckVersionValues = {
@@ -52,27 +56,27 @@ const createDefaultOperatingSystemState = (
   [PostureCheckOs.Windows]: {
     conditions: [],
     securityUpdateMaxAge: null,
-    version: getCurrentOrLatestVersion(versionValues.windows),
+    version: getCurrentVersionOrAny(versionValues.windows),
   },
   [PostureCheckOs.Macos]: {
     conditions: [],
     securityUpdateMaxAge: null,
-    version: getCurrentOrLatestVersion(versionValues.macos),
+    version: getCurrentVersionOrAny(versionValues.macos),
   },
   [PostureCheckOs.Linux]: {
     conditions: [],
     securityUpdateMaxAge: null,
-    version: getCurrentOrLatestVersion(versionValues.linux),
+    version: getCurrentVersionOrAny(versionValues.linux),
   },
   [PostureCheckOs.Ios]: {
     conditions: [],
     securityUpdateMaxAge: null,
-    version: getCurrentOrLatestVersion(versionValues.ios),
+    version: getCurrentVersionOrAny(versionValues.ios),
   },
   [PostureCheckOs.Android]: {
     conditions: [],
     securityUpdateMaxAge: null,
-    version: getCurrentOrLatestVersion(versionValues.android),
+    version: getCurrentVersionOrAny(versionValues.android),
   },
 });
 
@@ -81,7 +85,7 @@ const createDefaultState = (versionValues: PostureCheckVersionValues): StoreValu
   allowPrereleaseClient: false,
   configuredOperatingSystems: [],
   description: null,
-  minimumClientVersion: getCurrentOrLatestVersion(versionValues.defguard) ?? '',
+  minimumClientVersion: getCurrentVersionOrAny(versionValues.defguard),
   name: '',
   operatingSystemState: createDefaultOperatingSystemState(versionValues),
   availableVersionValues: versionValues,
@@ -121,41 +125,42 @@ export const useAddPostureCheckWizardStore = create<Store>()((set, get) => ({
   syncVersionValues: (versionValues) => {
     set((state) => ({
       availableVersionValues: versionValues,
-      minimumClientVersion:
-        getCurrentOrLatestVersion(versionValues.defguard, state.minimumClientVersion) ??
-        '',
+      minimumClientVersion: getCurrentVersionOrAny(
+        versionValues.defguard,
+        state.minimumClientVersion,
+      ),
       operatingSystemState: {
         [PostureCheckOs.Windows]: {
           ...state.operatingSystemState[PostureCheckOs.Windows],
-          version: getCurrentOrLatestVersion(
+          version: getCurrentVersionOrAny(
             versionValues.windows,
             state.operatingSystemState[PostureCheckOs.Windows].version,
           ),
         },
         [PostureCheckOs.Macos]: {
           ...state.operatingSystemState[PostureCheckOs.Macos],
-          version: getCurrentOrLatestVersion(
+          version: getCurrentVersionOrAny(
             versionValues.macos,
             state.operatingSystemState[PostureCheckOs.Macos].version,
           ),
         },
         [PostureCheckOs.Linux]: {
           ...state.operatingSystemState[PostureCheckOs.Linux],
-          version: getCurrentOrLatestVersion(
+          version: getCurrentVersionOrAny(
             versionValues.linux,
             state.operatingSystemState[PostureCheckOs.Linux].version,
           ),
         },
         [PostureCheckOs.Ios]: {
           ...state.operatingSystemState[PostureCheckOs.Ios],
-          version: getCurrentOrLatestVersion(
+          version: getCurrentVersionOrAny(
             versionValues.ios,
             state.operatingSystemState[PostureCheckOs.Ios].version,
           ),
         },
         [PostureCheckOs.Android]: {
           ...state.operatingSystemState[PostureCheckOs.Android],
-          version: getCurrentOrLatestVersion(
+          version: getCurrentVersionOrAny(
             versionValues.android,
             state.operatingSystemState[PostureCheckOs.Android].version,
           ),

--- a/web/src/pages/EditPostureCheckPage/EditPostureCheckPage.tsx
+++ b/web/src/pages/EditPostureCheckPage/EditPostureCheckPage.tsx
@@ -62,8 +62,8 @@ const EditPostureCheckForm = ({
 }) => {
   const navigate = useNavigate();
   const defaults = useMemo(
-    () => getInitialEditPostureCheckFormValues(postureCheck, versionValues),
-    [postureCheck, versionValues],
+    () => getInitialEditPostureCheckFormValues(postureCheck),
+    [postureCheck],
   );
   const [values, setValues] = useState<EditPostureCheckFormValues>(defaults);
   const locationOptions = useMemo<PostureCheckEditorLocationOption[]>(

--- a/web/src/pages/EditPostureCheckPage/form.ts
+++ b/web/src/pages/EditPostureCheckPage/form.ts
@@ -1,9 +1,6 @@
 import type { ApiDevicePosture, ApiDevicePostureOsRule } from '../../shared/api/types';
 import type { OperatingSystemConditionKey } from '../AddPostureCheckWizardPage/useAddPostureCheckWizardStore';
-import {
-  PostureCheckOs,
-  type PostureCheckOsValue,
-} from '../PostureChecksPage/types';
+import { PostureCheckOs, type PostureCheckOsValue } from '../PostureChecksPage/types';
 
 export type EditPostureCheckOperatingSystemState = {
   conditions: OperatingSystemConditionKey[];

--- a/web/src/pages/EditPostureCheckPage/form.ts
+++ b/web/src/pages/EditPostureCheckPage/form.ts
@@ -3,7 +3,6 @@ import type { OperatingSystemConditionKey } from '../AddPostureCheckWizardPage/u
 import {
   PostureCheckOs,
   type PostureCheckOsValue,
-  type PostureCheckVersionValues,
 } from '../PostureChecksPage/types';
 
 export type EditPostureCheckOperatingSystemState = {
@@ -17,7 +16,7 @@ export type EditPostureCheckFormValues = {
   configuredOperatingSystems: PostureCheckOsValue[];
   description: string | null;
   locations: Set<number>;
-  minimumClientVersion: string;
+  minimumClientVersion: string | null;
   name: string;
   operatingSystemState: Record<PostureCheckOsValue, EditPostureCheckOperatingSystemState>;
 };
@@ -30,33 +29,34 @@ export const editPostureCheckOperatingSystems: PostureCheckOsValue[] = [
   PostureCheckOs.Android,
 ];
 
-export const getDefaultEditPostureCheckOperatingSystemState = (
-  versionValues: PostureCheckVersionValues,
-): Record<PostureCheckOsValue, EditPostureCheckOperatingSystemState> => ({
+export const getDefaultEditPostureCheckOperatingSystemState = (): Record<
+  PostureCheckOsValue,
+  EditPostureCheckOperatingSystemState
+> => ({
   [PostureCheckOs.Windows]: {
     conditions: [],
     securityUpdateMaxAge: null,
-    version: versionValues.windows[versionValues.windows.length - 1] ?? null,
+    version: null,
   },
   [PostureCheckOs.Macos]: {
     conditions: [],
     securityUpdateMaxAge: null,
-    version: versionValues.macos[versionValues.macos.length - 1] ?? null,
+    version: null,
   },
   [PostureCheckOs.Linux]: {
     conditions: [],
     securityUpdateMaxAge: null,
-    version: versionValues.linux[versionValues.linux.length - 1] ?? null,
+    version: null,
   },
   [PostureCheckOs.Ios]: {
     conditions: [],
     securityUpdateMaxAge: null,
-    version: versionValues.ios[versionValues.ios.length - 1] ?? null,
+    version: null,
   },
   [PostureCheckOs.Android]: {
     conditions: [],
     securityUpdateMaxAge: null,
-    version: versionValues.android[versionValues.android.length - 1] ?? null,
+    version: null,
   },
 });
 
@@ -99,10 +99,8 @@ const getRuleVersion = (rule: ApiDevicePostureOsRule): number | null => {
 
 export const getInitialEditPostureCheckFormValues = (
   postureCheck: ApiDevicePosture,
-  versionValues: PostureCheckVersionValues,
 ): EditPostureCheckFormValues => {
-  const operatingSystemState =
-    getDefaultEditPostureCheckOperatingSystemState(versionValues);
+  const operatingSystemState = getDefaultEditPostureCheckOperatingSystemState();
 
   for (const rule of postureCheck.os_rules) {
     operatingSystemState[rule.os_type] = {
@@ -120,10 +118,7 @@ export const getInitialEditPostureCheckFormValues = (
     configuredOperatingSystems: postureCheck.os_rules.map((rule) => rule.os_type),
     description: postureCheck.description,
     locations: new Set(postureCheck.locations),
-    minimumClientVersion:
-      postureCheck.min_client_version ??
-      versionValues.defguard[versionValues.defguard.length - 1] ??
-      '',
+    minimumClientVersion: postureCheck.min_client_version,
     name: postureCheck.name,
     operatingSystemState,
   };

--- a/web/src/pages/PostureChecksPage/postureChecks.ts
+++ b/web/src/pages/PostureChecksPage/postureChecks.ts
@@ -137,6 +137,11 @@ export const isPostureCheckFilterValue = (
 const mapVersionFilterValue = (value: number | string | undefined | null) =>
   value ?? undefined;
 
+const mapAnyVersionSummary = (
+  value: number | undefined | null,
+  getLabel: (value: number) => string,
+) => (isPresent(value) ? getLabel(value) : m.posture_checks_version_any());
+
 const joinRequirementParts = (parts: Array<string | null | undefined | false>) => {
   const filteredParts = parts.filter((part): part is string => Boolean(part));
 
@@ -169,7 +174,7 @@ const getOsRuleParts = (
     case PostureCheckOs.Windows:
       return {
         summaryParts: [
-          rule.min_os_version?.toString(),
+          mapAnyVersionSummary(rule.min_os_version, (value) => value.toString()),
           rule.disk_encryption_required && PostureCheckRequirement.DiskEncryption,
           rule.antivirus_required && PostureCheckRequirement.Antivirus,
           rule.ad_domain_joined_required && PostureCheckRequirement.AdJoined,
@@ -188,7 +193,7 @@ const getOsRuleParts = (
     case PostureCheckOs.Macos:
       return {
         summaryParts: [
-          rule.min_os_version?.toString(),
+          mapAnyVersionSummary(rule.min_os_version, (value) => value.toString()),
           rule.disk_encryption_required && PostureCheckRequirement.DiskEncryption,
           rule.device_integrity_required && PostureCheckRequirement.DeviceIntegrity,
         ],
@@ -201,7 +206,7 @@ const getOsRuleParts = (
     case PostureCheckOs.Linux:
       return {
         summaryParts: [
-          rule.min_kernel_version ? `Kernel ${rule.min_kernel_version}` : null,
+          mapAnyVersionSummary(rule.min_kernel_version, (value) => `Kernel ${value}`),
           rule.disk_encryption_required && PostureCheckRequirement.DiskEncryption,
         ],
         filterParts: [
@@ -211,13 +216,15 @@ const getOsRuleParts = (
       };
     case PostureCheckOs.Ios:
       return {
-        summaryParts: [rule.min_os_version ? `iOS ${rule.min_os_version}+` : null],
+        summaryParts: [
+          mapAnyVersionSummary(rule.min_os_version, (value) => `iOS ${value}+`),
+        ],
         filterParts: [mapVersionFilterValue(rule.min_os_version)],
       };
     case PostureCheckOs.Android:
       return {
         summaryParts: [
-          rule.min_os_version ? `Android ${rule.min_os_version}+` : null,
+          mapAnyVersionSummary(rule.min_os_version, (value) => `Android ${value}+`),
           rule.device_integrity_required && PostureCheckRequirement.DeviceIntegrity,
         ],
         filterParts: [
@@ -257,7 +264,9 @@ export const mapApiDevicePostureToRow = (posture: ApiDevicePosture): PostureChec
   android: getOsRuleSummary(getDevicePostureRule(posture, PostureCheckOs.Android)),
   androidFilters: getOsRuleFilters(getDevicePostureRule(posture, PostureCheckOs.Android)),
   defguard: joinRequirementParts([
-    posture.min_client_version ? `Defguard ${posture.min_client_version}+` : null,
+    posture.min_client_version === null
+      ? m.posture_checks_version_any()
+      : `Defguard ${posture.min_client_version}+`,
     posture.allow_prerelease_client && 'Pre-release allowed',
   ]),
   defguardFilters: joinFilters([

--- a/web/src/pages/PostureChecksPage/types.ts
+++ b/web/src/pages/PostureChecksPage/types.ts
@@ -13,10 +13,7 @@ export type PostureCheckOsValue = (typeof PostureCheckOs)[keyof typeof PostureCh
 export type PostureCheckOsVersionValue = number | null;
 export type PostureCheckDefguardVersionValue = string | null;
 
-export type PostureCheckVersionValues = Record<
-  PostureCheckOsValue,
-  readonly number[]
-> & {
+export type PostureCheckVersionValues = Record<PostureCheckOsValue, readonly number[]> & {
   defguard: readonly string[];
 };
 

--- a/web/src/pages/PostureChecksPage/types.ts
+++ b/web/src/pages/PostureChecksPage/types.ts
@@ -10,14 +10,14 @@ export const PostureCheckOs = {
 
 export type PostureCheckOsValue = (typeof PostureCheckOs)[keyof typeof PostureCheckOs];
 
-export type PostureCheckOsVersionValue = number;
-export type PostureCheckDefguardVersionValue = string;
+export type PostureCheckOsVersionValue = number | null;
+export type PostureCheckDefguardVersionValue = string | null;
 
 export type PostureCheckVersionValues = Record<
   PostureCheckOsValue,
-  readonly PostureCheckOsVersionValue[]
+  readonly number[]
 > & {
-  defguard: readonly PostureCheckDefguardVersionValue[];
+  defguard: readonly string[];
 };
 
 export const getPostureCheckVersionValues = (

--- a/web/src/shared/components/postureChecksEditor/PostureCheckEditorSections.tsx
+++ b/web/src/shared/components/postureChecksEditor/PostureCheckEditorSections.tsx
@@ -111,12 +111,18 @@ const conditionDefinitions = (): Record<PostureCheckOsValue, ConditionDefinition
 const getVersionOptions = (
   operatingSystem: PostureCheckOsValue,
   versionValues: PostureCheckVersionValues,
-): SelectOption<number>[] =>
-  versionValues[operatingSystem].map((value) => ({
+): SelectOption<number | null>[] => [
+  {
+    key: 'any',
+    label: m.posture_checks_version_any(),
+    value: null,
+  },
+  ...versionValues[operatingSystem].map((value) => ({
     key: value,
     label: getOperatingSystemVersionOptionLabel(operatingSystem, value),
     value,
-  }));
+  })),
+];
 
 export const PostureCheckGeneralSection = ({
   updateValues,
@@ -358,22 +364,28 @@ export const PostureCheckDefguardSection = ({
   values,
   versionValues,
 }: DefguardSectionProps) => {
+  const versionOptions: SelectOption<PostureCheckDefguardVersionValue>[] = [
+    {
+      key: 'any',
+      label: m.posture_checks_version_any(),
+      value: null,
+    },
+    ...versionValues.defguard.map((version) => ({
+      key: version,
+      label: m.posture_checks_wizard_client_version_option({ version }),
+      value: version,
+    })),
+  ];
+  const selectedVersion =
+    versionOptions.find((option) => option.value === values.minimumClientVersion) ??
+    versionOptions[0];
+
   return (
     <div className="posture-check-defguard">
       <p className="note">{m.posture_checks_edit_defguard_note()}</p>
       <Select
-        options={versionValues.defguard.map((version) => ({
-          key: version,
-          label: m.posture_checks_wizard_client_version_option({ version }),
-          value: version,
-        }))}
-        value={{
-          key: values.minimumClientVersion,
-          label: m.posture_checks_wizard_client_version_option({
-            version: values.minimumClientVersion,
-          }),
-          value: values.minimumClientVersion,
-        }}
+        options={versionOptions}
+        value={selectedVersion}
         onChange={(option) => {
           updateValues((current) => ({
             ...current,

--- a/web/src/shared/utils/postureCheckAssignmentSummary.ts
+++ b/web/src/shared/utils/postureCheckAssignmentSummary.ts
@@ -9,8 +9,12 @@ export type PostureCheckAssignmentSummarySection = {
 
 const getOsLine = (
   osType: 'windows' | 'macos' | 'linux' | 'ios' | 'android',
-  version: number,
+  version: number | null,
 ) => {
+  if (version === null) {
+    return String(m.posture_checks_version_any());
+  }
+
   switch (osType) {
     case 'windows':
     case 'macos':
@@ -33,9 +37,7 @@ export const getPostureCheckAssignmentSummarySections = (
     switch (rule.os_type) {
       case 'windows': {
         const lines = [
-          rule.min_os_version !== null
-            ? getOsLine(rule.os_type, rule.min_os_version)
-            : null,
+          getOsLine(rule.os_type, rule.min_os_version),
           rule.windows_security_update_max_age !== null
             ? String(
                 m.posture_checks_wizard_operating_systems_windows_security_updates_within_days(
@@ -68,9 +70,7 @@ export const getPostureCheckAssignmentSummarySections = (
       }
       case 'macos': {
         const lines = [
-          rule.min_os_version !== null
-            ? getOsLine(rule.os_type, rule.min_os_version)
-            : null,
+          getOsLine(rule.os_type, rule.min_os_version),
           rule.disk_encryption_required
             ? String(
                 m.posture_checks_wizard_operating_systems_condition_disk_encryption(),
@@ -93,9 +93,7 @@ export const getPostureCheckAssignmentSummarySections = (
       }
       case 'linux': {
         const lines = [
-          rule.min_kernel_version !== null
-            ? getOsLine(rule.os_type, rule.min_kernel_version)
-            : null,
+          getOsLine(rule.os_type, rule.min_kernel_version),
           rule.disk_encryption_required
             ? String(
                 m.posture_checks_wizard_operating_systems_condition_disk_encryption(),
@@ -112,11 +110,9 @@ export const getPostureCheckAssignmentSummarySections = (
         break;
       }
       case 'ios': {
-        const lines = [
-          rule.min_os_version !== null
-            ? getOsLine(rule.os_type, rule.min_os_version)
-            : null,
-        ].filter((line): line is string => Boolean(line));
+        const lines = [getOsLine(rule.os_type, rule.min_os_version)].filter(
+          (line): line is string => Boolean(line),
+        );
 
         if (lines.length > 0) {
           sections.push({
@@ -128,9 +124,7 @@ export const getPostureCheckAssignmentSummarySections = (
       }
       case 'android': {
         const lines = [
-          rule.min_os_version !== null
-            ? getOsLine(rule.os_type, rule.min_os_version)
-            : null,
+          getOsLine(rule.os_type, rule.min_os_version),
           rule.device_integrity_required
             ? String(
                 m.posture_checks_wizard_operating_systems_condition_device_integrity(),
@@ -150,13 +144,13 @@ export const getPostureCheckAssignmentSummarySections = (
   });
 
   const clientLines = [
-    postureCheck.min_client_version !== null
-      ? String(
+    postureCheck.min_client_version === null
+      ? String(m.posture_checks_version_any())
+      : String(
           m.posture_checks_wizard_summary_defguard_version({
             version: postureCheck.min_client_version,
           }),
-        )
-      : null,
+        ),
     postureCheck.allow_prerelease_client
       ? String(m.posture_checks_wizard_summary_prerelease())
       : null,

--- a/web/src/shared/utils/postureInfo.ts
+++ b/web/src/shared/utils/postureInfo.ts
@@ -1,3 +1,4 @@
+import { m } from '../../paraglide/messages';
 import type { ApiDevicePosture } from '../api/types';
 import { IconKind } from '../defguard-ui/components/Icon';
 
@@ -21,9 +22,13 @@ export const getWindowsSection = (
   if (rule.disk_encryption_required) otherItems.push('Disk encryption enabled');
 
   const rows: OsDetailRow[] = [];
-  if (rule.min_os_version !== null) {
-    rows.push({ label: 'Version', value: `Windows ${rule.min_os_version} and higher` });
-  }
+  rows.push({
+    label: 'Version',
+    value:
+      rule.min_os_version === null
+        ? m.posture_checks_version_any()
+        : `Windows ${rule.min_os_version} and higher`,
+  });
   if (rule.windows_security_update_max_age !== null) {
     rows.push({
       label: 'Update',
@@ -45,9 +50,13 @@ export const getMacosSection = (
   if (rule.device_integrity_required) otherItems.push('Device integrity');
 
   const rows: OsDetailRow[] = [];
-  if (rule.min_os_version !== null) {
-    rows.push({ label: 'Version', value: `macOS ${rule.min_os_version} and higher` });
-  }
+  rows.push({
+    label: 'Version',
+    value:
+      rule.min_os_version === null
+        ? m.posture_checks_version_any()
+        : `macOS ${rule.min_os_version} and higher`,
+  });
   if (otherItems.length > 0) {
     rows.push({ label: 'Other', value: otherItems });
   }
@@ -62,12 +71,13 @@ export const getLinuxSection = (
   if (rule.disk_encryption_required) otherItems.push('Disk encryption enabled');
 
   const rows: OsDetailRow[] = [];
-  if (rule.min_kernel_version !== null) {
-    rows.push({
-      label: 'Version',
-      value: `Kernel ${rule.min_kernel_version} and higher`,
-    });
-  }
+  rows.push({
+    label: 'Version',
+    value:
+      rule.min_kernel_version === null
+        ? m.posture_checks_version_any()
+        : `Kernel ${rule.min_kernel_version} and higher`,
+  });
   if (otherItems.length > 0) {
     rows.push({ label: 'Other', value: otherItems });
   }
@@ -79,9 +89,13 @@ export const getIosSection = (
   rule: Extract<ApiDevicePosture['os_rules'][number], { os_type: 'ios' }>,
 ): OsSection => {
   const rows: OsDetailRow[] = [];
-  if (rule.min_os_version !== null) {
-    rows.push({ label: 'Version', value: `iOS ${rule.min_os_version}+` });
-  }
+  rows.push({
+    label: 'Version',
+    value:
+      rule.min_os_version === null
+        ? m.posture_checks_version_any()
+        : `iOS ${rule.min_os_version}+`,
+  });
 
   return { icon: IconKind.AppStore, name: 'iOS', rows };
 };
@@ -93,9 +107,13 @@ export const getAndroidSection = (
   if (rule.device_integrity_required) otherItems.push('Device integrity');
 
   const rows: OsDetailRow[] = [];
-  if (rule.min_os_version !== null) {
-    rows.push({ label: 'Version', value: `Android ${rule.min_os_version}+` });
-  }
+  rows.push({
+    label: 'Version',
+    value:
+      rule.min_os_version === null
+        ? m.posture_checks_version_any()
+        : `Android ${rule.min_os_version}+`,
+  });
   if (otherItems.length > 0) {
     rows.push({ label: 'Other', value: otherItems });
   }
@@ -104,15 +122,14 @@ export const getAndroidSection = (
 };
 
 export const getDefguardSection = (posture: ApiDevicePosture): OsSection | null => {
-  if (!posture.min_client_version && !posture.allow_prerelease_client) return null;
-
   const rows: OsDetailRow[] = [];
-  if (posture.min_client_version) {
-    rows.push({
-      label: 'Version',
-      value: `Defguard ${posture.min_client_version} and higher`,
-    });
-  }
+  rows.push({
+    label: 'Version',
+    value:
+      posture.min_client_version === null
+        ? m.posture_checks_version_any()
+        : `Defguard ${posture.min_client_version} and higher`,
+  });
   if (posture.allow_prerelease_client) {
     rows.push({ label: 'Other', value: 'Pre-release allowed' });
   }

--- a/web/tests/add-posture-check-payload.test.ts
+++ b/web/tests/add-posture-check-payload.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { buildAddPostureCheckRequest } from '../src/pages/AddPostureCheckWizardPage/payload';
+import { PostureCheckOs } from '../src/pages/PostureChecksPage/types';
+
+describe('add posture check payload', () => {
+  it('preserves Any version as null in the API request', () => {
+    expect(
+      buildAddPostureCheckRequest({
+        allowPrereleaseClient: false,
+        configuredOperatingSystems: [PostureCheckOs.Windows, PostureCheckOs.Linux],
+        description: null,
+        minimumClientVersion: null,
+        name: 'Any version policy',
+        operatingSystemState: {
+          [PostureCheckOs.Windows]: {
+            conditions: ['disk-encryption'],
+            securityUpdateMaxAge: null,
+            version: null,
+          },
+          [PostureCheckOs.Macos]: {
+            conditions: [],
+            securityUpdateMaxAge: null,
+            version: null,
+          },
+          [PostureCheckOs.Linux]: {
+            conditions: [],
+            securityUpdateMaxAge: null,
+            version: null,
+          },
+          [PostureCheckOs.Ios]: {
+            conditions: [],
+            securityUpdateMaxAge: null,
+            version: null,
+          },
+          [PostureCheckOs.Android]: {
+            conditions: [],
+            securityUpdateMaxAge: null,
+            version: null,
+          },
+        },
+      }),
+    ).toEqual({
+      name: 'Any version policy',
+      description: null,
+      min_client_version: null,
+      allow_prerelease_client: false,
+      os_rules: [
+        {
+          os_type: 'windows',
+          min_os_version: null,
+          disk_encryption_required: true,
+          antivirus_required: null,
+          ad_domain_joined_required: null,
+          windows_security_update_max_age: null,
+        },
+        {
+          os_type: 'linux',
+          min_kernel_version: null,
+          disk_encryption_required: null,
+        },
+      ],
+    });
+  });
+});

--- a/web/tests/add-posture-check-summary.test.ts
+++ b/web/tests/add-posture-check-summary.test.ts
@@ -34,4 +34,27 @@ describe('add posture check summary helpers', () => {
       ],
     });
   });
+
+  it('shows Any version when version requirements are disabled', () => {
+    expect(
+      buildOperatingSystemSummarySection(PostureCheckOs.Windows, {
+        conditions: ['disk-encryption'],
+        securityUpdateMaxAge: null,
+        version: null,
+      }),
+    ).toEqual({
+      icon: 'windows',
+      label: 'Windows',
+      lines: [
+        { emphasized: true, text: 'Any version' },
+        { text: 'Disk encryption enabled' },
+      ],
+    });
+
+    expect(buildClientSummarySection(null, false)).toEqual({
+      icon: 'defguard',
+      label: 'Defguard',
+      lines: [{ emphasized: true, text: 'Any version' }],
+    });
+  });
 });

--- a/web/tests/add-posture-check-wizard-store.test.ts
+++ b/web/tests/add-posture-check-wizard-store.test.ts
@@ -24,9 +24,7 @@ describe('add posture check wizard store', () => {
   });
 
   it('stores defguard client-version settings and restores their defaults on reset', () => {
-    expect(useAddPostureCheckWizardStore.getState().minimumClientVersion).toBe(
-      versionValues.defguard[versionValues.defguard.length - 1],
-    );
+    expect(useAddPostureCheckWizardStore.getState().minimumClientVersion).toBeNull();
     expect(useAddPostureCheckWizardStore.getState().allowPrereleaseClient).toBe(false);
 
     useAddPostureCheckWizardStore.getState().setMinimumClientVersion('1.6');
@@ -37,10 +35,51 @@ describe('add posture check wizard store', () => {
 
     useAddPostureCheckWizardStore.getState().reset();
 
-    expect(useAddPostureCheckWizardStore.getState().minimumClientVersion).toBe(
-      versionValues.defguard[versionValues.defguard.length - 1],
-    );
+    expect(useAddPostureCheckWizardStore.getState().minimumClientVersion).toBeNull();
     expect(useAddPostureCheckWizardStore.getState().allowPrereleaseClient).toBe(false);
+  });
+
+  it('uses Any version as the default for operating systems', () => {
+    expect(useAddPostureCheckWizardStore.getState().operatingSystemState).toMatchObject({
+      windows: { version: null },
+      macos: { version: null },
+      linux: { version: null },
+      ios: { version: null },
+      android: { version: null },
+    });
+  });
+
+  it('resets unavailable concrete versions to Any when metadata changes', () => {
+    const store = useAddPostureCheckWizardStore.getState();
+
+    store.setMinimumClientVersion('1.6');
+    store.updateOperatingSystemDetails(PostureCheckOs.Windows, {
+      version: 10,
+    });
+    store.updateOperatingSystemDetails(PostureCheckOs.Macos, {
+      version: null,
+    });
+
+    useAddPostureCheckWizardStore.getState().syncVersionValues(
+      getPostureCheckVersionValues({
+        os_versions: {
+          windows: [11],
+          macos: [13],
+          ios: [17],
+          android: [13],
+        },
+        linux_kernel_versions: [6],
+        client_versions: ['2.0'],
+      } satisfies DevicePostureVersionMetadata),
+    );
+
+    expect(useAddPostureCheckWizardStore.getState().minimumClientVersion).toBeNull();
+    expect(
+      useAddPostureCheckWizardStore.getState().operatingSystemState.windows.version,
+    ).toBeNull();
+    expect(
+      useAddPostureCheckWizardStore.getState().operatingSystemState.macos.version,
+    ).toBeNull();
   });
 
   it('keeps selected operating systems unique while preserving append order', () => {

--- a/web/tests/edit-location-posture-checks.test.ts
+++ b/web/tests/edit-location-posture-checks.test.ts
@@ -28,6 +28,7 @@ vi.mock('../src/paraglide/messages', () => ({
     posture_checks_wizard_summary_prerelease: () =>
       'Allow pre-release versions of the Defguard client.',
     posture_checks_wizard_summary_defguard_label: () => 'Defguard',
+    posture_checks_version_any: () => 'Any version',
   },
 }));
 
@@ -176,6 +177,38 @@ describe('edit location posture-checks section state', () => {
           'Defguard 2.0 and higher',
           'Allow pre-release versions of the Defguard client.',
         ],
+      },
+    ]);
+  });
+
+  it('shows Any version in assignment tooltip sections for configured null-version rules', () => {
+    const postureCheck: ApiDevicePosture = {
+      id: 2,
+      name: 'Any version policy',
+      description: null,
+      min_client_version: null,
+      allow_prerelease_client: false,
+      locations: [],
+      os_rules: [
+        {
+          os_type: 'windows',
+          min_os_version: null,
+          disk_encryption_required: true,
+          antivirus_required: false,
+          ad_domain_joined_required: false,
+          windows_security_update_max_age: null,
+        },
+      ],
+    };
+
+    expect(getPostureCheckAssignmentSummarySections(postureCheck)).toEqual([
+      {
+        label: 'Windows',
+        lines: ['Any version', 'Disk encryption enabled'],
+      },
+      {
+        label: 'Defguard',
+        lines: ['Any version'],
       },
     ]);
   });

--- a/web/tests/posture-checks-page.test.ts
+++ b/web/tests/posture-checks-page.test.ts
@@ -88,7 +88,7 @@ describe('posture checks page helpers', () => {
     });
   });
 
-  it('uses empty placeholders when an OS rule is missing or has no requirements', () => {
+  it('shows Any version for configured null-version rules without adding filter values', () => {
     const postureCheck: ApiDevicePosture = {
       id: 2,
       name: 'Second posture check',
@@ -112,7 +112,7 @@ describe('posture checks page helpers', () => {
       id: 2,
       name: 'Second posture check',
       locations: [],
-      windows: '-',
+      windows: 'Any version',
       windowsFilters: [],
       macos: '-',
       macosFilters: [],
@@ -122,7 +122,7 @@ describe('posture checks page helpers', () => {
       iosFilters: [],
       android: '-',
       androidFilters: [],
-      defguard: '-',
+      defguard: 'Any version',
       defguardFilters: [],
     });
   });
@@ -256,10 +256,7 @@ describe('posture checks page helpers', () => {
 
     expect(
       normalizeEditPostureCheckFormValues(
-        getInitialEditPostureCheckFormValues(
-          postureCheck,
-          getPostureCheckVersionValues(makeVersionMetadata()),
-        ),
+        getInitialEditPostureCheckFormValues(postureCheck),
       ),
     ).toEqual({
       allowPrereleaseClient: true,
@@ -277,17 +274,17 @@ describe('posture checks page helpers', () => {
         macos: {
           conditions: [],
           securityUpdateMaxAge: null,
-          version: 26,
+          version: null,
         },
         linux: {
           conditions: [],
           securityUpdateMaxAge: null,
-          version: 7,
+          version: null,
         },
         ios: {
           conditions: [],
           securityUpdateMaxAge: null,
-          version: 26,
+          version: null,
         },
         android: {
           conditions: ['device-integrity'],

--- a/web/tests/posture-info.test.ts
+++ b/web/tests/posture-info.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import type { ApiDevicePosture } from '../src/shared/api/types';
+import { buildOsSections } from '../src/shared/utils/postureInfo';
+
+describe('posture check drawer info', () => {
+  it('shows Any version for configured null-version rules', () => {
+    const postureCheck: ApiDevicePosture = {
+      id: 1,
+      name: 'Any version policy',
+      description: null,
+      min_client_version: null,
+      allow_prerelease_client: false,
+      locations: [],
+      os_rules: [
+        {
+          os_type: 'windows',
+          min_os_version: null,
+          disk_encryption_required: true,
+          antivirus_required: false,
+          ad_domain_joined_required: false,
+          windows_security_update_max_age: null,
+        },
+      ],
+    };
+
+    expect(buildOsSections(postureCheck)).toEqual([
+      expect.objectContaining({
+        name: 'Windows',
+        rows: [
+          { label: 'Version', value: 'Any version' },
+          { label: 'Other', value: ['Disk encryption enabled'] },
+        ],
+      }),
+      expect.objectContaining({
+        name: 'Defguard',
+        rows: [{ label: 'Version', value: 'Any version' }],
+      }),
+    ]);
+  });
+});


### PR DESCRIPTION
Related issue: https://github.com/DefGuard/defguard/issues/3082.