### PR TITLE
Posture assigned to

### DIFF
--- a/web/messages/en/postures.json
+++ b/web/messages/en/postures.json
@@ -47,7 +47,7 @@
   "posture_checks_edit_general": "General",
   "posture_checks_edit_operating_systems": "Operating systems",
   "posture_checks_edit_defguard": "Defguard",
-  "posture_checks_edit_locations": "Used to locations",
+  "posture_checks_edit_locations": "Assigned locations",
   "posture_checks_edit_defguard_note": "\u201cDefguard versions\u201d includes major releases as well as all subsequent patch updates with fixes and improvements.",
   "posture_checks_edit_delete_title": "Delete posture check",
   "posture_checks_edit_delete_body": "Are you sure you want to delete posture check **{name}**? This action cannot be undone.",

--- a/web/src/pages/EditLocationPage/style.scss
+++ b/web/src/pages/EditLocationPage/style.scss
@@ -11,7 +11,7 @@
 
       .posture-checks-empty-state {
         display: flex;
-        align-items: flex-start;
+        align-items: center;
         gap: var(--spacing-2xl);
 
         .posture-check-shield {

--- a/web/src/pages/EditPostureCheckPage/EditPostureCheckPage.tsx
+++ b/web/src/pages/EditPostureCheckPage/EditPostureCheckPage.tsx
@@ -46,8 +46,9 @@ import {
   normalizeEditPostureCheckFormValues,
 } from './form';
 
-const buildLocationOptions = (locations: NetworkLocation[]) =>
+const buildLocationOptions = (locations: NetworkLocation[], assigned: Set<number>) =>
   [...locations]
+    .filter((location) => assigned.has(location.id))
     .sort((left, right) => left.name.localeCompare(right.name))
     .map((location) => ({ id: location.id, label: location.name }));
 
@@ -67,8 +68,8 @@ const EditPostureCheckForm = ({
   );
   const [values, setValues] = useState<EditPostureCheckFormValues>(defaults);
   const locationOptions = useMemo<PostureCheckEditorLocationOption[]>(
-    () => buildLocationOptions(locations),
-    [locations],
+    () => buildLocationOptions(locations, values.locations),
+    [locations, values.locations],
   );
 
   useEffect(() => {
@@ -147,7 +148,6 @@ const EditPostureCheckForm = ({
       <EditPageFormSection label={m.posture_checks_edit_locations()}>
         <PostureCheckLocationsSection
           locationOptions={locationOptions}
-          values={values}
           updateValues={updateValues}
         />
       </EditPageFormSection>

--- a/web/src/pages/EditPostureCheckPage/EditPostureCheckPage.tsx
+++ b/web/src/pages/EditPostureCheckPage/EditPostureCheckPage.tsx
@@ -46,9 +46,8 @@ import {
   normalizeEditPostureCheckFormValues,
 } from './form';
 
-const buildLocationOptions = (locations: NetworkLocation[], assigned: Set<number>) =>
+const buildLocationOptions = (locations: NetworkLocation[]) =>
   [...locations]
-    .filter((location) => assigned.has(location.id))
     .sort((left, right) => left.name.localeCompare(right.name))
     .map((location) => ({ id: location.id, label: location.name }));
 
@@ -68,8 +67,8 @@ const EditPostureCheckForm = ({
   );
   const [values, setValues] = useState<EditPostureCheckFormValues>(defaults);
   const locationOptions = useMemo<PostureCheckEditorLocationOption[]>(
-    () => buildLocationOptions(locations, values.locations),
-    [locations, values.locations],
+    () => buildLocationOptions(locations),
+    [locations],
   );
 
   useEffect(() => {
@@ -148,6 +147,7 @@ const EditPostureCheckForm = ({
       <EditPageFormSection label={m.posture_checks_edit_locations()}>
         <PostureCheckLocationsSection
           locationOptions={locationOptions}
+          values={values}
           updateValues={updateValues}
         />
       </EditPageFormSection>

--- a/web/src/pages/EditPostureCheckPage/EditPostureCheckPage.tsx
+++ b/web/src/pages/EditPostureCheckPage/EditPostureCheckPage.tsx
@@ -149,6 +149,7 @@ const EditPostureCheckForm = ({
           locationOptions={locationOptions}
           values={values}
           updateValues={updateValues}
+          hideUnassigned
         />
       </EditPageFormSection>
       <EditPageControls

--- a/web/src/pages/EditPostureCheckPage/EditPostureCheckPage.tsx
+++ b/web/src/pages/EditPostureCheckPage/EditPostureCheckPage.tsx
@@ -150,6 +150,7 @@ const EditPostureCheckForm = ({
           values={values}
           updateValues={updateValues}
           hideUnassigned
+          visibleLocationIds={defaults.locations}
         />
       </EditPageFormSection>
       <EditPageControls

--- a/web/src/pages/EditPostureCheckPage/EditPostureCheckPage.tsx
+++ b/web/src/pages/EditPostureCheckPage/EditPostureCheckPage.tsx
@@ -70,6 +70,10 @@ const EditPostureCheckForm = ({
     () => buildLocationOptions(locations),
     [locations],
   );
+  const assignedLocationOptions = useMemo(
+    () => locationOptions.filter((location) => defaults.locations.has(location.id)),
+    [defaults.locations, locationOptions],
+  );
 
   useEffect(() => {
     setValues(defaults);
@@ -146,11 +150,9 @@ const EditPostureCheckForm = ({
       </EditPageFormSection>
       <EditPageFormSection label={m.posture_checks_edit_locations()}>
         <PostureCheckLocationsSection
-          locationOptions={locationOptions}
+          locationOptions={assignedLocationOptions}
           values={values}
           updateValues={updateValues}
-          hideUnassigned
-          visibleLocationIds={defaults.locations}
         />
       </EditPageFormSection>
       <EditPageControls

--- a/web/src/shared/components/postureChecksEditor/PostureCheckEditorSections.tsx
+++ b/web/src/shared/components/postureChecksEditor/PostureCheckEditorSections.tsx
@@ -73,6 +73,7 @@ type DefguardSectionProps = {
 
 type LocationsSectionProps = {
   locationOptions: PostureCheckEditorLocationOption[];
+  values: PostureCheckEditorValues;
   updateValues: UpdateValues;
 };
 
@@ -411,13 +412,14 @@ export const PostureCheckDefguardSection = ({
 export const PostureCheckLocationsSection = ({
   locationOptions,
   updateValues,
+  values,
 }: LocationsSectionProps) => {
   return (
     <div className="posture-check-locations">
       {locationOptions.map((location) => (
         <Checkbox
           key={location.id}
-          active={true}
+          active={values.locations.has(location.id)}
           text={location.label}
           onClick={() => {
             updateValues((current) => {

--- a/web/src/shared/components/postureChecksEditor/PostureCheckEditorSections.tsx
+++ b/web/src/shared/components/postureChecksEditor/PostureCheckEditorSections.tsx
@@ -73,7 +73,6 @@ type DefguardSectionProps = {
 
 type LocationsSectionProps = {
   locationOptions: PostureCheckEditorLocationOption[];
-  values: PostureCheckEditorValues;
   updateValues: UpdateValues;
 };
 
@@ -412,14 +411,13 @@ export const PostureCheckDefguardSection = ({
 export const PostureCheckLocationsSection = ({
   locationOptions,
   updateValues,
-  values,
 }: LocationsSectionProps) => {
   return (
     <div className="posture-check-locations">
       {locationOptions.map((location) => (
         <Checkbox
           key={location.id}
-          active={values.locations.has(location.id)}
+          active={true}
           text={location.label}
           onClick={() => {
             updateValues((current) => {

--- a/web/src/shared/components/postureChecksEditor/PostureCheckEditorSections.tsx
+++ b/web/src/shared/components/postureChecksEditor/PostureCheckEditorSections.tsx
@@ -75,6 +75,7 @@ type LocationsSectionProps = {
   locationOptions: PostureCheckEditorLocationOption[];
   values: PostureCheckEditorValues;
   updateValues: UpdateValues;
+  hideUnassigned?: boolean;
 };
 
 const conditionDefinitions = (): Record<PostureCheckOsValue, ConditionDefinition[]> => ({
@@ -413,10 +414,12 @@ export const PostureCheckLocationsSection = ({
   locationOptions,
   updateValues,
   values,
+  hideUnassigned = false,
 }: LocationsSectionProps) => {
+  let options = hideUnassigned ? locationOptions.filter((location) => values.locations.has(location.id)) : locationOptions;
   return (
     <div className="posture-check-locations">
-      {locationOptions.map((location) => (
+      {options.map((location) => (
         <Checkbox
           key={location.id}
           active={values.locations.has(location.id)}

--- a/web/src/shared/components/postureChecksEditor/PostureCheckEditorSections.tsx
+++ b/web/src/shared/components/postureChecksEditor/PostureCheckEditorSections.tsx
@@ -76,6 +76,7 @@ type LocationsSectionProps = {
   values: PostureCheckEditorValues;
   updateValues: UpdateValues;
   hideUnassigned?: boolean;
+  visibleLocationIds?: Set<number>;
 };
 
 const conditionDefinitions = (): Record<PostureCheckOsValue, ConditionDefinition[]> => ({
@@ -415,8 +416,13 @@ export const PostureCheckLocationsSection = ({
   updateValues,
   values,
   hideUnassigned = false,
+  visibleLocationIds,
 }: LocationsSectionProps) => {
-  let options = hideUnassigned ? locationOptions.filter((location) => values.locations.has(location.id)) : locationOptions;
+  const visibleIds = visibleLocationIds ?? values.locations;
+  const options = hideUnassigned
+    ? locationOptions.filter((location) => visibleIds.has(location.id))
+    : locationOptions;
+
   return (
     <div className="posture-check-locations">
       {options.map((location) => (

--- a/web/src/shared/components/postureChecksEditor/PostureCheckEditorSections.tsx
+++ b/web/src/shared/components/postureChecksEditor/PostureCheckEditorSections.tsx
@@ -75,8 +75,6 @@ type LocationsSectionProps = {
   locationOptions: PostureCheckEditorLocationOption[];
   values: PostureCheckEditorValues;
   updateValues: UpdateValues;
-  hideUnassigned?: boolean;
-  visibleLocationIds?: Set<number>;
 };
 
 const conditionDefinitions = (): Record<PostureCheckOsValue, ConditionDefinition[]> => ({
@@ -415,17 +413,10 @@ export const PostureCheckLocationsSection = ({
   locationOptions,
   updateValues,
   values,
-  hideUnassigned = false,
-  visibleLocationIds,
 }: LocationsSectionProps) => {
-  const visibleIds = visibleLocationIds ?? values.locations;
-  const options = hideUnassigned
-    ? locationOptions.filter((location) => visibleIds.has(location.id))
-    : locationOptions;
-
   return (
     <div className="posture-check-locations">
-      {options.map((location) => (
+      {locationOptions.map((location) => (
         <Checkbox
           key={location.id}
           active={values.locations.has(location.id)}


### PR DESCRIPTION
Related issue: https://github.com/DefGuard/defguard/issues/3094

- Only show assigned locations in posture check edit form
- Better wording for "Assigned to" label
- Fix css in location edit form when no posture are defined