### PR TITLE
fix: avoid bidi request timeouts when calling blocking SMTP functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
           tool: cargo-deny
 
       - name: Run cargo deny
-        run: cargo deny check
+        run: cargo deny check --hide-inclusion-graph
 
       - name: Show sccache stats
         if: always()

--- a/crates/defguard_core/src/grpc/proxy/client_mfa.rs
+++ b/crates/defguard_core/src/grpc/proxy/client_mfa.rs
@@ -372,15 +372,22 @@ impl ClientMfaServer {
                     error!("Database error: {err}");
                     Status::internal("database error")
                 })?;
-                mfa_code_mail(&user.email, &mut transaction, &user.first_name, &code, None)
-                    .await
-                    .map_err(|err| {
-                        error!(
-                            "Failed to send email MFA code for user {}: {err}",
-                            user.username
-                        );
-                        Status::internal("unexpected error")
-                    })?;
+                mfa_code_mail(
+                    &user.email,
+                    &mut transaction,
+                    &user.first_name,
+                    &code,
+                    None,
+                    true,
+                )
+                .await
+                .map_err(|err| {
+                    error!(
+                        "Failed to send email MFA code for user {}: {err}",
+                        user.username
+                    );
+                    Status::internal("unexpected error")
+                })?;
             }
             MfaMethod::Oidc => {
                 if !is_business_license_active() {

--- a/crates/defguard_core/src/handlers/auth.rs
+++ b/crates/defguard_core/src/handlers/auth.rs
@@ -826,6 +826,7 @@ pub async fn email_mfa_init(session: SessionInfo, State(appstate): State<AppStat
         &user.first_name,
         &code,
         Some(&session.session.into()),
+        false,
     )
     .await?;
 
@@ -904,6 +905,7 @@ pub async fn request_email_mfa_code(
                 &user.first_name,
                 &code,
                 Some(&session.into()),
+                false,
             )
             .await?;
             info!("Sent email MFA code for user {}", user.username);

--- a/crates/defguard_core/src/mail/templates.rs
+++ b/crates/defguard_core/src/mail/templates.rs
@@ -522,6 +522,7 @@ pub async fn mfa_activation_mail(
     first_name: &str,
     code: &str,
     session: Option<&SessionContext>,
+    send_and_forget: bool,
 ) -> Result<(), TemplateError> {
     let (mut tera, mut context) = get_base_tera_mjml(Context::new(), session, None, None)?;
     let settings = Settings::get_current_settings();
@@ -538,7 +539,11 @@ pub async fn mfa_activation_mail(
 
     let message = MailMessage::MFAActivation;
     message.fill_context(conn, &mut context).await?;
-    message.mail(&mut tera, &context, to)?.send().await?;
+    if send_and_forget {
+        message.mail(&mut tera, &context, to)?.send_and_forget();
+    } else {
+        message.mail(&mut tera, &context, to)?.send().await?;
+    }
 
     Ok(())
 }
@@ -549,6 +554,7 @@ pub async fn mfa_code_mail(
     first_name: &str,
     code: &str,
     session: Option<&SessionContext>,
+    send_and_forget: bool,
 ) -> Result<(), TemplateError> {
     let (mut tera, mut context) = get_base_tera_mjml(Context::new(), session, None, None)?;
     let settings = Settings::get_current_settings();
@@ -565,7 +571,11 @@ pub async fn mfa_code_mail(
 
     let message = MailMessage::MFACode;
     message.fill_context(conn, &mut context).await?;
-    message.mail(&mut tera, &context, to)?.send().await?;
+    if send_and_forget {
+        message.mail(&mut tera, &context, to)?.send_and_forget();
+    } else {
+        message.mail(&mut tera, &context, to)?.send().await?;
+    }
 
     Ok(())
 }

--- a/crates/defguard_core/src/mail/tests.rs
+++ b/crates/defguard_core/src/mail/tests.rs
@@ -139,6 +139,7 @@ fn send_mfa_code(_: PgPoolOptions, options: PgConnectOptions) {
         first_name,
         code,
         None,
+        true,
     )
     .await
     .unwrap();
@@ -184,6 +185,7 @@ fn send_mfa_activation(_: PgPoolOptions, options: PgConnectOptions) {
         first_name,
         code,
         None,
+        true,
     )
     .await
     .unwrap();

--- a/crates/defguard_proxy_manager/src/servers/enrollment.rs
+++ b/crates/defguard_proxy_manager/src/servers/enrollment.rs
@@ -1061,12 +1061,19 @@ impl EnrollmentServer {
                     error!("Failed to generate MFA code for {user}\nReason:{err}");
                     Status::internal("Failed to generate MFA code".to_owned())
                 })?;
-                mfa_activation_mail(&user.email, &mut transaction, &user.first_name, &code, None)
-                    .await
-                    .map_err(|err| {
-                        error!("Failed to send MFA activation email\nReason:{err}");
-                        Status::internal("Failed to send activation email".to_owned())
-                    })?;
+                mfa_activation_mail(
+                    &user.email,
+                    &mut transaction,
+                    &user.first_name,
+                    &code,
+                    None,
+                    true,
+                )
+                .await
+                .map_err(|err| {
+                    error!("Failed to send MFA activation email\nReason:{err}");
+                    Status::internal("Failed to send activation email".to_owned())
+                })?;
                 Ok(CodeMfaSetupStartResponse { totp_secret: None })
             }
             MfaMethod::Totp => {


### PR DESCRIPTION
Allow choosing whether sending MFA-related emails is blocking or not to support both showing errors in the core UI while avoiding timeouts in proxy communication.

Closes https://github.com/DefGuard/client/issues/1054