### PR TITLE
fix(e2e): await network device row lookup

### DIFF
--- a/e2e/utils/controllers/vpn/createNetworkDevice.ts
+++ b/e2e/utils/controllers/vpn/createNetworkDevice.ts
@@ -15,13 +15,13 @@ export const getDeviceRow = async ({
 }) => {
   const deviceList = page.locator('#devices-page-devices-list').first();
   const deviceRows = await deviceList.locator('.device-row').all();
-  const row = deviceRows.find(async (val) => {
-    if ((await val.innerText()) === deviceName) {
-      return true;
-    } else {
-      return false;
+  let row: Locator | undefined;
+  for (const deviceRow of deviceRows) {
+    if ((await deviceRow.innerText()) === deviceName) {
+      row = deviceRow;
+      break;
     }
-  });
+  }
   expect(row).toBeDefined();
   return row as Locator;
 };


### PR DESCRIPTION
## Summary

Fixes the network device row lookup helper to await each row text comparison before selecting a row.

`Array.prototype.find()` does not await async predicates, so the previous helper could treat the returned Promise as truthy and select the wrong row. The updated code uses a small `for...of` loop so `deviceName` is compared against each row's text before returning the match.

## Why

This keeps the helper's existing behavior but makes the async lookup effective, which avoids false positives when E2E tests need to interact with a specific network device row.

## Test plan

- Reviewed every line of the diff.
- `git diff --check origin/stable/2.x..HEAD`
- `/Users/yongjae/Documents/e2e-skills/skills/e2e-reviewer/scripts/scan.sh e2e/utils/controllers/vpn/createNetworkDevice.ts` — no P0 findings; two existing P1/P2 heuristics remain outside this async lookup fix.
- `pnpm --filter @defguard/e2e test ...` targeted network-device flow — 2 passed locally.

---

Found while reviewing the test suite with [`e2e-skills/e2e-reviewer`](https://github.com/voidmatcha/e2e-skills#skill-2-e2e-reviewer--quality-review).
