### PR TITLE
add password reset disabled email

### DIFF
--- a/crates/defguard_core/src/enterprise/db/models/enterprise_settings.rs
+++ b/crates/defguard_core/src/enterprise/db/models/enterprise_settings.rs
@@ -1,3 +1,4 @@
+use defguard_common::db::models::Settings;
 use sqlx::{PgExecutor, Type, query, query_as};
 use struct_patch::Patch;
 
@@ -57,6 +58,15 @@ impl EnterpriseSettings {
         } else {
             Ok(Self::default())
         }
+    }
+
+    /// The effective password-reset visibility for Edge components.
+    /// Password reset requires email delivery, so if SMTP is missing the
+    /// option should not appear even when the admin toggle is on.
+    #[must_use]
+    pub fn edge_can_display_password_reset(&self) -> bool {
+        let settings = Settings::get_current_settings();
+        self.display_password_reset && settings.smtp_configured()
     }
 
     pub(crate) async fn save<'e, E>(&self, executor: E) -> Result<(), sqlx::Error>

--- a/crates/defguard_core/src/enterprise/handlers/enterprise_settings.rs
+++ b/crates/defguard_core/src/enterprise/handlers/enterprise_settings.rs
@@ -69,7 +69,7 @@ pub async fn patch_enterprise_settings(
         && let Err(err) = appstate
             .proxy_control_tx
             .send(ProxyControlMessage::BroadcastPublicSettings {
-                display_password_reset: settings.display_password_reset,
+                display_password_reset: settings.edge_can_display_password_reset(),
                 display_download_step: settings.display_download_step,
             })
             .await

--- a/crates/defguard_core/src/enterprise/license.rs
+++ b/crates/defguard_core/src/enterprise/license.rs
@@ -26,10 +26,12 @@ use strum::VariantArray;
 use thiserror::Error;
 use tokio::time::sleep;
 
-use super::limits::Counts;
-use crate::grpc::proto::enterprise::license::{
-    LicenseFeature as LicenseFeatureProto, LicenseKey, LicenseLimits, LicenseMetadata,
-    LicenseTier as LicenseTierProto, SupportType as SupportTypeProto,
+use crate::{
+    enterprise::limits::Counts,
+    grpc::proto::enterprise::license::{
+        LicenseFeature as LicenseFeatureProto, LicenseKey, LicenseLimits, LicenseMetadata,
+        LicenseTier as LicenseTierProto, SupportType as SupportTypeProto,
+    },
 };
 
 const LICENSE_SERVER_URL: &str = "https://pkgs.defguard.net/api/license/renew";
@@ -707,9 +709,10 @@ pub async fn run_periodic_license_check(
 
             // When the license is removed or expired, revert Edge UI controls
             // to their defaults so proxies no longer apply restricted settings.
+            let settings = Settings::get_current_settings();
             if let Err(err) = proxy_control_tx
                 .send(ProxyControlMessage::BroadcastPublicSettings {
-                    display_password_reset: true,
+                    display_password_reset: settings.smtp_configured(),
                     display_download_step: true,
                 })
                 .await

--- a/crates/defguard_core/src/handlers/settings.rs
+++ b/crates/defguard_core/src/handlers/settings.rs
@@ -3,12 +3,15 @@ use axum::{
     extract::{Json, Path, State},
     http::StatusCode,
 };
-use defguard_common::db::{
-    Id,
-    models::{
-        Settings, SettingsEssentials,
-        settings::{LdapSyncStatus, SettingsPatch, update_current_settings},
+use defguard_common::{
+    db::{
+        Id,
+        models::{
+            Settings, SettingsEssentials,
+            settings::{LdapSyncStatus, SettingsPatch, update_current_settings},
+        },
     },
+    types::proxy::ProxyControlMessage,
 };
 use sqlx::PgPool;
 use struct_patch::Patch;
@@ -17,7 +20,10 @@ use super::{ApiResponse, ApiResult};
 use crate::{
     AppState,
     auth::{AdminRole, SessionInfo},
-    enterprise::{handlers::LicenseInfo, ldap::LDAPConnection, license::update_cached_license},
+    enterprise::{
+        db::models::enterprise_settings::EnterpriseSettings, handlers::LicenseInfo,
+        ldap::LDAPConnection, license::update_cached_license,
+    },
     error::WebError,
     events::{ApiEvent, ApiEventType, ApiRequestContext},
 };
@@ -60,6 +66,24 @@ pub(crate) async fn update_settings(
 
     update_current_settings(&appstate.pool, data).await?;
     update_cached_license(license.as_deref())?;
+
+    // If SMTP configuration changed (e.g. server/port/sender toggled),
+    // push updated password-reset visibility to all connected proxies.
+    if before.smtp_configured() != after.smtp_configured()
+        && let Ok(enterprise_settings) = EnterpriseSettings::get(&appstate.pool).await
+    {
+        let display_password_reset = enterprise_settings.edge_can_display_password_reset();
+        if let Err(err) = appstate
+            .proxy_control_tx
+            .send(ProxyControlMessage::BroadcastPublicSettings {
+                display_password_reset,
+                display_download_step: enterprise_settings.display_download_step,
+            })
+            .await
+        {
+            error!("Failed to broadcast PublicSettings after SMTP config change: {err:?}");
+        }
+    }
 
     info!("User {} updated settings", session.user.username);
     appstate.emit_event(ApiEvent {
@@ -156,6 +180,24 @@ pub async fn patch_settings(
     if let Some(license_key) = &license {
         update_cached_license(license_key.as_deref())?;
         debug!("Updated cached license after saving settings patch");
+    }
+
+    // If SMTP configuration changed (e.g. server/port/sender toggled),
+    // push updated password-reset visibility to all connected proxies.
+    if before.smtp_configured() != after.smtp_configured()
+        && let Ok(enterprise_settings) = EnterpriseSettings::get(&appstate.pool).await
+    {
+        let display_password_reset = enterprise_settings.edge_can_display_password_reset();
+        if let Err(err) = appstate
+            .proxy_control_tx
+            .send(ProxyControlMessage::BroadcastPublicSettings {
+                display_password_reset,
+                display_download_step: enterprise_settings.display_download_step,
+            })
+            .await
+        {
+            error!("Failed to broadcast PublicSettings after SMTP config change: {err:?}");
+        }
     }
 
     info!("Admin {} patched settings", session.user.username);

--- a/crates/defguard_core/src/mail/mod.rs
+++ b/crates/defguard_core/src/mail/mod.rs
@@ -334,6 +334,7 @@ pub enum MailMessage {
     MFACode,
     PasswordReset,
     PasswordResetDone,
+    PasswordResetDisabled,
     UserImportBlocked,
     /// Enrollment notification for admins.
     EnrollmentNotification,
@@ -371,6 +372,7 @@ impl MailMessage {
             Self::MFACode => "Defguard: Multi-Factor Authentication code for login".to_string(),
             Self::PasswordReset => "Defguard: Password reset".to_string(),
             Self::PasswordResetDone => "Defguard: Password reset success".to_string(),
+            Self::PasswordResetDisabled => "Defguard: Password reset disabled".to_string(),
             Self::UserImportBlocked => "User import blocked".to_string(),
             Self::EnrollmentNotification => "Defguard: User enrollment completed".to_string(),
             Self::LetsencryptCertRefreshFailed => {
@@ -398,6 +400,7 @@ impl MailMessage {
             Self::MFACode => "mfa-code",
             Self::PasswordReset => "password-reset",
             Self::PasswordResetDone => "password-reset-done",
+            Self::PasswordResetDisabled => "password-reset-disabled",
             Self::UserImportBlocked => "user-import-blocked",
             Self::EnrollmentNotification => "enrollment-admin-notification",
             Self::LetsencryptCertRefreshFailed => "letsencrypt-cert-refresh-failed",
@@ -423,6 +426,7 @@ impl MailMessage {
             Self::MFACode => include_str!("templates/mfa-code.mjml"),
             Self::PasswordReset => include_str!("templates/password-reset.mjml"),
             Self::PasswordResetDone => include_str!("templates/password-reset-done.mjml"),
+            Self::PasswordResetDisabled => include_str!("templates/password-reset-disabled.mjml"),
             Self::UserImportBlocked => include_str!("templates/plain-notification.mjml"),
             Self::EnrollmentNotification => {
                 include_str!("templates/enrollment-admin-notification.mjml")
@@ -453,6 +457,7 @@ impl MailMessage {
             Self::MFACode => include_str!("templates/mfa-code.text"),
             Self::PasswordReset => include_str!("templates/password-reset.text"),
             Self::PasswordResetDone => include_str!("templates/password-reset-done.text"),
+            Self::PasswordResetDisabled => include_str!("templates/password-reset-disabled.text"),
             Self::UserImportBlocked => include_str!("templates/plain-notification.text"),
             Self::EnrollmentNotification => {
                 include_str!("templates/enrollment-admin-notification.text")

--- a/crates/defguard_core/src/mail/templates.rs
+++ b/crates/defguard_core/src/mail/templates.rs
@@ -614,6 +614,23 @@ pub async fn password_reset_success_mail(
     Ok(())
 }
 
+/// Notification that password reset has been disabled for this user.
+pub async fn password_reset_disabled_mail(
+    to: &str,
+    conn: &mut PgConnection,
+    ip_address: Option<&str>,
+    device_info: Option<&str>,
+) -> Result<(), TemplateError> {
+    let (mut tera, mut context) =
+        get_base_tera_mjml(Context::new(), None, ip_address, device_info)?;
+
+    let message = MailMessage::PasswordResetDisabled;
+    message.fill_context(conn, &mut context).await?;
+    message.mail(&mut tera, &context, to)?.send_and_forget();
+
+    Ok(())
+}
+
 /// Certificate is about to expire.
 pub async fn certificate_expiration_mail(
     to: &str,

--- a/crates/defguard_core/src/mail/templates/password-reset-disabled.mjml
+++ b/crates/defguard_core/src/mail/templates/password-reset-disabled.mjml
@@ -1,0 +1,17 @@
+{% import "macros.mjml" as macros %}
+{% extends "base.mjml" %}
+{% block content %}
+
+{{ macros::email_header() }}
+
+<mj-section>
+  <mj-column>
+    <mj-text mj-class="t-body-sm-400" css-class="fg-neutral-c">
+      {{ notification_text }}
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+{{ macros::footer_divider() }}
+
+{% endblock content %}

--- a/crates/defguard_core/src/mail/templates/password-reset-disabled.text
+++ b/crates/defguard_core/src/mail/templates/password-reset-disabled.text
@@ -1,0 +1,4 @@
+{{ title }}
+{% if subtitle %}{{ subtitle }}{% endif %}
+
+{{ notification_text }}

--- a/crates/defguard_core/tests/integration/api/settings.rs
+++ b/crates/defguard_core/tests/integration/api/settings.rs
@@ -1,12 +1,19 @@
-use defguard_common::db::models::{
-    Settings,
-    settings::{SettingsPatch, update_current_settings},
+use std::time::Duration;
+
+use defguard_common::{
+    db::models::{
+        Settings,
+        settings::{SettingsPatch, update_current_settings},
+    },
+    types::proxy::ProxyControlMessage,
 };
 use defguard_core::handlers::Auth;
 use reqwest::StatusCode;
+use serde_json::json;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
+use tokio::time::sleep;
 
-use super::common::{make_test_client, setup_pool};
+use super::common::{exceed_enterprise_limits, make_test_client, setup_pool};
 
 #[sqlx::test]
 async fn test_settings(_: PgPoolOptions, options: PgConnectOptions) {
@@ -299,5 +306,70 @@ async fn test_ldap_remote_enrollment_validation(_: PgPoolOptions, options: PgCon
     assert!(
         from_db.ldap_remote_enrollment_send_invite,
         "ldap_remote_enrollment_send_invite must be persisted to DB after enabling"
+    );
+}
+
+/// When SMTP settings change from unconfigured to configured via the settings
+/// API, a `BroadcastPublicSettings` control message must be sent so connected
+/// proxies receive the updated password-reset visibility.
+///
+/// The `display_password_reset` in the broadcast is the folded value
+/// (`enterprise_toggle && smtp_configured()`).
+#[sqlx::test]
+async fn test_smtp_change_triggers_public_settings_broadcast(
+    _: PgPoolOptions,
+    options: PgConnectOptions,
+) {
+    let pool = setup_pool(options).await;
+    let (client, client_state) = make_test_client(pool).await;
+    let mut proxy_control_rx = client_state.proxy_control_rx;
+
+    exceed_enterprise_limits(&client).await;
+
+    // Drain any messages sent during setup (e.g. from app startup).
+    while proxy_control_rx.try_recv().is_ok() {}
+
+    // Patch settings to enable SMTP.  Previously SMTP is unconfigured, so
+    // smtp_configured() transitions from false → true and the handler must
+    // broadcast the updated public settings.
+    let settings = json!({
+        "smtp_server": "smtp.example.com",
+        "smtp_port": 587,
+        "smtp_sender": "noreply@example.com",
+    });
+    let response = client
+        .patch("/api/v1/settings")
+        .json(&settings)
+        .send()
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Allow the async broadcast to land.
+    sleep(Duration::from_millis(100)).await;
+
+    let mut found = false;
+    loop {
+        match proxy_control_rx.try_recv() {
+            Ok(ProxyControlMessage::BroadcastPublicSettings {
+                display_password_reset,
+                display_download_step,
+            }) => {
+                assert!(
+                    display_password_reset,
+                    "with SMTP configured, display_password_reset should be true"
+                );
+                assert!(
+                    display_download_step,
+                    "display_download_step should remain the enterprise default"
+                );
+                found = true;
+            }
+            Ok(_) => {} // ignore other control messages
+            Err(_) => break,
+        }
+    }
+    assert!(
+        found,
+        "BroadcastPublicSettings should have been sent after SMTP config change"
     );
 }

--- a/crates/defguard_proxy_manager/src/handler.rs
+++ b/crates/defguard_proxy_manager/src/handler.rs
@@ -399,7 +399,7 @@ impl ProxyHandler {
             // Push public settings (Edge UI controls) to the newly-connected proxy.
             if let Ok(settings) = EnterpriseSettings::get(&self.pool).await {
                 let public_settings = PublicSettings {
-                    display_password_reset: settings.display_password_reset,
+                    display_password_reset: settings.edge_can_display_password_reset(),
                     display_download_step: settings.display_download_step,
                 };
                 let _ = tx.send(CoreResponse {
@@ -1202,7 +1202,7 @@ impl ProxyHandler {
         // Push public settings to the test proxy.
         if let Ok(settings) = EnterpriseSettings::get(&self.pool).await {
             let public_settings = PublicSettings {
-                display_password_reset: settings.display_password_reset,
+                display_password_reset: settings.edge_can_display_password_reset(),
                 display_download_step: settings.display_download_step,
             };
             let _ = tx.send(CoreResponse {

--- a/crates/defguard_proxy_manager/src/servers/password_reset.rs
+++ b/crates/defguard_proxy_manager/src/servers/password_reset.rs
@@ -2,7 +2,8 @@ use defguard_common::db::models::{Settings, User};
 use defguard_core::{
     db::models::enrollment::{PASSWORD_RESET_TOKEN_TYPE, Token},
     enterprise::{
-        db::models::enterprise_settings::EnterpriseSettings, ldap::utils::ldap_change_password,
+        db::models::{enterprise_settings::EnterpriseSettings, openid_provider::OpenIdProvider},
+        ldap::utils::ldap_change_password,
     },
     events::{
         BidiRequestContext, BidiStreamEvent, BidiStreamEventType, LdapSyncEventType,
@@ -11,7 +12,9 @@ use defguard_core::{
     grpc::utils::parse_client_ip_agent,
     handlers::user::check_password_strength,
     headers::get_device_info,
-    mail::templates::{password_reset_mail, password_reset_success_mail},
+    mail::templates::{
+        password_reset_disabled_mail, password_reset_mail, password_reset_success_mail,
+    },
 };
 use defguard_proto::proxy::{
     DeviceInfo, PasswordResetInitializeRequest, PasswordResetRequest, PasswordResetStartRequest,
@@ -130,12 +133,59 @@ impl PasswordResetServer {
             return Ok(());
         };
 
-        // Do not allow password change if user is disabled or not enrolled
-        if !user.has_password() || !user.is_active {
+        // Do not allow password reset for inactive (disabled) users.
+        if !user.is_active {
             debug!(
-                "Password reset skipped for disabled or not enrolled user {} ({email})",
+                "Password reset skipped for disabled user {} ({email})",
                 user.username
             );
+            return Ok(());
+        }
+
+        // Externally-managed users get a clear feedback email;
+        // other passwordless users (e.g. half-enrolled) stay silent.
+        if !user.has_password() {
+            let is_admin = user.is_admin(&self.pool).await.map_err(|err| {
+                error!("Failed to check if user is admin: {err}");
+                Status::internal("unexpected error")
+            })?;
+            let settings = Settings::get_current_settings();
+            let oidc_disable_password_management =
+                OpenIdProvider::current_disables_password_management(&self.pool)
+                    .await
+                    .map_err(|err| {
+                        error!("Failed to check OIDC password management flag: {err}");
+                        Status::internal("unexpected error")
+                    })?;
+
+            if user.password_management_disabled(
+                is_admin,
+                &settings,
+                oidc_disable_password_management,
+            ) {
+                debug!(
+                    "Password reset disabled for externally-managed user {} ({email})",
+                    user.username
+                );
+                if let Err(err) = password_reset_disabled_mail(
+                    &user.email,
+                    &mut *self.pool.acquire().await.map_err(|err| {
+                        error!("Failed to acquire DB connection: {err}");
+                        Status::internal("unexpected error")
+                    })?,
+                    Some(&ip_address),
+                    Some(&device_info),
+                )
+                .await
+                {
+                    error!("Failed to send password reset disabled email: {err}");
+                }
+            } else {
+                debug!(
+                    "Password reset skipped for passwordless user {} ({email})",
+                    user.username
+                );
+            }
             return Ok(());
         }
 

--- a/crates/defguard_proxy_manager/src/tests/proxy_manager/handler/mod.rs
+++ b/crates/defguard_proxy_manager/src/tests/proxy_manager/handler/mod.rs
@@ -1,4 +1,4 @@
-mod support;
+pub(crate) mod support;
 
 mod acme;
 mod enrollment;

--- a/crates/defguard_proxy_manager/src/tests/proxy_manager/handler/password_reset.rs
+++ b/crates/defguard_proxy_manager/src/tests/proxy_manager/handler/password_reset.rs
@@ -1,4 +1,7 @@
-use defguard_common::db::models::User;
+use defguard_common::db::models::{
+    User,
+    settings::{Settings, update_current_settings},
+};
 use defguard_core::events::{BidiStreamEventType, PasswordResetEvent};
 use defguard_proto::proxy::core_response;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
@@ -213,6 +216,98 @@ async fn test_password_reset_start_wrong_token_type_returns_error(
         code,
         tonic::Code::PermissionDenied,
         "enrollment token used in PasswordResetStart must return PermissionDenied"
+    );
+
+    context.finish().await.expect_server_finished().await;
+}
+
+/// An externally-managed (LDAP) user with password management disabled must
+/// receive a "disabled" notification email and no password reset token must be
+/// created. The HTTP/gRPC response is indistinguishable from an unknown email.
+#[sqlx::test]
+async fn test_password_reset_init_disabled_user_no_token(
+    _: PgPoolOptions,
+    options: PgConnectOptions,
+) {
+    let mut context = HandlerTestContext::new(options).await;
+    complete_proxy_handshake(&mut context).await;
+
+    // Enable LDAP password management disabling in settings.
+    let mut settings = Settings::get_current_settings();
+    settings.ldap_disable_password_management = true;
+    update_current_settings(&context.pool, settings)
+        .await
+        .unwrap();
+
+    // Create an LDAP-sourced user without a local password.
+    let mut user = create_user(&context.pool).await;
+    user.from_ldap = true;
+    user.save(&context.pool)
+        .await
+        .expect("failed to save LDAP user");
+
+    let response = send_password_reset_init(&mut context, &user.email).await;
+
+    // Response must be Empty — indistinguishable from unknown email.
+    match &response.payload {
+        Some(core_response::Payload::Empty(())) => {}
+        _ => panic!(
+            "expected Empty response for disabled user, got: {:?}",
+            response.payload.as_ref().map(std::mem::discriminant)
+        ),
+    }
+
+    // No PASSWORD_RESET token must have been created.
+    let count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM token WHERE user_id = $1 AND token_type = 'PASSWORD_RESET'",
+    )
+    .bind(user.id)
+    .fetch_one(&context.pool)
+    .await
+    .expect("failed to query token count");
+    assert_eq!(
+        count.0, 0,
+        "no password reset token should be created for disabled user"
+    );
+
+    context.finish().await.expect_server_finished().await;
+}
+
+/// A user without a local password who is NOT externally-managed must receive
+/// the same silent `Empty` response and no token — no feedback sent at all.
+#[sqlx::test]
+async fn test_password_reset_init_passwordless_user_silent_no_token(
+    _: PgPoolOptions,
+    options: PgConnectOptions,
+) {
+    let mut context = HandlerTestContext::new(options).await;
+    complete_proxy_handshake(&mut context).await;
+
+    // Create a user with no password and no external IdP affiliation.
+    let user = create_user(&context.pool).await;
+
+    let response = send_password_reset_init(&mut context, &user.email).await;
+
+    // Response must be Empty — silent, same as unknown email.
+    match &response.payload {
+        Some(core_response::Payload::Empty(())) => {}
+        _ => panic!(
+            "expected Empty response for passwordless user, got: {:?}",
+            response.payload.as_ref().map(std::mem::discriminant)
+        ),
+    }
+
+    // No PASSWORD_RESET token must have been created.
+    let count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM token WHERE user_id = $1 AND token_type = 'PASSWORD_RESET'",
+    )
+    .bind(user.id)
+    .fetch_one(&context.pool)
+    .await
+    .expect("failed to query token count");
+    assert_eq!(
+        count.0, 0,
+        "no password reset token should be created for passwordless user"
     );
 
     context.finish().await.expect_server_finished().await;

--- a/crates/defguard_proxy_manager/src/tests/proxy_manager/manager.rs
+++ b/crates/defguard_proxy_manager/src/tests/proxy_manager/manager.rs
@@ -1,12 +1,18 @@
 use std::time::Duration;
 
-use defguard_common::types::proxy::ProxyControlMessage;
+use defguard_common::{
+    db::models::settings::{Settings, update_current_settings},
+    types::proxy::ProxyControlMessage,
+};
 use defguard_proto::proxy::core_response;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 
-use crate::tests::common::{
-    ManagerTestContext, MockProxyHarness, create_proxy, create_proxy_with_enabled,
-    mock_proxy_socket_path, reload_proxy, wait_for_proxy_connection_state,
+use crate::tests::{
+    common::{
+        ManagerTestContext, MockProxyHarness, create_proxy, create_proxy_with_enabled,
+        mock_proxy_socket_path, reload_proxy, wait_for_proxy_connection_state,
+    },
+    proxy_manager::handler::support::configure_smtp,
 };
 
 const FAST_RETRY_DELAY: Duration = Duration::from_millis(20);
@@ -606,8 +612,8 @@ async fn test_broadcast_public_settings_reaches_proxy(_: PgPoolOptions, options:
 }
 
 /// When connected without a Business license, `EnterpriseSettings::get()` returns
-/// defaults (both `true`), so the `PublicSettings` pushed on connect should have
-/// both flags set to `true`.
+/// defaults (both `true`), but `display_password_reset` is folded with SMTP
+/// configuration. Without SMTP configured the flag must be `false`.
 #[sqlx::test]
 async fn test_public_settings_pushed_on_connect(_: PgPoolOptions, options: PgConnectOptions) {
     let mut context = ManagerTestContext::new(options).await;
@@ -625,12 +631,50 @@ async fn test_public_settings_pushed_on_connect(_: PgPoolOptions, options: PgCon
     match response.payload {
         Some(core_response::Payload::PublicSettings(s)) => {
             assert!(
-                s.display_password_reset,
-                "display_password_reset should default to true"
+                !s.display_password_reset,
+                "display_password_reset should be false without SMTP"
             );
             assert!(
                 s.display_download_step,
                 "display_download_step should default to true"
+            );
+        }
+        other => panic!(
+            "expected PublicSettings on connect, got: {:?}",
+            other.as_ref().map(std::mem::discriminant)
+        ),
+    }
+
+    context.finish().await;
+}
+
+/// When SMTP is configured, `EnterpriseSettings::edge_can_display_password_reset()`
+/// returns the admin toggle unmodified, so the default `true` passes through.
+#[sqlx::test]
+async fn test_public_settings_on_connect_with_smtp(_: PgPoolOptions, options: PgConnectOptions) {
+    let mut context = ManagerTestContext::new(options).await;
+
+    // Enable SMTP so the fold passes through the enterprise default.
+    let mut settings = Settings::get_current_settings();
+    configure_smtp(&mut settings);
+    update_current_settings(&context.pool, settings)
+        .await
+        .unwrap();
+
+    let proxy = create_proxy(&context.pool).await;
+    let mut mock = MockProxyHarness::start().await;
+    context.register_proxy_mock(&proxy, &mock);
+
+    context.start().await;
+    mock.wait_connected().await;
+    mock.recv_initial_info().await;
+
+    let response = mock.recv_outbound().await;
+    match response.payload {
+        Some(core_response::Payload::PublicSettings(s)) => {
+            assert!(
+                s.display_password_reset,
+                "display_password_reset should be true with SMTP configured"
             );
         }
         other => panic!(

--- a/migrations/20260701000000_[2.1.0]_password_reset_disabled_mail.down.sql
+++ b/migrations/20260701000000_[2.1.0]_password_reset_disabled_mail.down.sql
@@ -1,0 +1,1 @@
+DELETE FROM mail_context WHERE template = 'password-reset-disabled';

--- a/migrations/20260701000000_[2.1.0]_password_reset_disabled_mail.up.sql
+++ b/migrations/20260701000000_[2.1.0]_password_reset_disabled_mail.up.sql
@@ -1,0 +1,4 @@
+INSERT INTO mail_context (template, section, language_tag, text) VALUES
+    ('password-reset-disabled', 'title', 'en_US', 'Password reset not available'),
+    ('password-reset-disabled', 'subtitle', 'en_US', 'Your administrator has disabled password management for your account.'),
+    ('password-reset-disabled', 'notification_text', 'en_US', 'Your account is managed by an external identity provider. Password reset is not available for your account. Please contact your administrator if you need assistance.');


### PR DESCRIPTION
- add an email notification if password management is disabled for a given user
- don't show password reset option in Edge UI if SMTP is not configured

Closes https://github.com/DefGuard/proxy/issues/313