### PR TITLE
port IP assignment optimization from 2.x branch

### DIFF
--- a/crates/defguard_core/src/db/models/device.rs
+++ b/crates/defguard_core/src/db/models/device.rs
@@ -1,4 +1,4 @@
-use std::{fmt, net::IpAddr};
+use std::{collections::HashSet, fmt, net::IpAddr};
 
 use base64::{Engine, prelude::BASE64_STANDARD};
 #[cfg(test)]
@@ -853,6 +853,7 @@ impl Device<Id> {
         &self,
         transaction: &mut PgConnection,
         network: &WireguardNetwork<Id>,
+        used_ips: &HashSet<IpAddr>,
         reserved_ips: Option<&[IpAddr]>,
         current_ips: Option<&[IpAddr]>,
     ) -> Result<WireguardNetworkDevice, ModelError> {
@@ -882,15 +883,16 @@ impl Device<Id> {
             }
             let mut picked = None;
             for ip in address {
-                if network
-                    .can_assign_ips(transaction, &[ip], Some(self.id))
-                    .await
-                    .is_ok()
-                    && !reserved.contains(&ip)
-                {
-                    picked = Some(ip);
-                    break;
+                if ip == address.network() || ip == address.broadcast() || ip == address.ip() {
+                    continue;
                 }
+
+                if used_ips.contains(&ip) || reserved.contains(&ip) {
+                    continue;
+                }
+
+                picked = Some(ip);
+                break;
             }
 
             // Return error if no address can be assigned

--- a/crates/defguard_core/src/db/models/device.rs
+++ b/crates/defguard_core/src/db/models/device.rs
@@ -1257,4 +1257,264 @@ mod test {
         assert_eq!(devices.len(), 1);
         assert_eq!(devices[0].device_id, device.id);
     }
+
+    /// Test that assign_next_network_ip correctly preserves or reassigns device IPs
+    /// when a network's address list changes.
+    /// Initial network: 10.0.0.0/8, 123.10.0.0/16, 123.123.123.0/24
+    /// Device IPs:      10.0.0.234,  123.10.33.44,  123.123.123.52
+    /// New network:     10.0.0.0/16, 123.12.0.0/16, 123.123.0.0/16
+    /// Expected:
+    ///  - 10.0.0.234     KEPT    (still within 10.0.0.0/16)
+    ///  - 123.10.33.44   CHANGED (not within 123.12.0.0/16)
+    ///  - 123.123.123.52 KEPT    (still within 123.123.0.0/16)
+    #[sqlx::test]
+    async fn test_assign_next_network_ip_preserves_matching_subnets(
+        _: PgPoolOptions,
+        options: PgConnectOptions,
+    ) {
+        let pool = setup_pool(options).await;
+
+        let mut network = WireguardNetwork::default();
+        network
+            .try_set_address("10.0.0.1/8,123.10.0.1/16,123.123.123.1/24")
+            .unwrap();
+        let network = network.save(&pool).await.unwrap();
+
+        let user = User::new(
+            "testuser",
+            Some("password"),
+            "Tester",
+            "Test",
+            "test@test.com",
+            None,
+        )
+        .save(&pool)
+        .await
+        .unwrap();
+
+        let device = Device::new(
+            "dev1".into(),
+            "key1".into(),
+            user.id,
+            DeviceType::User,
+            None,
+            true,
+        )
+        .save(&pool)
+        .await
+        .unwrap();
+
+        let ip = IpAddr::from_str("10.0.0.234").unwrap();
+        let ip2 = IpAddr::from_str("123.10.33.44").unwrap();
+        let ip3 = IpAddr::from_str("123.123.123.52").unwrap();
+        let initial_ips = vec![ip, ip2, ip3];
+
+        let mut conn = pool.acquire().await.unwrap();
+        WireguardNetworkDevice::new(network.id, device.id, initial_ips.clone())
+            .insert(&mut *conn)
+            .await
+            .unwrap();
+
+        let mut updated_network = network.clone();
+        updated_network.address = vec![
+            "10.0.0.0/16".parse::<IpNetwork>().unwrap(),
+            "123.12.0.0/16".parse::<IpNetwork>().unwrap(),
+            "123.123.0.0/16".parse::<IpNetwork>().unwrap(),
+        ];
+        updated_network.save(&mut *conn).await.unwrap();
+
+        let used_ips = updated_network
+            .all_used_ips_for_network(&mut conn)
+            .await
+            .unwrap();
+
+        let result = device
+            .assign_next_network_ip(
+                &mut conn,
+                &updated_network,
+                &used_ips,
+                None,
+                Some(&initial_ips),
+            )
+            .await
+            .unwrap();
+
+        let new_ips = &result.wireguard_ips;
+        assert_eq!(new_ips.len(), 3, "should have one IP per subnet");
+
+        assert!(
+            new_ips.contains(&ip),
+            "10.0.0.234 should be kept - it is still within 10.0.0.0/16; got {new_ips:?}"
+        );
+
+        assert!(
+            !new_ips.contains(&ip2),
+            "123.10.33.44 should be reassigned - not within 123.12.0.0/16; got {new_ips:?}"
+        );
+        let narrowed_net: IpNetwork = "123.12.0.0/16".parse().unwrap();
+        assert!(
+            new_ips.iter().any(|ip| narrowed_net.contains(*ip)),
+            "a new IP within 123.12.0.0/16 should be assigned; got {new_ips:?}"
+        );
+
+        assert!(
+            new_ips.contains(&ip3),
+            "123.123.123.52 should be kept - it is still within 123.123.0.0/16; got {new_ips:?}"
+        );
+    }
+
+    /// Initial:  10.0.0.0/8  | 10.1.0.5
+    /// Modified: 10.0.0.0/16 | 10.1.0.5 should be replaced with a 10.0.x.x address
+    #[sqlx::test]
+    async fn test_assign_next_network_ip_subnet_narrowed(
+        _: PgPoolOptions,
+        options: PgConnectOptions,
+    ) {
+        let pool = setup_pool(options).await;
+
+        let mut network = WireguardNetwork::default();
+        network.try_set_address("10.0.0.1/8").unwrap();
+        let network = network.save(&pool).await.unwrap();
+
+        let user = User::new(
+            "testuser",
+            Some("password"),
+            "Tester",
+            "Test",
+            "test@test.com",
+            None,
+        )
+        .save(&pool)
+        .await
+        .unwrap();
+
+        let device = Device::new(
+            "dev1".into(),
+            "key1".into(),
+            user.id,
+            DeviceType::User,
+            None,
+            true,
+        )
+        .save(&pool)
+        .await
+        .unwrap();
+
+        let ip = IpAddr::from_str("10.1.0.5").unwrap();
+        let initial_ips = vec![ip];
+
+        let mut conn = pool.acquire().await.unwrap();
+        WireguardNetworkDevice::new(network.id, device.id, initial_ips.clone())
+            .insert(&mut *conn)
+            .await
+            .unwrap();
+
+        let mut updated_network = network.clone();
+        updated_network.address = vec!["10.0.0.0/16".parse::<IpNetwork>().unwrap()];
+        updated_network.save(&mut *conn).await.unwrap();
+
+        let used_ips = updated_network
+            .all_used_ips_for_network(&mut conn)
+            .await
+            .unwrap();
+
+        let result = device
+            .assign_next_network_ip(
+                &mut conn,
+                &updated_network,
+                &used_ips,
+                None,
+                Some(&initial_ips),
+            )
+            .await
+            .unwrap();
+
+        let new_ips = &result.wireguard_ips;
+        assert_eq!(new_ips.len(), 1, "should have one IP per subnet");
+
+        assert!(
+            !new_ips.contains(&ip),
+            "10.1.0.5 should be reassigned - outside narrowed 10.0.0.0/16; got {new_ips:?}"
+        );
+        let narrowed_net: IpNetwork = "10.0.0.0/16".parse().unwrap();
+        assert!(
+            new_ips.iter().all(|ip| narrowed_net.contains(*ip)),
+            "new IP must be within 10.0.0.0/16; got {new_ips:?}"
+        );
+    }
+
+    /// Initial:  123.123.123.0/24 | 123.123.123.254
+    /// Modified: 123.123.0.0/16   | 123.123.123.254 still fits
+    #[sqlx::test]
+    async fn test_assign_next_network_ip_still_valid_after_widening(
+        _: PgPoolOptions,
+        options: PgConnectOptions,
+    ) {
+        let pool = setup_pool(options).await;
+
+        let mut network = WireguardNetwork::default();
+        network.try_set_address("123.123.123.1/24").unwrap();
+        let network = network.save(&pool).await.unwrap();
+
+        let user = User::new(
+            "testuser",
+            Some("password"),
+            "Tester",
+            "Test",
+            "test@test.com",
+            None,
+        )
+        .save(&pool)
+        .await
+        .unwrap();
+
+        let device = Device::new(
+            "dev1".into(),
+            "key1".into(),
+            user.id,
+            DeviceType::User,
+            None,
+            true,
+        )
+        .save(&pool)
+        .await
+        .unwrap();
+
+        let ip = IpAddr::from_str("123.123.123.254").unwrap();
+        let initial_ips = vec![ip];
+
+        let mut conn = pool.acquire().await.unwrap();
+        WireguardNetworkDevice::new(network.id, device.id, initial_ips.clone())
+            .insert(&mut *conn)
+            .await
+            .unwrap();
+
+        let mut updated_network = network.clone();
+        updated_network.address = vec!["123.123.0.0/16".parse::<IpNetwork>().unwrap()];
+        updated_network.save(&mut *conn).await.unwrap();
+
+        let used_ips = updated_network
+            .all_used_ips_for_network(&mut conn)
+            .await
+            .unwrap();
+
+        let result = device
+            .assign_next_network_ip(
+                &mut conn,
+                &updated_network,
+                &used_ips,
+                None,
+                Some(&initial_ips),
+            )
+            .await
+            .unwrap();
+
+        let new_ips = &result.wireguard_ips;
+        assert_eq!(new_ips.len(), 1, "should have one IP per subnet");
+
+        assert!(
+            new_ips.contains(&ip),
+            "123.123.123.254 should be preserved - still within widened 123.123.0.0/16; got {new_ips:?}"
+        );
+    }
 }

--- a/crates/defguard_core/src/db/models/wireguard.rs
+++ b/crates/defguard_core/src/db/models/wireguard.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fmt::{self, Display},
     iter::zip,
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
@@ -553,11 +553,13 @@ impl WireguardNetwork<Id> {
             "Assigning IPs in network {} for all existing devices ",
             self
         );
+        let mut used_ips = self.all_used_ips_for_network(&mut *transaction).await?;
         let devices = self.get_allowed_devices(&mut *transaction).await?;
         for device in devices {
-            device
-                .assign_next_network_ip(&mut *transaction, self, None, None)
+            let wireguard_network_device = device
+                .assign_next_network_ip(&mut *transaction, self, &used_ips, None, None)
                 .await?;
+            used_ips.extend(wireguard_network_device.wireguard_ips);
         }
         Ok(())
     }
@@ -572,9 +574,10 @@ impl WireguardNetwork<Id> {
         info!("Assigning IP in network {self} for {device}");
         let allowed_devices = self.get_allowed_devices(&mut *transaction).await?;
         let allowed_device_ids: Vec<i64> = allowed_devices.iter().map(|dev| dev.id).collect();
+        let used_ips = self.all_used_ips_for_network(&mut *transaction).await?;
         if allowed_device_ids.contains(&device.id) {
             let wireguard_network_device = device
-                .assign_next_network_ip(&mut *transaction, self, reserved_ips, None)
+                .assign_next_network_ip(&mut *transaction, self, &used_ips, reserved_ips, None)
                 .await?;
             Ok(wireguard_network_device)
         } else {
@@ -609,6 +612,7 @@ impl WireguardNetwork<Id> {
         // Loop through current device configurations; remove no longer allowed, readdress
         // when necessary; remove processed entry from all devices list initial list should
         // now contain only devices to be added.
+        let mut used_ips = self.all_used_ips_for_network(&mut *transaction).await?;
         let mut events: Vec<GatewayEvent> = Vec::new();
         for device_network_config in currently_configured_devices {
             // Device is allowed and an IP was already assigned
@@ -621,10 +625,12 @@ impl WireguardNetwork<Id> {
                         .assign_next_network_ip(
                             &mut *transaction,
                             self,
+                            &used_ips,
                             reserved_ips,
                             Some(&device_network_config.wireguard_ips),
                         )
                         .await?;
+                    used_ips.extend(wireguard_network_device.wireguard_ips.iter().copied());
                     events.push(GatewayEvent::DeviceModified(DeviceInfo {
                         device,
                         network_info: vec![DeviceNetworkInfo {
@@ -642,6 +648,8 @@ impl WireguardNetwork<Id> {
                     device_network_config.device_id
                 );
                 device_network_config.delete(&mut *transaction).await?;
+                // Remove freed IPs so they can be reused by later assignments
+                used_ips.retain(|ip| !device_network_config.wireguard_ips.contains(ip));
                 if let Some(device) =
                     Device::find_by_id(&mut *transaction, device_network_config.device_id).await?
                 {
@@ -665,8 +673,9 @@ impl WireguardNetwork<Id> {
         // Add configs for new allowed devices
         for device in allowed_devices.into_values() {
             let wireguard_network_device = device
-                .assign_next_network_ip(&mut *transaction, self, reserved_ips, None)
+                .assign_next_network_ip(&mut *transaction, self, &used_ips, reserved_ips, None)
                 .await?;
+            used_ips.extend(wireguard_network_device.wireguard_ips.iter().copied());
             events.push(GatewayEvent::DeviceCreated(DeviceInfo {
                 device,
                 network_info: vec![DeviceNetworkInfo {
@@ -1297,6 +1306,20 @@ impl WireguardNetwork<Id> {
             LocationMfaMode::Internal | LocationMfaMode::External => true,
             LocationMfaMode::Disabled => false,
         }
+    }
+
+    /// Obtain all used IP addresses for network.
+    pub(crate) async fn all_used_ips_for_network(
+        &self,
+        transaction: &mut PgConnection,
+    ) -> Result<HashSet<IpAddr>, SqlxError> {
+        let all_devices =
+            WireguardNetworkDevice::all_for_network(&mut *transaction, self.id).await?;
+        let used_ips: HashSet<IpAddr> = all_devices
+            .into_iter()
+            .flat_map(|device| device.wireguard_ips)
+            .collect();
+        Ok(used_ips)
     }
 
     // fetch all locations using external MFA

--- a/crates/defguard_core/src/lib.rs
+++ b/crates/defguard_core/src/lib.rs
@@ -798,6 +798,10 @@ pub async fn init_dev_env(config: &DefGuardConfig) {
         info!("Test device exists already, skipping creation...");
     } else {
         info!("Creating test device");
+        let used_ips = network
+            .all_used_ips_for_network(&mut transaction)
+            .await
+            .expect("Failed to query used IPs from database");
         let device = Device::new(
             "TestDevice".to_string(),
             "gQYL5eMeFDj0R+lpC7oZyIl0/sNVmQDC6ckP7husZjc=".to_string(),
@@ -810,7 +814,7 @@ pub async fn init_dev_env(config: &DefGuardConfig) {
         .await
         .expect("Could not save device");
         device
-            .assign_next_network_ip(&mut transaction, &network, None, None)
+            .assign_next_network_ip(&mut transaction, &network, &used_ips, None, None)
             .await
             .expect("Could not assign IP to device");
     }

--- a/web/src/pages/network/NetworkPage.tsx
+++ b/web/src/pages/network/NetworkPage.tsx
@@ -22,6 +22,7 @@ export const NetworkPage = () => {
   } = useApi();
   const { LL } = useI18nContext();
   const setNetworks = useNetworkPageStore((state) => state.setNetworks);
+  const selectedNetworkId = useNetworkPageStore((state) => state.selectedNetworkId);
   const { breakpoint } = useBreakpoint(deviceBreakpoints);
 
   const { data: networksData } = useQuery({
@@ -44,7 +45,7 @@ export const NetworkPage = () => {
       {breakpoint === 'desktop' && <NetworkTabs />}
       <Card className="network-card" hideMobile>
         <NetworkControls />
-        <NetworkEditForm />
+        <NetworkEditForm key={selectedNetworkId} />
         <NetworkGatewaySetup />
       </Card>
     </PageContainer>


### PR DESCRIPTION
This ports the IP assignment optimization added in https://github.com/DefGuard/defguard/pull/2160.

Also forces location edit form remount due to reports of stale data not being reset.