### PR TITLE
add missing SMTP setup in password reset test

### DIFF
--- a/e2e/tests/passwordReset.spec.ts
+++ b/e2e/tests/passwordReset.spec.ts
@@ -9,7 +9,9 @@ import {
   selectPasswordReset,
   setEmail,
   setPassword,
+  waitForEdgePasswordResetEnabled,
 } from '../utils/controllers/passwordReset';
+import { setupSMTP } from '../utils/controllers/settings';
 import { disableUser } from '../utils/controllers/toggleUserState';
 import { getPasswordResetToken } from '../utils/db/getPasswordResetToken';
 import { dockerRestart } from '../utils/docker';
@@ -25,8 +27,11 @@ test.describe('Reset password', () => {
     await createUser(browser, user);
   });
 
-  test('Reset user password', async ({ page }) => {
+  test('Reset user password', async ({ page, browser }) => {
     await waitForBase(page);
+    // Password reset is only shown on Edge once SMTP is configured in Core.
+    await setupSMTP(browser);
+    await waitForEdgePasswordResetEnabled(page);
     await page.goto(testsConfig.ENROLLMENT_URL);
     await selectPasswordReset(page);
     await setEmail(user.mail, page);
@@ -48,6 +53,9 @@ test.describe('Reset password', () => {
   // TODO: Enable when https://github.com/DefGuard/defguard/issues/2425 is fixed
   test.skip('Reset disabled user password', async ({ page, browser }) => {
     await waitForBase(page);
+    // Password reset is only shown on Edge once SMTP is configured in Core.
+    await setupSMTP(browser);
+    await waitForEdgePasswordResetEnabled(page);
     await page.goto(testsConfig.ENROLLMENT_URL);
     await selectPasswordReset(page);
     await setEmail(user.mail, page);

--- a/e2e/utils/controllers/mfa/enableEmail.ts
+++ b/e2e/utils/controllers/mfa/enableEmail.ts
@@ -1,38 +1,17 @@
 import { Browser } from 'playwright';
 import { TOTP } from 'totp-generator';
 
-import { defaultUserAdmin, routes } from '../../../config';
+import { routes } from '../../../config';
 import { User } from '../../../types';
 import { extractEmailSecret } from '../../db/extractEmailSecret';
 import { waitForBase } from '../../waitForBase';
 import { acceptRecovery } from '../acceptRecovery';
 import { loginBasic } from '../login';
-import { logout } from '../logout';
+import { setupSMTP } from '../settings';
 
 export type EnableEmailResult = {
   secret: string;
   recoveryCodes?: string[];
-};
-
-export const setupSMTP = async (browser: Browser) => {
-  const context = await browser.newContext();
-  const page = await context.newPage();
-  await waitForBase(page);
-  await loginBasic(page, defaultUserAdmin);
-  await page.goto(routes.base + routes.settings.smtp);
-  await page.getByTestId('smtp-card-basic-configure').click();
-  await page.getByTestId('field-smtp_server').waitFor({ state: 'visible' });
-  await page.getByTestId('field-smtp_server').fill('testServer.com');
-  await page.getByTestId('field-smtp_port').fill('543');
-  await page.getByTestId('field-smtp_user').fill('testuser');
-  await page.getByTestId('field-smtp_password').fill('test');
-  await page.getByTestId('field-smtp_sender').fill('test@test.com');
-  const saveButton = await page.getByTestId('submit');
-  if (await saveButton.isEnabled()) {
-    await saveButton.click();
-  }
-  await logout(page);
-  await context.close();
 };
 
 export const enableEmailMFA = async (

--- a/e2e/utils/controllers/passwordReset.ts
+++ b/e2e/utils/controllers/passwordReset.ts
@@ -1,4 +1,25 @@
+import { expect } from '@playwright/test';
 import { Page } from 'playwright';
+
+import { testsConfig } from '../../config';
+
+// The Edge home page only shows the password-reset option once Core reports
+// display_password_reset === true (which requires SMTP to be configured and the
+// setting enabled). Core pushes that value to the proxy asynchronously, so poll
+// the proxy's public info endpoint until it is reflected before navigating.
+export const waitForEdgePasswordResetEnabled = async (page: Page) => {
+  await expect
+    .poll(
+      async () => {
+        const res = await page.request.get(`${testsConfig.ENROLLMENT_URL}/api/v1/info`);
+        if (!res.ok()) return false;
+        const body = await res.json();
+        return body.display_password_reset === true;
+      },
+      { timeout: 30_000 },
+    )
+    .toBe(true);
+};
 
 export const selectPasswordReset = async (page: Page) => {
   const selectButton = page.getByTestId('start-password-reset');

--- a/e2e/utils/controllers/settings.ts
+++ b/e2e/utils/controllers/settings.ts
@@ -1,0 +1,30 @@
+import { Browser } from 'playwright';
+
+import { defaultUserAdmin, routes } from '../../config';
+import { waitForBase } from '../waitForBase';
+import { loginBasic } from './login';
+import { logout } from './logout';
+
+// Configure SMTP in Core settings as an admin.
+// Several Edge features (password reset, email MFA) are only exposed once SMTP
+// is configured, so tests that exercise them must call this first.
+export const setupSMTP = async (browser: Browser) => {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await waitForBase(page);
+  await loginBasic(page, defaultUserAdmin);
+  await page.goto(routes.base + routes.settings.smtp);
+  await page.getByTestId('smtp-card-basic-configure').click();
+  await page.getByTestId('field-smtp_server').waitFor({ state: 'visible' });
+  await page.getByTestId('field-smtp_server').fill('testServer.com');
+  await page.getByTestId('field-smtp_port').fill('543');
+  await page.getByTestId('field-smtp_user').fill('testuser');
+  await page.getByTestId('field-smtp_password').fill('test');
+  await page.getByTestId('field-smtp_sender').fill('test@test.com');
+  const saveButton = await page.getByTestId('submit');
+  if (await saveButton.isEnabled()) {
+    await saveButton.click();
+  }
+  await logout(page);
+  await context.close();
+};

--- a/justfile
+++ b/justfile
@@ -1,3 +1,6 @@
+# default Docker image tag for e2e tests
+IMAGE_TAG := "release-2.1"
+
 # build release binary
 build:
     cargo build --release
@@ -90,3 +93,7 @@ test-ldap *ARGS:
     status=$?
     docker compose -p defguard-ldap -f docker-compose.ldap-test.yaml down
     exit $status
+
+# run e2e tests (requires Docker, IMAGE_TAG defaults to release-2.1)
+e2e-test *ARGS='':
+    cd e2e && IMAGE_TAG="{{IMAGE_TAG}}" pnpm exec playwright test {{ARGS}}


### PR DESCRIPTION
SMTP must be configured for the proxy to display the "Reset password" card.

Closes https://github.com/DefGuard/defguard/issues/3417