### PR TITLE
enable external user password reset

### DIFF
--- a/crates/defguard_common/Cargo.toml
+++ b/crates/defguard_common/Cargo.toml
@@ -44,6 +44,12 @@ webauthn-rs.workspace = true
 x25519-dalek.workspace = true
 url = "2.5"
 
+[features]
+# Test-only helpers (e.g. the mock SMTP server) meant to be shared with other
+# crates' test suites. Enable via `[dev-dependencies]` so it never reaches
+# production builds.
+test-support = ["tokio/net", "tokio/io-util"]
+
 [dev-dependencies]
 matches.workspace = true
 

--- a/crates/defguard_common/src/lib.rs
+++ b/crates/defguard_common/src/lib.rs
@@ -14,6 +14,8 @@ pub mod hex;
 pub mod messages;
 pub mod random;
 pub mod secret;
+#[cfg(feature = "test-support")]
+pub mod testing;
 pub mod types;
 pub mod utils;
 

--- a/crates/defguard_common/src/testing/mod.rs
+++ b/crates/defguard_common/src/testing/mod.rs
@@ -1,0 +1,7 @@
+//! Test-only helpers shared across the workspace.
+//!
+//! Everything under this module is gated behind the `test-support` feature and
+//! is intended to be pulled in via `[dev-dependencies]` by other crates'
+//! integration tests.
+
+pub mod smtp;

--- a/crates/defguard_common/src/testing/smtp.rs
+++ b/crates/defguard_common/src/testing/smtp.rs
@@ -1,0 +1,291 @@
+//! In-process mock SMTP server for integration tests.
+//!
+//! [`MockSmtpServer`] speaks just enough of the SMTP dialogue (plaintext, no
+//! authentication) for lettre's `AsyncSmtpTransport` to deliver a message,
+//! captures every delivered message, and can point the current settings at
+//! itself so that `Mail::send()` reaches it.
+//!
+//! Because most mail is sent fire-and-forget (`tokio::spawn`) the delivery
+//! happens after the triggering request returns, so tests should wait for a
+//! captured message with [`MockSmtpServer::wait_for`] /
+//! [`MockSmtpServer::wait_for_count`] rather than reading synchronously.
+
+use std::{
+    net::SocketAddr,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use sqlx::PgPool;
+use tokio::{
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+    net::{TcpListener, TcpStream},
+    time::{sleep, timeout},
+};
+use tracing::debug;
+
+use crate::db::models::settings::{
+    Settings, update_current_settings,
+    smtp::{SmtpAuthentication, SmtpEncryption},
+};
+
+/// Default time [`MockSmtpServer::wait_for`] and friends will poll before
+/// giving up.
+pub const DEFAULT_MAIL_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// A single message delivered to a [`MockSmtpServer`].
+#[derive(Debug, Clone)]
+pub struct CapturedMail {
+    /// Address from the `MAIL FROM` command.
+    pub from: String,
+    /// Addresses from the `RCPT TO` commands.
+    pub recipients: Vec<String>,
+    /// Raw payload sent after `DATA` (MIME headers + body), with SMTP
+    /// dot-unstuffing applied and the trailing `.` removed.
+    pub body: String,
+}
+
+impl CapturedMail {
+    /// Whether `recipients` contains `address`.
+    #[must_use]
+    pub fn sent_to(&self, address: &str) -> bool {
+        self.recipients.iter().any(|r| r == address)
+    }
+
+    /// Whether the raw payload contains `needle`.
+    #[must_use]
+    pub fn body_contains(&self, needle: &str) -> bool {
+        self.body.contains(needle)
+    }
+}
+
+/// In-process SMTP server that accepts any message and records it.
+///
+/// The listener is owned by a background task, so the server keeps running even
+/// if this handle is dropped; it stops when the test's tokio runtime shuts
+/// down.
+pub struct MockSmtpServer {
+    addr: SocketAddr,
+    received: Arc<Mutex<Vec<CapturedMail>>>,
+}
+
+impl MockSmtpServer {
+    /// Bind an ephemeral port on localhost and start accepting connections.
+    #[must_use = "the returned handle exposes the captured messages"]
+    pub async fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("failed to bind mock SMTP listener");
+        let addr = listener
+            .local_addr()
+            .expect("failed to read mock SMTP local address");
+        debug!("Mock SMTP server listening on {addr}");
+
+        let received = Arc::new(Mutex::new(Vec::new()));
+        let received_bg = Arc::clone(&received);
+        tokio::spawn(async move {
+            loop {
+                let Ok((stream, _)) = listener.accept().await else {
+                    return;
+                };
+                let received_conn = Arc::clone(&received_bg);
+                tokio::spawn(handle_connection(stream, received_conn));
+            }
+        });
+
+        Self { addr, received }
+    }
+
+    /// Address the server is listening on.
+    #[must_use]
+    pub fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    /// Point the current settings (global cache + database) at this server,
+    /// using plaintext transport with no authentication.
+    pub async fn configure(&self, pool: &PgPool) {
+        let mut settings = Settings::get_current_settings();
+        settings.smtp.server = Some(self.addr.ip().to_string());
+        settings.smtp.port = Some(i32::from(self.addr.port()));
+        settings.smtp.sender = Some("noreply@example.com".into());
+        settings.smtp.encryption = SmtpEncryption::None;
+        settings.smtp.authentication = SmtpAuthentication::None;
+        update_current_settings(pool, settings)
+            .await
+            .expect("failed to persist mock SMTP settings");
+    }
+
+    /// Snapshot of all messages received so far.
+    #[must_use]
+    pub fn messages(&self) -> Vec<CapturedMail> {
+        self.received.lock().unwrap().clone()
+    }
+
+    /// Number of messages received so far.
+    #[must_use]
+    pub fn message_count(&self) -> usize {
+        self.received.lock().unwrap().len()
+    }
+
+    /// Wait until at least `n` messages have been received, then return a
+    /// snapshot of all captured messages.
+    ///
+    /// # Panics
+    /// Panics if [`DEFAULT_MAIL_TIMEOUT`] elapses first.
+    pub async fn wait_for_count(&self, n: usize) -> Vec<CapturedMail> {
+        let poll = async {
+            loop {
+                {
+                    let guard = self.received.lock().unwrap();
+                    if guard.len() >= n {
+                        return guard.clone();
+                    }
+                }
+                sleep(Duration::from_millis(20)).await;
+            }
+        };
+        timeout(DEFAULT_MAIL_TIMEOUT, poll).await.unwrap_or_else(|_| {
+            panic!(
+                "timed out waiting for {n} mail(s); received {}",
+                self.message_count()
+            )
+        })
+    }
+
+    /// Wait for the first captured message matching `predicate` and return it.
+    ///
+    /// Searches the whole capture buffer on every poll, so it is robust to
+    /// unrelated fire-and-forget mails (e.g. new-device-login notifications)
+    /// arriving in between.
+    ///
+    /// # Panics
+    /// Panics if [`DEFAULT_MAIL_TIMEOUT`] elapses before a match appears.
+    pub async fn wait_for<F>(&self, predicate: F) -> CapturedMail
+    where
+        F: Fn(&CapturedMail) -> bool,
+    {
+        self.wait_for_from(0, predicate).await.1
+    }
+
+    /// Like [`wait_for`](Self::wait_for), but only considers messages at index
+    /// `>= start` in arrival order. Returns the matched message together with
+    /// its absolute index, so a caller stepping through a multi-mail flow can
+    /// advance a cursor (`start = index + 1`) and ignore already-consumed mail.
+    ///
+    /// # Panics
+    /// Panics if [`DEFAULT_MAIL_TIMEOUT`] elapses before a match appears.
+    pub async fn wait_for_from<F>(&self, start: usize, predicate: F) -> (usize, CapturedMail)
+    where
+        F: Fn(&CapturedMail) -> bool,
+    {
+        let poll = async {
+            loop {
+                {
+                    let guard = self.received.lock().unwrap();
+                    if let Some((index, mail)) = guard
+                        .iter()
+                        .enumerate()
+                        .skip(start)
+                        .find(|(_, m)| predicate(m))
+                    {
+                        return (index, mail.clone());
+                    }
+                }
+                sleep(Duration::from_millis(20)).await;
+            }
+        };
+        timeout(DEFAULT_MAIL_TIMEOUT, poll)
+            .await
+            .unwrap_or_else(|_| panic!("timed out waiting for a matching mail"))
+    }
+}
+
+/// Convenience wrapper: start a server and point the current settings at it.
+///
+/// Mirrors the previous per-crate helper of the same name; prefer constructing
+/// a [`MockSmtpServer`] directly when you need to inspect captured mail.
+pub async fn configure_working_smtp(pool: &PgPool) -> MockSmtpServer {
+    let server = MockSmtpServer::start().await;
+    server.configure(pool).await;
+    server
+}
+
+/// Extract the `<...>` address from a `MAIL FROM` / `RCPT TO` command line.
+fn extract_address(line: &str) -> String {
+    match (line.find('<'), line.find('>')) {
+        (Some(start), Some(end)) if start < end => line[start + 1..end].to_string(),
+        // Fall back to whatever follows the ':' if the client omitted brackets.
+        _ => line
+            .split_once(':')
+            .map_or_else(String::new, |(_, rest)| rest.trim().to_string()),
+    }
+}
+
+/// Handle a single SMTP connection, recording any delivered message.
+async fn handle_connection(stream: TcpStream, received: Arc<Mutex<Vec<CapturedMail>>>) {
+    let (reader, mut writer) = stream.into_split();
+    let mut reader = BufReader::new(reader);
+
+    if writer.write_all(b"220 localhost ESMTP\r\n").await.is_err() {
+        return;
+    }
+
+    let mut from = String::new();
+    let mut recipients = Vec::new();
+    let mut line = String::new();
+
+    loop {
+        line.clear();
+        match reader.read_line(&mut line).await {
+            Ok(0) | Err(_) => return,
+            Ok(_) => {}
+        }
+        let upper = line.trim_end().to_ascii_uppercase();
+
+        if upper.starts_with("EHLO") || upper.starts_with("HELO") {
+            let _ = writer.write_all(b"250 localhost\r\n").await;
+        } else if upper.starts_with("MAIL FROM") {
+            from = extract_address(line.trim_end());
+            let _ = writer.write_all(b"250 OK\r\n").await;
+        } else if upper.starts_with("RCPT TO") {
+            recipients.push(extract_address(line.trim_end()));
+            let _ = writer.write_all(b"250 OK\r\n").await;
+        } else if upper.starts_with("RSET") {
+            from.clear();
+            recipients.clear();
+            let _ = writer.write_all(b"250 OK\r\n").await;
+        } else if upper.starts_with("DATA") {
+            let _ = writer
+                .write_all(b"354 End data with <CR><LF>.<CR><LF>\r\n")
+                .await;
+            let mut body = String::new();
+            loop {
+                line.clear();
+                match reader.read_line(&mut line).await {
+                    Ok(0) | Err(_) => return,
+                    Ok(_) => {}
+                }
+                if line == ".\r\n" || line == ".\n" {
+                    break;
+                }
+                // Undo SMTP dot-stuffing of lines that begin with '.'.
+                let content = line.strip_prefix('.').unwrap_or(&line);
+                body.push_str(content);
+            }
+            // Record the message before acknowledging, so that an awaited
+            // `send()` observes the capture as soon as it returns.
+            received.lock().unwrap().push(CapturedMail {
+                from: std::mem::take(&mut from),
+                recipients: std::mem::take(&mut recipients),
+                body,
+            });
+            let _ = writer.write_all(b"250 OK message queued\r\n").await;
+        } else if upper.starts_with("QUIT") {
+            let _ = writer.write_all(b"221 Bye\r\n").await;
+            return;
+        } else {
+            let _ = writer.write_all(b"250 OK\r\n").await;
+        }
+    }
+}

--- a/crates/defguard_common/src/testing/smtp.rs
+++ b/crates/defguard_common/src/testing/smtp.rs
@@ -168,7 +168,8 @@ impl MockSmtpServer {
     where
         F: Fn(&CapturedMail) -> bool,
     {
-        self.wait_for_from(0, predicate).await.1
+        let (_, mail) = self.wait_for_from(0, predicate).await;
+        mail
     }
 
     /// Like [`wait_for`](Self::wait_for), but only considers messages at index

--- a/crates/defguard_common/src/testing/smtp.rs
+++ b/crates/defguard_common/src/testing/smtp.rs
@@ -25,8 +25,9 @@ use tokio::{
 use tracing::debug;
 
 use crate::db::models::settings::{
-    Settings, update_current_settings,
+    Settings,
     smtp::{SmtpAuthentication, SmtpEncryption},
+    update_current_settings,
 };
 
 /// Default time [`MockSmtpServer::wait_for`] and friends will poll before
@@ -145,12 +146,14 @@ impl MockSmtpServer {
                 sleep(Duration::from_millis(20)).await;
             }
         };
-        timeout(DEFAULT_MAIL_TIMEOUT, poll).await.unwrap_or_else(|_| {
-            panic!(
-                "timed out waiting for {n} mail(s); received {}",
-                self.message_count()
-            )
-        })
+        timeout(DEFAULT_MAIL_TIMEOUT, poll)
+            .await
+            .unwrap_or_else(|_| {
+                panic!(
+                    "timed out waiting for {n} mail(s); received {}",
+                    self.message_count()
+                )
+            })
     }
 
     /// Wait for the first captured message matching `predicate` and return it.

--- a/crates/defguard_core/Cargo.toml
+++ b/crates/defguard_core/Cargo.toml
@@ -96,6 +96,8 @@ uaparser = "0.6"
 async-stream = "0.3"
 
 [dev-dependencies]
+# Enable the shared test-only helpers (mock SMTP server) for the test build.
+defguard_common = { workspace = true, features = ["test-support"] }
 claims.workspace = true
 hyper-util = "0.1"
 matches.workspace = true

--- a/crates/defguard_core/tests/integration/api/auth.rs
+++ b/crates/defguard_core/tests/integration/api/auth.rs
@@ -1,9 +1,12 @@
 use std::time::SystemTime;
 
 use chrono::DateTime;
-use defguard_common::db::models::{
-    MFAInfo, MFAMethod, User,
-    user::{TOTP_CODE_DIGITS, TOTP_CODE_VALIDITY_PERIOD},
+use defguard_common::{
+    db::models::{
+        MFAInfo, MFAMethod, User,
+        user::{TOTP_CODE_DIGITS, TOTP_CODE_VALIDITY_PERIOD},
+    },
+    testing::smtp::{CapturedMail, MockSmtpServer},
 };
 use defguard_core::{
     events::ApiEventType,
@@ -403,19 +406,35 @@ async fn dg25_15_test_totp_brute_force(_: PgPoolOptions, options: PgConnectOptio
     }
 }
 
-// static EMAIL_CODE_REGEX: &str = r"<b>(?<code>\d{6})</b>";
-// fn extract_email_code(content: &str) -> &str {
-//     let re = regex::Regex::new(EMAIL_CODE_REGEX).unwrap();
-//     re.captures(content).unwrap().name("code").unwrap().as_str()
-// }
+/// Whether a captured email carries a 6-digit MFA code. The plain-text MIME
+/// part renders `{{ code }}` on its own line, so we look for a line that is
+/// exactly six digits.
+fn has_mfa_code(mail: &CapturedMail) -> bool {
+    mail.body
+        .lines()
+        .map(str::trim)
+        .any(|line| line.len() == 6 && line.bytes().all(|b| b.is_ascii_digit()))
+}
 
-/*
+/// Extract the 6-digit MFA code from a captured email (see [`has_mfa_code`]).
+fn extract_email_code(mail: &CapturedMail) -> String {
+    mail.body
+        .lines()
+        .map(str::trim)
+        .find(|line| line.len() == 6 && line.bytes().all(|b| b.is_ascii_digit()))
+        .expect("no 6-digit MFA code found in email body")
+        .to_string()
+}
+
 #[sqlx::test]
 async fn test_email_mfa(_: PgPoolOptions, options: PgConnectOptions) {
     let pool = setup_pool(options).await;
 
     let (client, state) = make_test_client(pool).await;
     let pool = state.pool;
+
+    // stand up a mock SMTP server, but leave SMTP unconfigured for now
+    let smtp = MockSmtpServer::start().await;
 
     // try to initialize email MFA setup before logging in
     let response = client.post("/api/v1/auth/email/init").send().await;
@@ -428,53 +447,27 @@ async fn test_email_mfa(_: PgPoolOptions, options: PgConnectOptions) {
 
     // try to initialize email MFA setup without SMTP settings configured
     let response = client.post("/api/v1/auth/email/init").send().await;
-    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
 
-    // add dummy SMTP settings
-    let mut settings = Settings::get_current_settings();
-    settings.smtp.server = Some("smtp_server".into());
-    settings.smtp.port = Some(587);
-    settings.smtp.sender = Some("smtp@sender.pl".into());
-    update_current_settings(&pool, settings).await.unwrap();
+    // point SMTP at the mock server
+    smtp.configure(&pool).await;
 
-    // initialize email MFA setup
+    // initialize email MFA setup - sends the activation email (awaited)
     let response = client.post("/api/v1/auth/email/init").send().await;
     assert_eq!(response.status(), StatusCode::OK);
 
-    // check email was sent
-    let mail = mail_rx.try_recv().unwrap();
-    assert_ok!(mail_rx.try_recv());
-    assert_eq!(mail.to(), "h.potter@hogwart.edu.uk");
-    assert_eq!(
-        mail.subject(),
-        "Defguard: new device logged in to your account"
-    );
+    // the activation email is the first one carrying a 6-digit code
+    let (activation_idx, activation_mail) = smtp.wait_for_from(0, has_mfa_code).await;
+    assert!(activation_mail.sent_to("h.potter@hogwart.edu.uk"));
+    let code = extract_email_code(&activation_mail);
 
-    // resend setup email
-    let response = client.post("/api/v1/auth/email/init").send().await;
+    // finish setup with the emailed code
+    let response = client
+        .post("/api/v1/auth/email")
+        .json(&AuthCode::new(code))
+        .send()
+        .await;
     assert_eq!(response.status(), StatusCode::OK);
-    let mail = mail_rx.try_recv().unwrap();
-    assert_err!(mail_rx.try_recv());
-    assert_eq!(mail.to(), "h.potter@hogwart.edu.uk");
-    assert_eq!(
-        mail.subject(),
-        "Defguard: Multi-Factor Authentication activation"
-    );
-    let code = extract_email_code(mail.content());
-
-    // finish setup
-    let code = AuthCode::new(code);
-    let response = client.post("/api/v1/auth/email").json(&code).send().await;
-    assert_eq!(response.status(), StatusCode::OK);
-
-    // check that confirmation email was sent
-    let mail = mail_rx.try_recv().unwrap();
-    assert_err!(mail_rx.try_recv());
-    assert_eq!(mail.to(), "h.potter@hogwart.edu.uk");
-    assert_eq!(
-        mail.subject(),
-        "MFA method Email has been activated on your account"
-    );
 
     // check recovery codes
     let recovery_codes: RecoveryCodes = response.json().await;
@@ -488,15 +481,14 @@ async fn test_email_mfa(_: PgPoolOptions, options: PgConnectOptions) {
     let response = client.post("/api/v1/auth").json(&auth).send().await;
     assert_eq!(response.status(), StatusCode::CREATED);
 
-    // still unauthorized
+    // still unauthorized until the emailed code is provided
     let response = client.get("/api/v1/me").send().await;
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 
     // provide wrong code
-    let code = AuthCode::new("0");
     let response = client
         .post("/api/v1/auth/email/verify")
-        .json(&code)
+        .json(&AuthCode::new("0"))
         .send()
         .await;
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
@@ -505,40 +497,21 @@ async fn test_email_mfa(_: PgPoolOptions, options: PgConnectOptions) {
     let response = client.get("/api/v1/me").send().await;
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 
-    // request code
+    // request a login code - sends the code email (awaited)
     let response = client.get("/api/v1/auth/email").send().await;
     assert_eq!(response.status(), StatusCode::OK);
 
-    // check that code email was sent
-    let mail = mail_rx.try_recv().unwrap();
-    assert_ok!(mail_rx.try_recv());
-    assert_eq!(mail.to(), "h.potter@hogwart.edu.uk");
-    assert_eq!(
-        mail.subject(),
-        "Defguard: new device logged in to your account"
-    );
-
-    // resend code
-    let response = client.get("/api/v1/auth/email").send().await;
-    assert_eq!(response.status(), StatusCode::OK);
-    let mail = mail_rx.try_recv().unwrap();
-    assert_err!(mail_rx.try_recv());
-    assert_eq!(mail.to(), "h.potter@hogwart.edu.uk");
-    assert_eq!(
-        mail.subject(),
-        "Defguard: Multi-Factor Authentication code for login"
-    );
-    let code = extract_email_code(mail.content());
-
-    // login
-    let response = client.post("/api/v1/auth").json(&auth).send().await;
-    assert_eq!(response.status(), StatusCode::CREATED);
+    // grab the next code-bearing email after the activation one
+    let (_, code_mail) = smtp
+        .wait_for_from(activation_idx + 1, has_mfa_code)
+        .await;
+    assert!(code_mail.sent_to("h.potter@hogwart.edu.uk"));
+    let code = extract_email_code(&code_mail);
 
     // provide correct code
-    let code = AuthCode::new(code);
     let response = client
         .post("/api/v1/auth/email/verify")
-        .json(&code)
+        .json(&AuthCode::new(code))
         .send()
         .await;
     assert_eq!(response.status(), StatusCode::OK);
@@ -551,12 +524,10 @@ async fn test_email_mfa(_: PgPoolOptions, options: PgConnectOptions) {
     let response = client.delete("/api/v1/auth/mfa").send().await;
     assert_eq!(response.status(), StatusCode::OK);
 
-    // login again
-    let auth = Auth::new("hpotter", "pass123");
+    // login again - MFA no longer required
     let response = client.post("/api/v1/auth").json(&auth).send().await;
     assert_eq!(response.status(), StatusCode::OK);
 }
-*/
 
 /*
 #[sqlx::test]

--- a/crates/defguard_core/tests/integration/api/auth.rs
+++ b/crates/defguard_core/tests/integration/api/auth.rs
@@ -1,4 +1,4 @@
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 use chrono::DateTime;
 use defguard_common::{
@@ -19,6 +19,7 @@ use sqlx::{
     postgres::{PgConnectOptions, PgPoolOptions},
     query,
 };
+use tokio::time::sleep;
 use totp_lite::{Sha1, totp_custom};
 use webauthn_authenticator_rs::{WebauthnAuthenticator, prelude::Url, softpasskey::SoftPasskey};
 use webauthn_rs::prelude::{CreationChallengeResponse, RequestChallengeResponse};
@@ -529,7 +530,6 @@ async fn test_email_mfa(_: PgPoolOptions, options: PgConnectOptions) {
     assert_eq!(response.status(), StatusCode::OK);
 }
 
-/*
 #[sqlx::test]
 async fn dg25_15_test_email_mfa_brute_force(_: PgPoolOptions, options: PgConnectOptions) {
     let pool = setup_pool(options).await;
@@ -545,30 +545,25 @@ async fn dg25_15_test_email_mfa_brute_force(_: PgPoolOptions, options: PgConnect
     let auth = Auth::new("hpotter", "pass123");
     let response = client.post("/api/v1/auth").json(&auth).send().await;
     assert_eq!(response.status(), StatusCode::OK);
-    // remove login confirmation email from queue
-    let _mail = mail_rx.try_recv().unwrap();
 
-    // add dummy SMTP settings
-    let mut settings = Settings::get_current_settings();
-    settings.smtp.server = Some("smtp_server".into());
-    settings.smtp.port = Some(587);
-    settings.smtp.sender = Some("smtp@sender.pl".into());
-    update_current_settings(&pool, settings).await.unwrap();
+    // point SMTP at the mock server
+    let smtp = MockSmtpServer::start().await;
+    smtp.configure(&pool).await;
 
-    // initialize email MFA setup
+    // initialize email MFA setup - sends the activation email (awaited)
     let response = client.post("/api/v1/auth/email/init").send().await;
     assert_eq!(response.status(), StatusCode::OK);
-    let mail = mail_rx.try_recv().unwrap();
-    assert_eq!(mail.to(), "h.potter@hogwart.edu.uk");
-    assert_eq!(
-        mail.subject(),
-        "Defguard: Multi-Factor Authentication activation"
-    );
-    let code = extract_email_code(mail.content());
 
-    // finish setup
-    let code = AuthCode::new(code);
-    let response = client.post("/api/v1/auth/email").json(&code).send().await;
+    let activation = smtp.wait_for(has_mfa_code).await;
+    assert!(activation.sent_to("h.potter@hogwart.edu.uk"));
+    let code = extract_email_code(&activation);
+
+    // finish setup with the emailed code
+    let response = client
+        .post("/api/v1/auth/email")
+        .json(&AuthCode::new(code))
+        .send()
+        .await;
     assert_eq!(response.status(), StatusCode::OK);
 
     // enable MFA
@@ -580,11 +575,11 @@ async fn dg25_15_test_email_mfa_brute_force(_: PgPoolOptions, options: PgConnect
     assert_eq!(response.status(), StatusCode::CREATED);
 
     // provide wrong code more than 5 times in a row
-    let code = AuthCode::new("0");
+    let wrong_code = AuthCode::new("0");
     for i in 0..10 {
         let response = client
             .post("/api/v1/auth/email/verify")
-            .json(&code)
+            .json(&wrong_code)
             .send()
             .await;
         if i >= 5 {
@@ -594,7 +589,6 @@ async fn dg25_15_test_email_mfa_brute_force(_: PgPoolOptions, options: PgConnect
         }
     }
 }
-*/
 
 #[sqlx::test]
 async fn test_webauthn(_: PgPoolOptions, options: PgConnectOptions) {
@@ -855,12 +849,12 @@ async fn test_mfa_method_is_updated_when_removing_last_webauthn_passkey(
     assert_eq!(mfa_info.current_mfa_method(), &MFAMethod::OneTimePassword);
 }
 
-/*
 #[sqlx::test]
 async fn test_mfa_method_totp_enabled_mail(_: PgPoolOptions, options: PgConnectOptions) {
     let pool = setup_pool(options).await;
 
     let (client, state) = make_test_client(pool).await;
+    let pool = state.pool;
     let user_agent_header = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1 Mobile/15E148 Safari/604.1";
 
     // login
@@ -873,40 +867,44 @@ async fn test_mfa_method_totp_enabled_mail(_: PgPoolOptions, options: PgConnectO
         .await;
     assert_eq!(response.status(), StatusCode::OK);
 
+    // point SMTP at the mock server (after login, so only the activation mail is captured)
+    let smtp = MockSmtpServer::start().await;
+    smtp.configure(&pool).await;
+
     // new TOTP secret
     let response = client.post("/api/v1/auth/totp/init").send().await;
     assert_eq!(response.status(), StatusCode::OK);
     let auth_totp: AuthTotp = response.json().await;
 
-    // enable TOTP
+    // enable TOTP - sends the "MFA method activated" notification (fire-and-forget)
     let code = totp_code(&auth_totp);
     let response = client.post("/api/v1/auth/totp").json(&code).send().await;
     assert_eq!(response.status(), StatusCode::OK);
 
-    mail_rx.try_recv().unwrap();
-    let mail = mail_rx.try_recv().unwrap();
-    assert_eq!(mail.to(), "h.potter@hogwart.edu.uk");
-    assert_eq!(
-        mail.subject(),
-        "MFA method TOTP has been activated on your account"
-    );
-    assert!(mail.content().contains("IP Address:</span> 127.0.0.1"));
+    let mail = smtp
+        .wait_for(|m| m.body_contains("Multi-Factor Authentication TOTP has been activated"))
+        .await;
     assert!(
-        mail.content()
-            .contains("Device type:</span> iPhone, OS: iOS 17.1, Mobile Safari")
+        mail.sent_to("h.potter@hogwart.edu.uk"),
+        "MFA activation notification should be addressed to the user"
     );
 }
-*/
 
 #[sqlx::test]
 async fn test_new_device_login(_: PgPoolOptions, options: PgConnectOptions) {
     let pool = setup_pool(options).await;
 
-    let (client, _) = make_test_client(pool).await;
+    let (client, state) = make_test_client(pool).await;
+    let pool = state.pool;
+
+    // point SMTP at a mock server so new-device-login notifications are delivered
+    let smtp = MockSmtpServer::start().await;
+    smtp.configure(&pool).await;
+
     let user_agent_header_iphone = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1 Mobile/15E148 Safari/604.1";
     let user_agent_header_android = "Mozilla/5.0 (Linux; Android 7.0; SM-G930VC Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36";
 
-    // login
+    // login from a new device - triggers a notification email
     let auth = Auth::new("hpotter", "pass123");
     let response = client
         .post("/api/v1/auth")
@@ -916,22 +914,23 @@ async fn test_new_device_login(_: PgPoolOptions, options: PgConnectOptions) {
         .await;
     assert_eq!(response.status(), StatusCode::OK);
 
-    // assert_eq!(mail.to(), "h.potter@hogwart.edu.uk");
-    // assert_eq!(
-    //     mail.subject(),
-    //     "Defguard: new device logged in to your account"
-    // );
-    // assert!(mail.content().contains("IP Address:</span> 127.0.0.1"));
-    // assert!(
-    //     mail.content()
-    //         .contains("Device type:</span> iPhone, OS: iOS 17.1, Mobile Safari")
-    // );
+    let mail = smtp
+        .wait_for(|m| m.sent_to("h.potter@hogwart.edu.uk"))
+        .await;
+    assert!(
+        mail.body_contains("Defguard: New device logged in to your account"),
+        "new-device notification should carry the expected subject"
+    );
+    assert!(
+        mail.body_contains("127.0.0.1"),
+        "new-device notification should include the client IP address"
+    );
+    assert_eq!(smtp.message_count(), 1);
 
     let response = client.post("/api/v1/auth/logout").send().await;
     assert_eq!(response.status(), StatusCode::OK);
 
-    // login using the same device
-    let auth = Auth::new("hpotter", "pass123");
+    // login again from the SAME device - a known device must not re-notify
     let response = client
         .post("/api/v1/auth")
         .header(USER_AGENT, user_agent_header_iphone)
@@ -940,8 +939,15 @@ async fn test_new_device_login(_: PgPoolOptions, options: PgConnectOptions) {
         .await;
     assert_eq!(response.status(), StatusCode::OK);
 
-    // login using a different device
-    let auth = Auth::new("hpotter", "pass123");
+    // give any (erroneous) fire-and-forget mail a chance to arrive, then confirm none did
+    sleep(Duration::from_millis(300)).await;
+    assert_eq!(
+        smtp.message_count(),
+        1,
+        "logging in from a known device must not send a new-device notification"
+    );
+
+    // login from a different device - triggers another notification
     let response = client
         .post("/api/v1/auth")
         .header(USER_AGENT, user_agent_header_android)
@@ -950,22 +956,24 @@ async fn test_new_device_login(_: PgPoolOptions, options: PgConnectOptions) {
         .await;
     assert_eq!(response.status(), StatusCode::OK);
 
-    // assert_eq!(
-    //     mail.subject(),
-    //     "Defguard: new device logged in to your account"
-    // );
-    // assert!(mail.content().contains("IP Address:</span> 127.0.0.1"));
-    // assert!(
-    //     mail.content()
-    //         .contains("Device type:</span> SM-G930VC, OS: Android 7.0, Chrome Mobile WebView")
-    // );
+    let mails = smtp.wait_for_count(2).await;
+    assert!(
+        mails.iter().all(|m| m.sent_to("h.potter@hogwart.edu.uk")),
+        "both notifications should be addressed to the user"
+    );
 }
 
 #[sqlx::test]
 async fn test_login_ip_headers(_: PgPoolOptions, options: PgConnectOptions) {
     let pool = setup_pool(options).await;
 
-    let (client, _) = make_test_client(pool).await;
+    let (client, state) = make_test_client(pool).await;
+    let pool = state.pool;
+
+    // point SMTP at a mock server so the new-device notification is delivered
+    let smtp = MockSmtpServer::start().await;
+    smtp.configure(&pool).await;
+
     let user_agent_header_iphone = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1 Mobile/15E148 Safari/604.1";
 
     // Works with X-Forwarded-For header
@@ -979,12 +987,20 @@ async fn test_login_ip_headers(_: PgPoolOptions, options: PgConnectOptions) {
         .await;
     assert_eq!(response.status(), StatusCode::OK);
 
-    // assert_eq!(mail.to(), "h.potter@hogwart.edu.uk");
-    // assert_eq!(
-    //     mail.subject(),
-    //     "Defguard: new device logged in to your account"
-    // );
-    // assert!(mail.content().contains("IP Address:</span> 10.0.0.20"));
+    // the notification records the IP from X-Forwarded-For rather than the socket
+    // address; ClientIpAddr uses the *rightmost* (trusted-proxy) entry, which is
+    // not client-spoofable, so 10.1.1.10 is expected here, not 10.0.0.20
+    let mail = smtp
+        .wait_for(|m| m.sent_to("h.potter@hogwart.edu.uk"))
+        .await;
+    assert!(
+        mail.body_contains("Defguard: New device logged in to your account"),
+        "new-device notification should carry the expected subject"
+    );
+    assert!(
+        mail.body_contains("10.1.1.10"),
+        "notification should record the rightmost X-Forwarded-For IP address"
+    );
 }
 
 #[sqlx::test]

--- a/crates/defguard_core/tests/integration/api/auth.rs
+++ b/crates/defguard_core/tests/integration/api/auth.rs
@@ -502,9 +502,7 @@ async fn test_email_mfa(_: PgPoolOptions, options: PgConnectOptions) {
     assert_eq!(response.status(), StatusCode::OK);
 
     // grab the next code-bearing email after the activation one
-    let (_, code_mail) = smtp
-        .wait_for_from(activation_idx + 1, has_mfa_code)
-        .await;
+    let (_, code_mail) = smtp.wait_for_from(activation_idx + 1, has_mfa_code).await;
     assert!(code_mail.sent_to("h.potter@hogwart.edu.uk"));
     let code = extract_email_code(&code_mail);
 

--- a/crates/defguard_core/tests/integration/api/auth.rs
+++ b/crates/defguard_core/tests/integration/api/auth.rs
@@ -406,22 +406,24 @@ async fn dg25_15_test_totp_brute_force(_: PgPoolOptions, options: PgConnectOptio
     }
 }
 
-/// Whether a captured email carries a 6-digit MFA code. The plain-text MIME
-/// part renders `{{ code }}` on its own line, so we look for a line that is
+/// Find the 6-digit MFA code in a captured email, if present. The plain-text
+/// MIME part renders `{{ code }}` on its own line, so we look for a line that is
 /// exactly six digits.
-fn has_mfa_code(mail: &CapturedMail) -> bool {
-    mail.body
-        .lines()
-        .map(str::trim)
-        .any(|line| line.len() == 6 && line.bytes().all(|b| b.is_ascii_digit()))
-}
-
-/// Extract the 6-digit MFA code from a captured email (see [`has_mfa_code`]).
-fn extract_email_code(mail: &CapturedMail) -> String {
+fn find_mfa_code(mail: &CapturedMail) -> Option<&str> {
     mail.body
         .lines()
         .map(str::trim)
         .find(|line| line.len() == 6 && line.bytes().all(|b| b.is_ascii_digit()))
+}
+
+/// Whether a captured email carries a 6-digit MFA code.
+fn has_mfa_code(mail: &CapturedMail) -> bool {
+    find_mfa_code(mail).is_some()
+}
+
+/// Extract the 6-digit MFA code from a captured email (see [`find_mfa_code`]).
+fn extract_email_code(mail: &CapturedMail) -> String {
+    find_mfa_code(mail)
         .expect("no 6-digit MFA code found in email body")
         .to_string()
 }

--- a/crates/defguard_core/tests/integration/api/openid.rs
+++ b/crates/defguard_core/tests/integration/api/openid.rs
@@ -1,13 +1,16 @@
 use std::str::FromStr;
 
 use axum::http::header::ToStrError;
-use defguard_common::db::{
-    Id,
-    models::{
-        OAuth2AuthorizedApp, Settings, User,
-        oauth2client::OAuth2Client,
-        settings::{OPENID_KEY_SIZE, update_current_settings},
+use defguard_common::{
+    db::{
+        Id,
+        models::{
+            OAuth2AuthorizedApp, Settings, User,
+            oauth2client::OAuth2Client,
+            settings::{OPENID_KEY_SIZE, update_current_settings},
+        },
     },
+    testing::smtp::MockSmtpServer,
 };
 use defguard_core::handlers::{Auth, openid_clients::NewOpenIDClient};
 use openidconnect::{
@@ -1529,8 +1532,13 @@ async fn dg25_21_test_openid_html_injection(_: PgPoolOptions, options: PgConnect
 async fn test_openid_flow_new_login_mail(_: PgPoolOptions, options: PgConnectOptions) {
     let pool = setup_pool(options).await;
 
-    let (client, _) = make_test_client(pool).await;
+    let (client, state) = make_test_client(pool).await;
+    let pool = state.pool;
     let user_agent_header = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1 Mobile/15E148 Safari/604.1";
+
+    // point SMTP at a mock server so the OIDC new-login notification is delivered
+    let smtp = MockSmtpServer::start().await;
+    smtp.configure(&pool).await;
 
     let auth = Auth::new("admin", "pass123");
     let response = client
@@ -1587,16 +1595,19 @@ async fn test_openid_flow_new_login_mail(_: PgPoolOptions, options: PgConnectOpt
     let auth_response: AuthenticationResponse = serde_qs::from_str(query).unwrap();
     assert_eq!(auth_response.state, "ABCDEF");
 
-    // assert_eq!(mail.to(), "admin@defguard");
-    // assert_eq!(
-    //     mail.subject(),
-    //     "New login to Test application with Defguard"
-    // );
-    // assert!(mail.content().contains("IP Address:</span> 127.0.0.1"));
-    // assert!(
-    //     mail.content()
-    //         .contains("Device type:</span> iPhone, OS: iOS 17.1, Mobile Safari")
-    // );
+    // authorizing the app for the first time sends a new-OIDC-login notification;
+    // match it by subject to distinguish it from the password-login new-device mail
+    let mail = smtp
+        .wait_for(|m| m.body_contains("New login to OIDC application"))
+        .await;
+    assert!(
+        mail.sent_to("admin@defguard"),
+        "OIDC login notification should be addressed to the user"
+    );
+    assert!(
+        mail.body_contains("Test"),
+        "OIDC login notification should name the authorized application"
+    );
 
     let response = client
         .post(format!(

--- a/crates/defguard_core/tests/integration/api/user.rs
+++ b/crates/defguard_core/tests/integration/api/user.rs
@@ -15,6 +15,7 @@ use defguard_common::{
             vpn_session_stats::VpnSessionStats,
         },
     },
+    testing::smtp::MockSmtpServer,
     types::user_info::UserInfo,
 };
 use defguard_core::{
@@ -2931,4 +2932,38 @@ async fn test_password_management_disabled_for_oidc_user(
         .send()
         .await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[sqlx::test]
+async fn test_reset_password_sends_email(_: PgPoolOptions, options: PgConnectOptions) {
+    let pool = setup_pool(options).await;
+    let (mut client, pool) = make_client_with_db(pool).await;
+
+    // Configure a proxy URL (needed to build the reset link) and point SMTP at
+    // an in-process mock server so the reset email is actually delivered.
+    let mut settings = Settings::get_current_settings();
+    settings.public_proxy_url = "https://proxy.example.com".to_string();
+    update_current_settings(&pool, settings).await.unwrap();
+    let smtp = MockSmtpServer::start().await;
+    smtp.configure(&pool).await;
+
+    // Admin triggers a password reset for another user.
+    client.login_user("admin", "pass123").await;
+    let response = client
+        .post("/api/v1/user/hpotter/reset_password")
+        .send()
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // The reset email (sent fire-and-forget) is delivered to the target user
+    // and carries a tokenized reset link pointing at the configured proxy.
+    let mail = smtp.wait_for(|m| m.sent_to("h.potter@hogwart.edu.uk")).await;
+    assert!(
+        mail.body_contains("token"),
+        "reset email should contain a reset token link"
+    );
+    assert!(
+        mail.body_contains("proxy.example.com"),
+        "reset link should point at the configured proxy URL"
+    );
 }

--- a/crates/defguard_core/tests/integration/api/user.rs
+++ b/crates/defguard_core/tests/integration/api/user.rs
@@ -2957,7 +2957,9 @@ async fn test_reset_password_sends_email(_: PgPoolOptions, options: PgConnectOpt
 
     // The reset email (sent fire-and-forget) is delivered to the target user
     // and carries a tokenized reset link pointing at the configured proxy.
-    let mail = smtp.wait_for(|m| m.sent_to("h.potter@hogwart.edu.uk")).await;
+    let mail = smtp
+        .wait_for(|m| m.sent_to("h.potter@hogwart.edu.uk"))
+        .await;
     assert!(
         mail.body_contains("token"),
         "reset email should contain a reset token link"

--- a/crates/defguard_core/tests/integration/api/user.rs
+++ b/crates/defguard_core/tests/integration/api/user.rs
@@ -1440,6 +1440,10 @@ async fn test_user_add_device(_: PgPoolOptions, options: PgConnectOptions) {
     let (mut client, state) = make_test_client(pool).await;
     let user_agent_header = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1 Mobile/15E148 Safari/604.1";
 
+    // point SMTP at a mock server so device/login notifications are delivered
+    let smtp = MockSmtpServer::start().await;
+    smtp.configure(&state.pool).await;
+
     let mut expected_events = Vec::new();
 
     // log in as admin
@@ -1452,13 +1456,6 @@ async fn test_user_add_device(_: PgPoolOptions, options: PgConnectOptions) {
         .await;
     assert_eq!(response.status(), StatusCode::OK);
     expected_events.push(ApiEventType::UserLogin);
-
-    // first email received is regarding admin login
-    // assert_eq!(mail.to(), "admin@defguard");
-    // assert_eq!(
-    //     mail.subject(),
-    //     "Defguard: new device logged in to your account"
-    // );
 
     // create network
     make_network(&client, "network").await;
@@ -1483,13 +1480,6 @@ async fn test_user_add_device(_: PgPoolOptions, options: PgConnectOptions) {
         device: get_db_device(&state.pool, 1).await,
     });
 
-    // send email regarding new device being added
-    // it does not contain session info
-    // assert_eq!(mail.to(), "h.potter@hogwart.edu.uk");
-    // assert_eq!(mail.subject(), "Defguard: new device added to your account");
-    // assert!(!mail.content().contains("IP Address:</span>"));
-    // assert!(!mail.content().contains("Device type:</span>"));
-
     // add device for themselves
     let device_data = AddDevice {
         name: "TestDevice2".into(),
@@ -1507,16 +1497,6 @@ async fn test_user_add_device(_: PgPoolOptions, options: PgConnectOptions) {
         device: get_db_device(&state.pool, 2).await,
     });
 
-    // send email regarding new device being added
-    // it should contain session info
-    // assert_eq!(mail.to(), "admin@defguard");
-    // assert_eq!(mail.subject(), "Defguard: new device added to your account");
-    // assert!(mail.content().contains("IP Address:</span> 127.0.0.1"));
-    // assert!(
-    //     mail.content()
-    //         .contains("Device type:</span> iPhone, OS: iOS 17.1, Mobile Safari")
-    // );
-
     // log in as normal user
     let auth = Auth::new("hpotter", "pass123");
     let response = client
@@ -1530,18 +1510,6 @@ async fn test_user_add_device(_: PgPoolOptions, options: PgConnectOptions) {
 
     let response = client.get("/api/v1/me").send().await;
     assert_eq!(response.status(), StatusCode::OK);
-
-    // send email regarding user login
-    // assert_eq!(mail.to(), "h.potter@hogwart.edu.uk");
-    // assert_eq!(
-    //     mail.subject(),
-    //     "Defguard: new device logged in to your account"
-    // );
-    // assert!(mail.content().contains("IP Address:</span> 127.0.0.1"));
-    // assert!(
-    //     mail.content()
-    //         .contains("Device type:</span> iPhone, OS: iOS 17.1, Mobile Safari")
-    // );
 
     // a device with duplicate pubkey cannot be added
     let response = client
@@ -1578,14 +1546,27 @@ async fn test_user_add_device(_: PgPoolOptions, options: PgConnectOptions) {
         device: get_db_device(&state.pool, 3).await,
     });
 
-    // send email regarding new device being added
-    // assert_eq!(mail.to(), "h.potter@hogwart.edu.uk");
-    // assert_eq!(mail.subject(), "Defguard: new device added to your account");
-    // assert!(mail.content().contains("IP Address:</span> 127.0.0.1"));
-    // assert!(
-    //     mail.content()
-    //         .contains("Device type:</span> iPhone, OS: iOS 17.1, Mobile Safari")
-    // );
+    // Verify the notifications delivered across the flow (all fire-and-forget,
+    // so assert the recipient/subject multiset rather than relying on order):
+    //  - admin login                 -> new-device-login  to admin
+    //  - admin adds device (hpotter)  -> new-device-added  to hpotter
+    //  - admin adds device (self)     -> new-device-added  to admin
+    //  - hpotter login                -> new-device-login  to hpotter
+    //  - hpotter adds device (self)   -> new-device-added  to hpotter
+    let mails = smtp.wait_for_count(5).await;
+    let login_subject = "Defguard: New device logged in to your account";
+    let added_subject = "Defguard: new device added to your account";
+    let count = |to: &str, subject: &str| {
+        mails
+            .iter()
+            .filter(|m| m.sent_to(to) && m.body_contains(subject))
+            .count()
+    };
+    assert_eq!(count("admin@defguard", login_subject), 1);
+    assert_eq!(count("admin@defguard", added_subject), 1);
+    assert_eq!(count("h.potter@hogwart.edu.uk", login_subject), 1);
+    assert_eq!(count("h.potter@hogwart.edu.uk", added_subject), 2);
+    assert_eq!(mails.len(), 5, "exactly five notifications expected");
 
     client.verify_api_events(&expected_events);
 }

--- a/crates/defguard_proxy_manager/Cargo.toml
+++ b/crates/defguard_proxy_manager/Cargo.toml
@@ -31,6 +31,8 @@ tonic.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+# Enable the shared test-only helpers (mock SMTP server) for the test build.
+defguard_common = { workspace = true, features = ["test-support"] }
 base32.workspace = true
 base64.workspace = true
 hyper-util = "0.1"

--- a/crates/defguard_proxy_manager/src/servers/password_reset.rs
+++ b/crates/defguard_proxy_manager/src/servers/password_reset.rs
@@ -142,8 +142,13 @@ impl PasswordResetServer {
             return Ok(());
         }
 
-        // Externally-managed users get a clear feedback email;
-        // other passwordless users (e.g. half-enrolled) stay silent.
+        // Handle passwordless users. There are three cases:
+        // - externally-managed (their IdP disables password management): send a
+        //   clear feedback email explaining they cannot set a local password;
+        // - linked to an external IdP that still allows local passwords
+        //   (OIDC or LDAP): allowed to set their first local password, so they
+        //   fall through to the normal reset flow below;
+        // - any other passwordless user (e.g. half-enrolled): stay silent.
         if !user.has_password() {
             let is_admin = user.is_admin(&self.pool).await.map_err(|err| {
                 error!("Failed to check if user is admin: {err}");
@@ -180,13 +185,21 @@ impl PasswordResetServer {
                 {
                     error!("Failed to send password reset disabled email: {err}");
                 }
+                return Ok(());
+            } else if user.openid_sub.is_some() || user.from_ldap {
+                // IdP-linked user allowed to hold a local password: let them set
+                // their first one through the normal reset flow below.
+                debug!(
+                    "Issuing password reset for passwordless IdP-linked user {} ({email})",
+                    user.username
+                );
             } else {
                 debug!(
                     "Password reset skipped for passwordless user {} ({email})",
                     user.username
                 );
+                return Ok(());
             }
-            return Ok(());
         }
 
         let mut transaction = self.pool.begin().await.map_err(|_| {
@@ -272,14 +285,15 @@ impl PasswordResetServer {
 
         let user = enrollment.fetch_user(&self.pool).await?;
 
-        if !user.has_password() || !user.is_active {
+        // A passwordless user may be setting their first local password (e.g. an
+        // OIDC/LDAP user), so only reject disabled users here. A token is only
+        // ever issued to users allowed to reset (see `request_password_reset`).
+        if !user.is_active {
             error!(
-                "Can't start password reset for a disabled or not enrolled user {}.",
+                "Can't start password reset for a disabled user {}.",
                 user.username
             );
-            return Err(Status::permission_denied(
-                "user disabled or not yet enrolled",
-            ));
+            return Err(Status::permission_denied("user disabled"));
         }
 
         let mut transaction = self.pool.begin().await.map_err(|_| {

--- a/crates/defguard_proxy_manager/src/tests/proxy_manager/handler/password_reset.rs
+++ b/crates/defguard_proxy_manager/src/tests/proxy_manager/handler/password_reset.rs
@@ -1,16 +1,19 @@
-use defguard_common::db::{
-    Id,
-    models::{
-        User,
-        settings::{Settings, update_current_settings},
+use defguard_common::{
+    db::{
+        Id,
+        models::{
+            User,
+            settings::{Settings, update_current_settings},
+        },
     },
+    testing::smtp::MockSmtpServer,
 };
 use defguard_core::events::{BidiStreamEventType, PasswordResetEvent};
 use defguard_proto::proxy::core_response;
 use sqlx::{
     PgPool,
     postgres::{PgConnectOptions, PgPoolOptions},
-    query_as, query_scalar,
+    query_scalar,
 };
 use tokio::time::timeout;
 
@@ -108,13 +111,13 @@ async fn test_password_reset_completes_successfully(_: PgPoolOptions, options: P
 
     // Start the session (consumes the PasswordResetStarted event).
     let start_response = send_password_reset_start(&mut context, &token.id).await;
-    assert!(
-        matches!(
-            start_response.payload,
-            Some(core_response::Payload::PasswordResetStart(_))
+    match &start_response.payload {
+        Some(core_response::Payload::PasswordResetStart(_)) => {}
+        _ => panic!(
+            "expected PasswordResetStart response, got: {:?}",
+            start_response.payload.as_ref().map(std::mem::discriminant)
         ),
-        "start must succeed"
-    );
+    }
     let _ = timeout(TEST_TIMEOUT, context.bidi_events_rx.recv()).await;
 
     // Reset the password.
@@ -180,13 +183,13 @@ async fn test_password_reset_weak_password_returns_error(
 
     // Start the session.
     let start_response = send_password_reset_start(&mut context, &token.id).await;
-    assert!(
-        matches!(
-            start_response.payload,
-            Some(core_response::Payload::PasswordResetStart(_))
+    match &start_response.payload {
+        Some(core_response::Payload::PasswordResetStart(_)) => {}
+        _ => panic!(
+            "expected PasswordResetStart response, got: {:?}",
+            start_response.payload.as_ref().map(std::mem::discriminant)
         ),
-        "start must succeed"
-    );
+    }
     let _ = timeout(TEST_TIMEOUT, context.bidi_events_rx.recv()).await;
 
     // Submit a weak password.
@@ -239,7 +242,12 @@ async fn test_password_reset_init_disabled_user_no_token(
     let mut context = HandlerTestContext::new(options).await;
     complete_proxy_handshake(&mut context).await;
 
-    // Enable LDAP password management disabling in settings.
+    // Capture outgoing mail so we can assert the "disabled" notification is sent.
+    let smtp = MockSmtpServer::start().await;
+    smtp.configure(&context.pool).await;
+
+    // Enable LDAP password management disabling (preserving the SMTP config just
+    // written to settings).
     let mut settings = Settings::get_current_settings();
     settings.ldap_disable_password_management = true;
     update_current_settings(&context.pool, settings)
@@ -264,17 +272,18 @@ async fn test_password_reset_init_disabled_user_no_token(
         ),
     }
 
-    // No PASSWORD_RESET token must have been created.
-    let count: (i64,) = sqlx::query_as(
-        "SELECT COUNT(*) FROM token WHERE user_id = $1 AND token_type = 'PASSWORD_RESET'",
-    )
-    .bind(user.id)
-    .fetch_one(&context.pool)
-    .await
-    .expect("failed to query token count");
+    // No PASSWORD_RESET token must have been created ...
     assert_eq!(
-        count.0, 0,
+        count_password_reset_tokens(&context.pool, user.id).await,
+        0,
         "no password reset token should be created for disabled user"
+    );
+
+    // ... but the user must receive a "password reset disabled" notification.
+    let mail = smtp.wait_for(|m| m.sent_to(&user.email)).await;
+    assert!(
+        mail.body_contains("Password reset disabled"),
+        "externally-managed user must receive the password-reset-disabled email"
     );
 
     context.finish().await.expect_server_finished().await;
@@ -305,15 +314,9 @@ async fn test_password_reset_init_passwordless_user_silent_no_token(
     }
 
     // No PASSWORD_RESET token must have been created.
-    let count: (i64,) = sqlx::query_as(
-        "SELECT COUNT(*) FROM token WHERE user_id = $1 AND token_type = 'PASSWORD_RESET'",
-    )
-    .bind(user.id)
-    .fetch_one(&context.pool)
-    .await
-    .expect("failed to query token count");
     assert_eq!(
-        count.0, 0,
+        count_password_reset_tokens(&context.pool, user.id).await,
+        0,
         "no password reset token should be created for passwordless user"
     );
 
@@ -347,6 +350,15 @@ async fn fetch_single_password_reset_token_id(pool: &PgPool, user_id: Id) -> Str
         ids.len()
     );
     ids.into_iter().next().unwrap()
+}
+
+/// Count the PASSWORD_RESET tokens for a user.
+async fn count_password_reset_tokens(pool: &PgPool, user_id: Id) -> i64 {
+    query_scalar("SELECT COUNT(*) FROM token WHERE user_id = $1 AND token_type = 'PASSWORD_RESET'")
+        .bind(user_id)
+        .fetch_one(pool)
+        .await
+        .expect("failed to query password reset token count")
 }
 
 /// Regression test for issue #3388: a passwordless user linked to an external
@@ -385,14 +397,9 @@ async fn test_password_reset_init_oidc_user_creates_token(
     }
 
     // A PASSWORD_RESET token must have been created so the user can set a password.
-    let count: (i64,) =
-        query_as("SELECT COUNT(*) FROM token WHERE user_id = $1 AND token_type = 'PASSWORD_RESET'")
-            .bind(user.id)
-            .fetch_one(&context.pool)
-            .await
-            .expect("failed to query token count");
     assert_eq!(
-        count.0, 1,
+        count_password_reset_tokens(&context.pool, user.id).await,
+        1,
         "a password reset token must be created for a passwordless OIDC user"
     );
 
@@ -445,15 +452,9 @@ async fn test_password_reset_init_ldap_user_creates_token(
         ),
     }
 
-    let count: (i64,) = sqlx::query_as(
-        "SELECT COUNT(*) FROM token WHERE user_id = $1 AND token_type = 'PASSWORD_RESET'",
-    )
-    .bind(user.id)
-    .fetch_one(&context.pool)
-    .await
-    .expect("failed to query token count");
     assert_eq!(
-        count.0, 1,
+        count_password_reset_tokens(&context.pool, user.id).await,
+        1,
         "a password reset token must be created for a passwordless LDAP user"
     );
 
@@ -485,27 +486,26 @@ async fn test_password_reset_completes_for_oidc_user(_: PgPoolOptions, options: 
 
     // Init: must create a reset token and emit PasswordResetRequested.
     let init_response = send_password_reset_init(&mut context, &user.email).await;
-    assert!(
-        matches!(
-            init_response.payload,
-            Some(core_response::Payload::Empty(()))
+    match &init_response.payload {
+        Some(core_response::Payload::Empty(())) => {}
+        _ => panic!(
+            "expected Empty response on init, got: {:?}",
+            init_response.payload.as_ref().map(std::mem::discriminant)
         ),
-        "init must return Empty"
-    );
+    }
     let token_id = fetch_single_password_reset_token_id(&context.pool, user.id).await;
     // Drain the PasswordResetRequested event.
     let _ = timeout(TEST_TIMEOUT, context.bidi_events_rx.recv()).await;
 
     // Start: must succeed even though the user has no password yet.
     let start_response = send_password_reset_start(&mut context, &token_id).await;
-    assert!(
-        matches!(
-            start_response.payload,
-            Some(core_response::Payload::PasswordResetStart(_))
+    match &start_response.payload {
+        Some(core_response::Payload::PasswordResetStart(_)) => {}
+        _ => panic!(
+            "start must succeed for a passwordless OIDC user, got: {:?}",
+            start_response.payload.as_ref().map(std::mem::discriminant)
         ),
-        "start must succeed for a passwordless OIDC user, got: {:?}",
-        start_response.payload.as_ref().map(std::mem::discriminant)
-    );
+    }
     // Drain the PasswordResetStarted event.
     let _ = timeout(TEST_TIMEOUT, context.bidi_events_rx.recv()).await;
 

--- a/crates/defguard_proxy_manager/src/tests/proxy_manager/handler/password_reset.rs
+++ b/crates/defguard_proxy_manager/src/tests/proxy_manager/handler/password_reset.rs
@@ -1,10 +1,17 @@
-use defguard_common::db::models::{
-    User,
-    settings::{Settings, update_current_settings},
+use defguard_common::db::{
+    Id,
+    models::{
+        User,
+        settings::{Settings, update_current_settings},
+    },
 };
 use defguard_core::events::{BidiStreamEventType, PasswordResetEvent};
 use defguard_proto::proxy::core_response;
-use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
+use sqlx::{
+    PgPool,
+    postgres::{PgConnectOptions, PgPoolOptions},
+    query_as, query_scalar,
+};
 use tokio::time::timeout;
 
 use super::support::{
@@ -309,6 +316,232 @@ async fn test_password_reset_init_passwordless_user_silent_no_token(
         count.0, 0,
         "no password reset token should be created for passwordless user"
     );
+
+    context.finish().await.expect_server_finished().await;
+}
+
+/// Configure a valid public proxy URL so the reset-mail step in
+/// `request_password_reset` can build its enrollment link. The mail send itself
+/// is fire-and-forget and a no-op without SMTP, so this only needs to parse.
+async fn set_public_proxy_url(pool: &PgPool) {
+    let mut settings = Settings::get_current_settings();
+    settings.public_proxy_url = "https://proxy.example.com".to_owned();
+    update_current_settings(pool, settings)
+        .await
+        .expect("failed to set public_proxy_url");
+}
+
+/// Fetch the `id` of the single PASSWORD_RESET token for a user, asserting
+/// exactly one exists.
+async fn fetch_single_password_reset_token_id(pool: &PgPool, user_id: Id) -> String {
+    let ids: Vec<String> =
+        query_scalar("SELECT id FROM token WHERE user_id = $1 AND token_type = 'PASSWORD_RESET'")
+            .bind(user_id)
+            .fetch_all(pool)
+            .await
+            .expect("failed to query password reset tokens");
+    assert_eq!(
+        ids.len(),
+        1,
+        "expected exactly one PASSWORD_RESET token, found {}",
+        ids.len()
+    );
+    ids.into_iter().next().unwrap()
+}
+
+/// Regression test for issue #3388: a passwordless user linked to an external
+/// OIDC provider whose IdP does NOT disable password management must be able to
+/// obtain a password reset. `PasswordResetInit` must create a PASSWORD_RESET
+/// token and emit a `PasswordResetRequested` event (the reset email is sent via
+/// the fire-and-forget mailer, which is not observable in tests).
+///
+/// Before the fix this user falls into the silent branch and no token is
+/// created, so this test fails (red).
+#[sqlx::test]
+async fn test_password_reset_init_oidc_user_creates_token(
+    _: PgPoolOptions,
+    options: PgConnectOptions,
+) {
+    let mut context = HandlerTestContext::new(options).await;
+    complete_proxy_handshake(&mut context).await;
+    set_public_proxy_url(&context.pool).await;
+
+    // Passwordless user linked to an external OIDC provider. Password management
+    // is NOT disabled (the default), so they may hold a local password.
+    let mut user = create_user(&context.pool).await;
+    user.openid_sub = Some("oidc-sub-123".to_owned());
+    user.save(&context.pool)
+        .await
+        .expect("failed to save OIDC user");
+
+    let response = send_password_reset_init(&mut context, &user.email).await;
+
+    match &response.payload {
+        Some(core_response::Payload::Empty(())) => {}
+        _ => panic!(
+            "expected Empty response for OIDC user, got: {:?}",
+            response.payload.as_ref().map(std::mem::discriminant)
+        ),
+    }
+
+    // A PASSWORD_RESET token must have been created so the user can set a password.
+    let count: (i64,) =
+        query_as("SELECT COUNT(*) FROM token WHERE user_id = $1 AND token_type = 'PASSWORD_RESET'")
+            .bind(user.id)
+            .fetch_one(&context.pool)
+            .await
+            .expect("failed to query token count");
+    assert_eq!(
+        count.0, 1,
+        "a password reset token must be created for a passwordless OIDC user"
+    );
+
+    // A BidiStreamEvent::PasswordReset(PasswordResetRequested) must have been emitted.
+    let event = timeout(TEST_TIMEOUT, context.bidi_events_rx.recv())
+        .await
+        .expect("timed out waiting for BidiStreamEvent")
+        .expect("bidi_events_rx closed");
+    match event.event {
+        BidiStreamEventType::PasswordReset(e) => match *e {
+            PasswordResetEvent::PasswordResetRequested => {}
+            other => panic!("expected PasswordResetRequested event, got: {other:?}"),
+        },
+        other => panic!("expected BidiStreamEventType::PasswordReset, got: {other:?}"),
+    }
+
+    context.finish().await.expect_server_finished().await;
+}
+
+/// Regression test for issue #3388: a passwordless user synced from LDAP whose
+/// IdP does NOT disable password management (the default) must be able to obtain
+/// a password reset. `PasswordResetInit` must create a PASSWORD_RESET token.
+///
+/// Before the fix this user falls into the silent branch and no token is
+/// created, so this test fails (red).
+#[sqlx::test]
+async fn test_password_reset_init_ldap_user_creates_token(
+    _: PgPoolOptions,
+    options: PgConnectOptions,
+) {
+    let mut context = HandlerTestContext::new(options).await;
+    complete_proxy_handshake(&mut context).await;
+    set_public_proxy_url(&context.pool).await;
+
+    // Passwordless LDAP-sourced user. `ldap_disable_password_management` is left
+    // at its default (false), so they may hold a local password.
+    let mut user = create_user(&context.pool).await;
+    user.from_ldap = true;
+    user.save(&context.pool)
+        .await
+        .expect("failed to save LDAP user");
+
+    let response = send_password_reset_init(&mut context, &user.email).await;
+
+    match &response.payload {
+        Some(core_response::Payload::Empty(())) => {}
+        _ => panic!(
+            "expected Empty response for LDAP user, got: {:?}",
+            response.payload.as_ref().map(std::mem::discriminant)
+        ),
+    }
+
+    let count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM token WHERE user_id = $1 AND token_type = 'PASSWORD_RESET'",
+    )
+    .bind(user.id)
+    .fetch_one(&context.pool)
+    .await
+    .expect("failed to query token count");
+    assert_eq!(
+        count.0, 1,
+        "a password reset token must be created for a passwordless LDAP user"
+    );
+
+    context.finish().await.expect_server_finished().await;
+}
+
+/// Regression test for issue #3388, full flow: a passwordless OIDC user must be
+/// able to complete a password reset end to end - init creates a token, start
+/// succeeds, and reset sets their first local password.
+///
+/// Before the fix, `start_password_reset` rejects the user with
+/// `PermissionDenied` because of its `!user.has_password()` guard, so this test
+/// fails (red) at the start step.
+#[sqlx::test]
+async fn test_password_reset_completes_for_oidc_user(_: PgPoolOptions, options: PgConnectOptions) {
+    let mut context = HandlerTestContext::new(options).await;
+    complete_proxy_handshake(&mut context).await;
+    set_public_proxy_url(&context.pool).await;
+
+    let mut user = create_user(&context.pool).await;
+    user.openid_sub = Some("oidc-sub-456".to_owned());
+    user.save(&context.pool)
+        .await
+        .expect("failed to save OIDC user");
+    assert!(
+        !user.has_password(),
+        "precondition: OIDC user starts without a local password"
+    );
+
+    // Init: must create a reset token and emit PasswordResetRequested.
+    let init_response = send_password_reset_init(&mut context, &user.email).await;
+    assert!(
+        matches!(
+            init_response.payload,
+            Some(core_response::Payload::Empty(()))
+        ),
+        "init must return Empty"
+    );
+    let token_id = fetch_single_password_reset_token_id(&context.pool, user.id).await;
+    // Drain the PasswordResetRequested event.
+    let _ = timeout(TEST_TIMEOUT, context.bidi_events_rx.recv()).await;
+
+    // Start: must succeed even though the user has no password yet.
+    let start_response = send_password_reset_start(&mut context, &token_id).await;
+    assert!(
+        matches!(
+            start_response.payload,
+            Some(core_response::Payload::PasswordResetStart(_))
+        ),
+        "start must succeed for a passwordless OIDC user, got: {:?}",
+        start_response.payload.as_ref().map(std::mem::discriminant)
+    );
+    // Drain the PasswordResetStarted event.
+    let _ = timeout(TEST_TIMEOUT, context.bidi_events_rx.recv()).await;
+
+    // Reset: sets the user's first local password.
+    const NEW_PASSWORD: &str = "NewPass2!";
+    let reset_response = send_password_reset(&mut context, &token_id, NEW_PASSWORD).await;
+    match &reset_response.payload {
+        Some(core_response::Payload::Empty(())) => {}
+        _ => panic!(
+            "expected Empty on successful password reset, got: {:?}",
+            reset_response.payload.as_ref().map(std::mem::discriminant)
+        ),
+    }
+
+    // The user must now have a local password set in the DB.
+    let updated = User::find_by_username(&context.pool, &user.username)
+        .await
+        .expect("db query failed")
+        .expect("user not found");
+    assert!(
+        updated.has_password(),
+        "OIDC user must have a local password after completing the reset"
+    );
+
+    // A PasswordResetCompleted event must have been emitted.
+    let event = timeout(TEST_TIMEOUT, context.bidi_events_rx.recv())
+        .await
+        .expect("timed out waiting for BidiStreamEvent")
+        .expect("bidi_events_rx closed");
+    match event.event {
+        BidiStreamEventType::PasswordReset(e) => match *e {
+            PasswordResetEvent::PasswordResetCompleted => {}
+            other => panic!("expected PasswordResetCompleted event, got: {other:?}"),
+        },
+        other => panic!("expected BidiStreamEventType::PasswordReset, got: {other:?}"),
+    }
 
     context.finish().await.expect_server_finished().await;
 }

--- a/crates/defguard_proxy_manager/src/tests/proxy_manager/handler/support.rs
+++ b/crates/defguard_proxy_manager/src/tests/proxy_manager/handler/support.rs
@@ -46,12 +46,7 @@ use defguard_proto::{
 };
 use ipnetwork::IpNetwork;
 use sqlx::PgPool;
-use tokio::{
-    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
-    net::TcpListener,
-    sync::mpsc::UnboundedReceiver,
-    time::timeout,
-};
+use tokio::{sync::mpsc::UnboundedReceiver, time::timeout};
 use tonic::Code;
 
 use crate::tests::common::{HandlerTestContext, MockOidcProvider, RECEIVE_TIMEOUT};
@@ -488,7 +483,7 @@ pub(crate) async fn create_external_mfa_network(pool: &PgPool) -> WireguardNetwo
 /// The code is valid immediately and can be passed directly to
 /// `ClientMfaFinishRequest::code`.
 pub(crate) async fn setup_user_email_mfa(pool: &PgPool, user: &mut User<Id>) -> String {
-    configure_working_smtp(pool).await;
+    defguard_common::testing::smtp::configure_working_smtp(pool).await;
     user.new_email_secret(pool).await.expect("new_email_secret");
     user.enable_email_mfa(pool).await.expect("enable_email_mfa");
     // generate_email_mfa_code uses the in-memory secret; note that
@@ -943,83 +938,6 @@ pub(crate) fn configure_smtp(settings: &mut Settings) {
     settings.smtp.server = Some("smtp.example.com".into());
     settings.smtp.port = Some(587);
     settings.smtp.sender = Some("noreply@example.com".into());
-}
-
-/// Spawn a minimal in-process SMTP server that accepts any message and replies
-/// with success codes, then point `pool`'s current settings at it.
-///
-/// MFA emails (`mfa_code_mail`/`mfa_activation_mail`) are actually sent
-/// (awaited) rather than fired-and-forgotten, so tests exercising the email
-/// MFA method need a real, reachable SMTP endpoint or the send fails with
-/// `SmtpNotConfigured`/`MailSendFailed`.
-pub(crate) async fn configure_working_smtp(pool: &PgPool) {
-    let listener = TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("failed to bind fake SMTP listener");
-    let addr = listener.local_addr().expect("failed to get local addr");
-
-    tokio::spawn(async move {
-        loop {
-            let Ok((stream, _)) = listener.accept().await else {
-                return;
-            };
-            tokio::spawn(async move {
-                let (reader, mut writer) = stream.into_split();
-                let mut reader = BufReader::new(reader);
-                let _ = writer.write_all(b"220 localhost ESMTP\r\n").await;
-                let mut line = String::new();
-                loop {
-                    line.clear();
-                    match reader.read_line(&mut line).await {
-                        Ok(0) => return,
-                        Ok(_) => {}
-                        Err(_) => return,
-                    }
-                    let upper = line.trim_end().to_ascii_uppercase();
-                    if upper.starts_with("EHLO") || upper.starts_with("HELO") {
-                        let _ = writer.write_all(b"250 localhost\r\n").await;
-                    } else if upper.starts_with("MAIL FROM")
-                        || upper.starts_with("RCPT TO")
-                        || upper.starts_with("RSET")
-                    {
-                        let _ = writer.write_all(b"250 OK\r\n").await;
-                    } else if upper.starts_with("DATA") {
-                        let _ = writer
-                            .write_all(b"354 End data with <CR><LF>.<CR><LF>\r\n")
-                            .await;
-                        loop {
-                            line.clear();
-                            match reader.read_line(&mut line).await {
-                                Ok(0) => return,
-                                Ok(_) => {}
-                                Err(_) => return,
-                            }
-                            if line == ".\r\n" || line == ".\n" {
-                                break;
-                            }
-                        }
-                        let _ = writer.write_all(b"250 OK message queued\r\n").await;
-                    } else if upper.starts_with("QUIT") {
-                        let _ = writer.write_all(b"221 Bye\r\n").await;
-                        return;
-                    } else {
-                        let _ = writer.write_all(b"250 OK\r\n").await;
-                    }
-                }
-            });
-        }
-    });
-
-    let mut settings = Settings::get_current_settings();
-    settings.smtp.server = Some(addr.ip().to_string());
-    settings.smtp.port = Some(i32::from(addr.port()));
-    settings.smtp.sender = Some("noreply@example.com".into());
-    settings.smtp.encryption = defguard_common::db::models::settings::smtp::SmtpEncryption::None;
-    settings.smtp.authentication =
-        defguard_common::db::models::settings::smtp::SmtpAuthentication::None;
-    update_current_settings(pool, settings)
-        .await
-        .expect("failed to persist fake SMTP settings");
 }
 
 /// Set minimal LDAP fields on a [`Settings`] so that `ldap_configured()` returns `true`.

--- a/crates/defguard_proxy_manager/src/tests/proxy_manager/handler/support.rs
+++ b/crates/defguard_proxy_manager/src/tests/proxy_manager/handler/support.rs
@@ -12,11 +12,13 @@ use defguard_common::{
             Device, DeviceType, User, WireguardNetwork,
             polling_token::PollingToken,
             settings::{Settings, update_current_settings},
+            user::{TOTP_CODE_DIGITS, TOTP_CODE_VALIDITY_PERIOD},
             vpn_client_session::VpnClientSession,
             wireguard::{LocationMfaMode, ServiceLocationMode},
         },
     },
     secret::SecretStringWrapper,
+    testing::smtp::configure_working_smtp,
 };
 use defguard_core::{
     db::models::enrollment::{ENROLLMENT_TOKEN_TYPE, PASSWORD_RESET_TOKEN_TYPE, Token},
@@ -48,6 +50,7 @@ use ipnetwork::IpNetwork;
 use sqlx::PgPool;
 use tokio::{sync::mpsc::UnboundedReceiver, time::timeout};
 use tonic::Code;
+use totp_lite::{Sha1, totp_custom};
 
 use crate::tests::common::{HandlerTestContext, MockOidcProvider, RECEIVE_TIMEOUT};
 
@@ -483,7 +486,7 @@ pub(crate) async fn create_external_mfa_network(pool: &PgPool) -> WireguardNetwo
 /// The code is valid immediately and can be passed directly to
 /// `ClientMfaFinishRequest::code`.
 pub(crate) async fn setup_user_email_mfa(pool: &PgPool, user: &mut User<Id>) -> String {
-    defguard_common::testing::smtp::configure_working_smtp(pool).await;
+    configure_working_smtp(pool).await;
     user.new_email_secret(pool).await.expect("new_email_secret");
     user.enable_email_mfa(pool).await.expect("enable_email_mfa");
     // generate_email_mfa_code uses the in-memory secret; note that
@@ -507,8 +510,6 @@ pub(crate) async fn setup_user_totp_mfa(pool: &PgPool, user: &mut User<Id>) {
 /// Mirrors the logic in `User::verify_totp_code`.  Call this immediately before
 /// `send_mfa_finish` so the code is within the current 30-second window.
 pub(crate) fn generate_totp_code(user: &User<Id>) -> String {
-    use defguard_common::db::models::user::{TOTP_CODE_DIGITS, TOTP_CODE_VALIDITY_PERIOD};
-    use totp_lite::{Sha1, totp_custom};
     let secret = user
         .totp_secret
         .as_ref()
@@ -523,8 +524,6 @@ pub(crate) fn generate_totp_code(user: &User<Id>) -> String {
 /// Generate a TOTP code from a **base32-encoded** secret string (as returned
 /// by `CodeMfaSetupStartResponse.totp_secret`).
 pub(crate) fn totp_code_from_base32_secret(base32_secret: &str) -> String {
-    use defguard_common::db::models::user::{TOTP_CODE_DIGITS, TOTP_CODE_VALIDITY_PERIOD};
-    use totp_lite::{Sha1, totp_custom};
     let secret = base32::decode(base32::Alphabet::Rfc4648 { padding: false }, base32_secret)
         .expect("invalid base32 TOTP secret from CodeMfaSetupStartResponse");
     let ts = SystemTime::now()


### PR DESCRIPTION
Enable external user to use the password reset functionality to set an internal password.
This also extracts a pre-existing mock SMTP server into a shared helper to be used in all integration tests and re-enables tests which have been commented out when we moved away from a mail channel + mailing service setup.

Closes https://github.com/DefGuard/defguard/issues/3388