### PR TITLE
add missing awaits in e2e test for generating TOTP codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"

--- a/e2e/tests/auth/mfaAuth.spec.ts
+++ b/e2e/tests/auth/mfaAuth.spec.ts
@@ -28,7 +28,7 @@ test.describe('MFA authentication', () => {
 
     await loginBasic(page, testUser);
     await page.goto(routes.base + routes.auth.email);
-    const { otp: code } = TOTP.generate(secret, {
+    const { otp: code } = await TOTP.generate(secret, {
       digits: 6,
       period: EMAIL_CODE_VALIDITY_TIME, //FIXME: Probably a bug, email codes should be valid for 60 seconds
     });

--- a/e2e/utils/controllers/login.ts
+++ b/e2e/utils/controllers/login.ts
@@ -33,7 +33,7 @@ export const loginTOTP = async (page: Page, userInfo: AuthInfo, totpSecret: stri
   await waitForRoute(page, routes.auth.totp);
   const codeField = await page.getByTestId('field-code');
   await codeField.clear();
-  const { otp: token } = TOTP.generate(totpSecret);
+  const { otp: token } = await TOTP.generate(totpSecret);
   await codeField.fill(token);
   const responsePromise = page.waitForResponse(
     (resp) => resp.url().includes('/api/v1/auth') && resp.request().method() === 'POST',

--- a/e2e/utils/controllers/mfa/enableEmail.ts
+++ b/e2e/utils/controllers/mfa/enableEmail.ts
@@ -49,7 +49,7 @@ export const enableEmailMFA = async (
   await page.getByTestId('enable-email').click();
   await page.getByTestId('field-code').waitFor({ state: 'visible' });
   const secret = await extractEmailSecret(user.username);
-  const { otp: code } = TOTP.generate(secret, {
+  const { otp: code } = await TOTP.generate(secret, {
     digits: 6,
     period: 300,
   });

--- a/e2e/utils/controllers/mfa/enableTOTP.ts
+++ b/e2e/utils/controllers/mfa/enableTOTP.ts
@@ -30,7 +30,7 @@ export const enableTOTP = async (
   const totpSecret =
     (await page.getByTestId('totp-code').locator('p').textContent()) ?? '';
 
-  const { otp: token } = TOTP.generate(totpSecret);
+  const { otp: token } = await TOTP.generate(totpSecret);
 
   await page.getByTestId('field-code').fill(token);
   await page.getByTestId('submit-totp').click();


### PR DESCRIPTION
The generate method has become async leading to test failures.