### PR TITLE
Ignore draft releases in APT tests

### DIFF
--- a/.github/workflows/test-apt-repo.yml
+++ b/.github/workflows/test-apt-repo.yml
@@ -74,7 +74,7 @@ jobs:
             -H "Authorization: Bearer $GH_TOKEN" \
             https://api.github.com/repos/${{ matrix.github_repo }}/releases \
             | jq -r --argjson pre "$PRERELEASE" --arg major "$MAJOR" \
-              '[.[] | select(.prerelease == $pre and (.tag_name | startswith($major)))][0].tag_name // empty')
+              '[.[] | select(.draft == false and .prerelease == $pre and (.tag_name | startswith($major)))][0].tag_name // empty')
           if [ -z "$VERSION" ]; then
             echo "::notice::no $MAJOR release (prerelease=$PRERELEASE) of ${{ matrix.package }} on GitHub, skipping"
             echo "SKIP=true" >> $GITHUB_ENV


### PR DESCRIPTION
The apt tests were failing since it pulled draft release for 2.0.2