### PR TITLE
LDAP remote enrollment fix

### DIFF
--- a/crates/defguard_common/src/db/models/settings/mod.rs
+++ b/crates/defguard_common/src/db/models/settings/mod.rs
@@ -63,10 +63,6 @@ pub enum SettingsValidationError {
     CannotEnableGatewayNotifications,
     #[error("Cannot enable remote enrollment for LDAP. LDAP and SMTP must both be configured")]
     CannotEnableLdapRemoteEnrollment,
-    #[error(
-        "Cannot enable automatic invites for LDAP remote enrollment. LDAP remote enrollment is not enabled"
-    )]
-    CannotEnableLdapRemoteEnrollmentInvite,
     #[error("Cannot enable LDAP. Required LDAP fields are not configured")]
     CannotEnableLdap,
     #[error("Invalid defguard_url `{0}`, url has to be a domain, not IP")]
@@ -545,12 +541,6 @@ impl Settings {
         if self.ldap_remote_enrollment_enabled && !self.ldap_configured() {
             warn!("Cannot enable remote enrollment for LDAP. LDAP is not configured.");
             return Err(SettingsValidationError::CannotEnableLdapRemoteEnrollment);
-        }
-        if self.ldap_remote_enrollment_send_invite && !self.ldap_remote_enrollment_enabled {
-            warn!(
-                "Cannot enable automatic invites for LDAP remote enrollment. LDAP remote enrollment is not enabled"
-            );
-            return Err(SettingsValidationError::CannotEnableLdapRemoteEnrollmentInvite);
         }
 
         Ok(())
@@ -1401,6 +1391,27 @@ mod test {
             settings.validate(),
             Err(SettingsValidationError::InvalidDefguardUrl(_))
         ));
+    }
+
+    /// Regression test for https://github.com/DefGuard/defguard/issues/3394
+    ///
+    /// Disabling LDAP remote enrollment while the dependent "send invite" option
+    /// is still set must not fail validation. The value is left untouched - the
+    /// email-sending path guards on both flags, so no invite is sent regardless.
+    #[test]
+    fn test_validate_accepts_send_invite_when_remote_enrollment_disabled() {
+        let mut settings = Settings {
+            defguard_url: "https://defguard.example.com".into(),
+            ldap_remote_enrollment_enabled: false,
+            ldap_remote_enrollment_send_invite: true,
+            ..Default::default()
+        };
+
+        assert!(
+            settings.validate().is_ok(),
+            "disabling remote enrollment must not fail validation when send invite is still set"
+        );
+        assert!(settings.ldap_remote_enrollment_send_invite);
     }
 
     #[test]

--- a/crates/defguard_core/src/enterprise/ldap/tests.rs
+++ b/crates/defguard_core/src/enterprise/ldap/tests.rs
@@ -3923,6 +3923,58 @@ async fn test_sync_invite_skipped_when_send_invite_flag_disabled(
     );
 }
 
+/// Regression test for <https://github.com/DefGuard/defguard/issues/3394>.
+///
+/// When `ldap_remote_enrollment_send_invite` is left on but its parent
+/// `ldap_remote_enrollment_enabled` toggle is off, syncing new LDAP users must NOT create
+/// enrollment tokens. Everything else needed to send an invite (SMTP, LDAP, proxy URL and an
+/// admin) is configured, so the disabled parent toggle is the only reason no invite is sent.
+#[sqlx::test]
+async fn test_sync_invite_skipped_when_remote_enrollment_disabled(
+    _: PgPoolOptions,
+    options: PgConnectOptions,
+) {
+    let pool = setup_pool(options).await;
+    let (wg_tx, _wg_rx) = wg_test_channel();
+    let (ldap_tx, _ldap_rx) = ldap_test_channel();
+    let _ = initialize_current_settings(&pool).await;
+
+    let mut settings = Settings::get_current_settings();
+    configure_smtp_and_ldap(&mut settings);
+    settings.ldap_remote_enrollment_enabled = false;
+    settings.ldap_remote_enrollment_send_invite = true;
+    settings.public_proxy_url = PROXY_URL.into();
+    update_current_settings(&pool, settings).await.unwrap();
+
+    make_test_admin(&pool, "sync_admin_enrollmentoff").await;
+
+    let mut ldap_conn = LDAPConnection::create().await.unwrap();
+    let config = ldap_conn.config.clone();
+
+    let mut ldap_user = make_test_user("sync_invite_enrollmentoff_user", None, None);
+    ldap_user.ldap_rdn = Some("sync_invite_enrollmentoff_user".into());
+    ldap_user.ldap_user_path = Some("ou=users,dc=example,dc=com".into());
+    ldap_conn
+        .test_client_mut()
+        .add_test_user(&ldap_user, &config);
+
+    ldap_conn
+        .sync(&pool, false, &wg_tx, &ldap_tx)
+        .await
+        .unwrap();
+
+    let saved = User::find_by_username(&pool, "sync_invite_enrollmentoff_user")
+        .await
+        .unwrap();
+    assert!(saved.is_some(), "User should have been synced to Defguard");
+
+    let tokens = Token::fetch_all(&pool).await.unwrap();
+    assert!(
+        tokens.is_empty(),
+        "Expected no enrollment token when remote enrollment is disabled, got {tokens:?}"
+    );
+}
+
 /// When both `ldap_remote_enrollment_enabled` and `ldap_remote_enrollment_send_invite` are on,
 /// syncing a new LDAP user must create an enrollment token and set `enrollment_pending = true`.
 ///

--- a/crates/defguard_core/src/enterprise/ldap/tests.rs
+++ b/crates/defguard_core/src/enterprise/ldap/tests.rs
@@ -9,6 +9,7 @@ use defguard_common::{
         setup_pool,
     },
     secret::SecretStringWrapper,
+    testing::smtp::MockSmtpServer,
 };
 use ldap3::SearchEntry;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
@@ -3825,7 +3826,8 @@ async fn test_ldap_sync_allowed_all_conditions_false(_: PgPoolOptions, options: 
 }
 
 /// When both `ldap_remote_enrollment_enabled` and `ldap_remote_enrollment_send_invite` are
-/// disabled (the default), syncing new LDAP users must NOT create any enrollment tokens.
+/// disabled (the default), syncing new LDAP users must NOT create any enrollment tokens and
+/// must NOT send any invite email - even though a working SMTP server is available.
 #[sqlx::test]
 async fn test_sync_does_not_send_invite_when_flags_disabled(
     _: PgPoolOptions,
@@ -3835,6 +3837,10 @@ async fn test_sync_does_not_send_invite_when_flags_disabled(
     let (wg_tx, _wg_rx) = wg_test_channel();
     let (ldap_tx, mut ldap_rx) = ldap_test_channel();
     let _ = initialize_current_settings(&pool).await;
+
+    // Working SMTP is available, so the disabled flags are the only reason no invite is sent.
+    let smtp = MockSmtpServer::start().await;
+    smtp.configure(&pool).await;
 
     // Create an admin so find_admins() would have something to return - we want to prove
     // the early-return on the flag guard, not the no-admin guard.
@@ -3874,6 +3880,15 @@ async fn test_sync_does_not_send_invite_when_flags_disabled(
         tokens.is_empty(),
         "Expected no enrollment token when invite flags are disabled, got {tokens:?}"
     );
+
+    // No invite email should have been sent. The invite mail is spawned only after the
+    // token is created, so with no token no mail is ever dispatched to the mock server.
+    assert_eq!(
+        smtp.message_count(),
+        0,
+        "Expected no invite email when invite flags are disabled, got {:?}",
+        smtp.messages()
+    );
 }
 
 /// When only `ldap_remote_enrollment_enabled` is on but `ldap_remote_enrollment_send_invite`
@@ -3893,6 +3908,11 @@ async fn test_sync_invite_skipped_when_send_invite_flag_disabled(
     settings.ldap_remote_enrollment_enabled = true;
     settings.ldap_remote_enrollment_send_invite = false;
     update_current_settings(&pool, settings).await.unwrap();
+
+    // Point SMTP at a working mock so the disabled send-invite flag is the only reason
+    // no invite is sent.
+    let smtp = MockSmtpServer::start().await;
+    smtp.configure(&pool).await;
 
     make_test_admin(&pool, "sync_admin_sendoff").await;
 
@@ -3921,14 +3941,22 @@ async fn test_sync_invite_skipped_when_send_invite_flag_disabled(
         tokens.is_empty(),
         "Expected no enrollment token when send_invite flag is disabled, got {tokens:?}"
     );
+
+    assert_eq!(
+        smtp.message_count(),
+        0,
+        "Expected no invite email when send_invite flag is disabled, got {:?}",
+        smtp.messages()
+    );
 }
 
 /// Regression test for <https://github.com/DefGuard/defguard/issues/3394>.
 ///
 /// When `ldap_remote_enrollment_send_invite` is left on but its parent
 /// `ldap_remote_enrollment_enabled` toggle is off, syncing new LDAP users must NOT create
-/// enrollment tokens. Everything else needed to send an invite (SMTP, LDAP, proxy URL and an
-/// admin) is configured, so the disabled parent toggle is the only reason no invite is sent.
+/// enrollment tokens and must NOT send an invite email. Everything else needed to send an
+/// invite (a working SMTP server, LDAP, proxy URL and an admin) is configured, so the disabled
+/// parent toggle is the only reason no invite is sent.
 #[sqlx::test]
 async fn test_sync_invite_skipped_when_remote_enrollment_disabled(
     _: PgPoolOptions,
@@ -3945,6 +3973,11 @@ async fn test_sync_invite_skipped_when_remote_enrollment_disabled(
     settings.ldap_remote_enrollment_send_invite = true;
     settings.public_proxy_url = PROXY_URL.into();
     update_current_settings(&pool, settings).await.unwrap();
+
+    // Point SMTP at a working mock so the disabled parent toggle is the only reason
+    // no invite is sent.
+    let smtp = MockSmtpServer::start().await;
+    smtp.configure(&pool).await;
 
     make_test_admin(&pool, "sync_admin_enrollmentoff").await;
 
@@ -3973,14 +4006,18 @@ async fn test_sync_invite_skipped_when_remote_enrollment_disabled(
         tokens.is_empty(),
         "Expected no enrollment token when remote enrollment is disabled, got {tokens:?}"
     );
+
+    assert_eq!(
+        smtp.message_count(),
+        0,
+        "Expected no invite email when remote enrollment is disabled, got {:?}",
+        smtp.messages()
+    );
 }
 
 /// When both `ldap_remote_enrollment_enabled` and `ldap_remote_enrollment_send_invite` are on,
-/// syncing a new LDAP user must create an enrollment token and set `enrollment_pending = true`.
-///
-/// SMTP is configured in settings but no real SMTP server is reachable, so `new_account_mail`
-/// will fail - but the token and flag are persisted before the mail attempt, so the DB side
-/// effects are still observable.
+/// syncing a new LDAP user must create an enrollment token, set `enrollment_pending = true`,
+/// and actually deliver an invite email to the user carrying the tokenized proxy link.
 #[sqlx::test]
 async fn test_sync_sends_invite_when_flags_enabled(_: PgPoolOptions, options: PgConnectOptions) {
     let pool = setup_pool(options).await;
@@ -3995,6 +4032,10 @@ async fn test_sync_sends_invite_when_flags_enabled(_: PgPoolOptions, options: Pg
     // Provide a valid proxy URL so proxy_public_url() succeeds.
     settings.public_proxy_url = PROXY_URL.into();
     update_current_settings(&pool, settings).await.unwrap();
+
+    // Point SMTP at a working mock so the invite email is actually delivered and captured.
+    let smtp = MockSmtpServer::start().await;
+    smtp.configure(&pool).await;
 
     make_test_admin(&pool, "sync_admin_invite").await;
 
@@ -4034,7 +4075,22 @@ async fn test_sync_sends_invite_when_flags_enabled(_: PgPoolOptions, options: Pg
         "Token should belong to the synced user"
     );
 
-    // Second sync: user already exists in Defguard - must NOT create a second token.
+    // The invite email (sent fire-and-forget) is delivered to the synced user and carries a
+    // tokenized enrollment link pointing at the configured proxy.
+    let mail = smtp
+        .wait_for(|m| m.sent_to("sync_invite_user@example.com"))
+        .await;
+    assert!(
+        mail.body_contains(&tokens[0].id),
+        "invite email should contain the enrollment token"
+    );
+    assert!(
+        mail.body_contains("proxy.example.com"),
+        "invite link should point at the configured proxy URL"
+    );
+
+    // Second sync: user already exists in Defguard - must NOT create a second token
+    // nor send a second invite email.
     ldap_conn
         .sync(&pool, false, &wg_tx, &ldap_tx)
         .await
@@ -4045,6 +4101,12 @@ async fn test_sync_sends_invite_when_flags_enabled(_: PgPoolOptions, options: Pg
         tokens.len(),
         1,
         "Expected still exactly one enrollment token after second sync, got {tokens:?}"
+    );
+    assert_eq!(
+        smtp.message_count(),
+        1,
+        "Expected exactly one invite email after second sync, got {:?}",
+        smtp.messages()
     );
 }
 

--- a/crates/defguard_core/src/enterprise/ldap/tests.rs
+++ b/crates/defguard_core/src/enterprise/ldap/tests.rs
@@ -9,7 +9,7 @@ use defguard_common::{
         setup_pool,
     },
     secret::SecretStringWrapper,
-    testing::smtp::MockSmtpServer,
+    testing::smtp::configure_working_smtp,
 };
 use ldap3::SearchEntry;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
@@ -3839,8 +3839,7 @@ async fn test_sync_does_not_send_invite_when_flags_disabled(
     let _ = initialize_current_settings(&pool).await;
 
     // Working SMTP is available, so the disabled flags are the only reason no invite is sent.
-    let smtp = MockSmtpServer::start().await;
-    smtp.configure(&pool).await;
+    let smtp = configure_working_smtp(&pool).await;
 
     // Create an admin so find_admins() would have something to return - we want to prove
     // the early-return on the flag guard, not the no-admin guard.
@@ -3911,8 +3910,7 @@ async fn test_sync_invite_skipped_when_send_invite_flag_disabled(
 
     // Point SMTP at a working mock so the disabled send-invite flag is the only reason
     // no invite is sent.
-    let smtp = MockSmtpServer::start().await;
-    smtp.configure(&pool).await;
+    let smtp = configure_working_smtp(&pool).await;
 
     make_test_admin(&pool, "sync_admin_sendoff").await;
 
@@ -3976,8 +3974,7 @@ async fn test_sync_invite_skipped_when_remote_enrollment_disabled(
 
     // Point SMTP at a working mock so the disabled parent toggle is the only reason
     // no invite is sent.
-    let smtp = MockSmtpServer::start().await;
-    smtp.configure(&pool).await;
+    let smtp = configure_working_smtp(&pool).await;
 
     make_test_admin(&pool, "sync_admin_enrollmentoff").await;
 
@@ -4034,8 +4031,7 @@ async fn test_sync_sends_invite_when_flags_enabled(_: PgPoolOptions, options: Pg
     update_current_settings(&pool, settings).await.unwrap();
 
     // Point SMTP at a working mock so the invite email is actually delivered and captured.
-    let smtp = MockSmtpServer::start().await;
-    smtp.configure(&pool).await;
+    let smtp = configure_working_smtp(&pool).await;
 
     make_test_admin(&pool, "sync_admin_invite").await;
 
@@ -4089,8 +4085,11 @@ async fn test_sync_sends_invite_when_flags_enabled(_: PgPoolOptions, options: Pg
         "invite link should point at the configured proxy URL"
     );
 
-    // Second sync: user already exists in Defguard - must NOT create a second token
-    // nor send a second invite email.
+    // Second sync: user already exists in Defguard - must NOT create a second token.
+    // An invite email is only ever dispatched together with a new enrollment token, so an
+    // unchanged token count is the deterministic guard that no second invite was sent. (A
+    // direct message_count() check here would be racy: mail is spawned fire-and-forget, so a
+    // wrongly-sent second mail might not have reached the mock by the time we read the count.)
     ldap_conn
         .sync(&pool, false, &wg_tx, &ldap_tx)
         .await
@@ -4101,12 +4100,6 @@ async fn test_sync_sends_invite_when_flags_enabled(_: PgPoolOptions, options: Pg
         tokens.len(),
         1,
         "Expected still exactly one enrollment token after second sync, got {tokens:?}"
-    );
-    assert_eq!(
-        smtp.message_count(),
-        1,
-        "Expected exactly one invite email after second sync, got {:?}",
-        smtp.messages()
     );
 }
 
@@ -4183,8 +4176,7 @@ async fn test_ldap_login_sends_invite_when_flags_enabled(
     update_current_settings(&pool, settings).await.unwrap();
 
     // Point SMTP at a working mock so the invite email is actually delivered and captured.
-    let smtp = MockSmtpServer::start().await;
-    smtp.configure(&pool).await;
+    let smtp = configure_working_smtp(&pool).await;
 
     make_test_admin(&pool, "login_admin_invite").await;
 
@@ -4238,8 +4230,10 @@ async fn test_ldap_login_sends_invite_when_flags_enabled(
         "invite link should point at the configured proxy URL"
     );
 
-    // Second login: user now exists in Defguard - must NOT create a second token
-    // nor send a second invite email.
+    // Second login: user now exists in Defguard - must NOT create a second token.
+    // As above, the unchanged token count is the deterministic guard that no second invite
+    // was sent (mail is dispatched only alongside a new token); an instantaneous
+    // message_count() check would be racy against fire-and-forget delivery.
     let result =
         login_through_ldap_with_connection(&pool, &mut ldap_conn, "login_invite_user", PASSWORD)
             .await;
@@ -4253,12 +4247,6 @@ async fn test_ldap_login_sends_invite_when_flags_enabled(
         tokens.len(),
         1,
         "Expected still exactly one enrollment token after second login, got {tokens:?}"
-    );
-    assert_eq!(
-        smtp.message_count(),
-        1,
-        "Expected exactly one invite email after second login, got {:?}",
-        smtp.messages()
     );
 }
 
@@ -4282,8 +4270,7 @@ async fn test_ldap_login_does_not_send_invite_for_existing_user(
 
     // Point SMTP at a working mock so the returning-user guard is the only reason no invite
     // is sent, not a missing SMTP configuration.
-    let smtp = MockSmtpServer::start().await;
-    smtp.configure(&pool).await;
+    let smtp = configure_working_smtp(&pool).await;
 
     make_test_admin(&pool, "login_admin_existing").await;
 

--- a/crates/defguard_core/src/enterprise/ldap/tests.rs
+++ b/crates/defguard_core/src/enterprise/ldap/tests.rs
@@ -4165,7 +4165,8 @@ async fn test_sync_invite_skipped_when_no_admin_exists(
 }
 
 /// When both invite flags are on and a user logs in through LDAP for the first time (not yet
-/// in Defguard), an enrollment token must be created and `enrollment_pending` set to `true`.
+/// in Defguard), an enrollment token must be created, `enrollment_pending` set to `true`, and
+/// an invite email actually delivered to the user carrying the tokenized proxy link.
 #[sqlx::test]
 async fn test_ldap_login_sends_invite_when_flags_enabled(
     _: PgPoolOptions,
@@ -4180,6 +4181,10 @@ async fn test_ldap_login_sends_invite_when_flags_enabled(
     settings.ldap_remote_enrollment_send_invite = true;
     settings.public_proxy_url = PROXY_URL.into();
     update_current_settings(&pool, settings).await.unwrap();
+
+    // Point SMTP at a working mock so the invite email is actually delivered and captured.
+    let smtp = MockSmtpServer::start().await;
+    smtp.configure(&pool).await;
 
     make_test_admin(&pool, "login_admin_invite").await;
 
@@ -4219,7 +4224,22 @@ async fn test_ldap_login_sends_invite_when_flags_enabled(
         "Token should belong to the logged-in user"
     );
 
-    // Second login: user now exists in Defguard - must NOT create a second token.
+    // The invite email (sent fire-and-forget) is delivered to the user and carries a
+    // tokenized enrollment link pointing at the configured proxy.
+    let mail = smtp
+        .wait_for(|m| m.sent_to("login_invite_user@example.com"))
+        .await;
+    assert!(
+        mail.body_contains(&tokens[0].id),
+        "invite email should contain the enrollment token"
+    );
+    assert!(
+        mail.body_contains("proxy.example.com"),
+        "invite link should point at the configured proxy URL"
+    );
+
+    // Second login: user now exists in Defguard - must NOT create a second token
+    // nor send a second invite email.
     let result =
         login_through_ldap_with_connection(&pool, &mut ldap_conn, "login_invite_user", PASSWORD)
             .await;
@@ -4234,10 +4254,17 @@ async fn test_ldap_login_sends_invite_when_flags_enabled(
         1,
         "Expected still exactly one enrollment token after second login, got {tokens:?}"
     );
+    assert_eq!(
+        smtp.message_count(),
+        1,
+        "Expected exactly one invite email after second login, got {:?}",
+        smtp.messages()
+    );
 }
 
 /// When both invite flags are on but the LDAP user already exists in Defguard (returning user),
-/// no additional enrollment token must be created.
+/// no additional enrollment token must be created and no invite email must be sent - even
+/// though a working SMTP server and both flags are configured.
 #[sqlx::test]
 async fn test_ldap_login_does_not_send_invite_for_existing_user(
     _: PgPoolOptions,
@@ -4252,6 +4279,11 @@ async fn test_ldap_login_does_not_send_invite_for_existing_user(
     settings.ldap_remote_enrollment_send_invite = true;
     settings.public_proxy_url = PROXY_URL.into();
     update_current_settings(&pool, settings).await.unwrap();
+
+    // Point SMTP at a working mock so the returning-user guard is the only reason no invite
+    // is sent, not a missing SMTP configuration.
+    let smtp = MockSmtpServer::start().await;
+    smtp.configure(&pool).await;
 
     make_test_admin(&pool, "login_admin_existing").await;
 
@@ -4286,6 +4318,13 @@ async fn test_ldap_login_does_not_send_invite_for_existing_user(
     assert!(
         tokens.is_empty(),
         "Expected no enrollment token for a returning LDAP user, got {tokens:?}"
+    );
+
+    assert_eq!(
+        smtp.message_count(),
+        0,
+        "Expected no invite email for a returning LDAP user, got {:?}",
+        smtp.messages()
     );
 }
 

--- a/crates/defguard_core/src/error.rs
+++ b/crates/defguard_core/src/error.rs
@@ -227,7 +227,6 @@ impl From<SettingsValidationError> for WebError {
         match err {
             SettingsValidationError::CannotEnableGatewayNotifications
             | SettingsValidationError::CannotEnableLdapRemoteEnrollment
-            | SettingsValidationError::CannotEnableLdapRemoteEnrollmentInvite
             | SettingsValidationError::CannotEnableLdap
             | SettingsValidationError::InvalidDefguardUrl(_) => Self::BadRequest(err.to_string()),
         }

--- a/crates/defguard_core/src/lib.rs
+++ b/crates/defguard_core/src/lib.rs
@@ -88,12 +88,12 @@ use tracing::Level;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
-use crate::enterprise::db::models::openid_provider::OpenIdProvider;
 use crate::{
     appstate::AppState,
     auth::failed_login::FailedLoginMap,
     db::AppEvent,
     enterprise::{
+        db::models::openid_provider::OpenIdProvider,
         firewall::try_get_location_firewall_config,
         handlers::{
             acl::{

--- a/crates/defguard_core/tests/integration/api/settings.rs
+++ b/crates/defguard_core/tests/integration/api/settings.rs
@@ -340,8 +340,10 @@ async fn test_ldap_remote_enrollment_validation(_: PgPoolOptions, options: PgCon
         "ldap_remote_enrollment_enabled must be persisted to DB after enabling"
     );
 
-    // enabling send_invite while remote enrollment is disabled must fail
-    // (use a fresh settings state: disable enrollment first)
+    // enabling send_invite while remote enrollment is disabled is allowed: the flag
+    // combination is no longer validated on submit (see issue #3394). The invite-sending
+    // guard requires BOTH flags, so a lingering send_invite has no effect while remote
+    // enrollment is off. Disable enrollment first to reach that state.
     let patch: SettingsPatch =
         serde_json::from_str(r#"{ "ldap_remote_enrollment_enabled": false }"#).unwrap();
     let response = client.patch("/api/v1/settings").json(&patch).send().await;
@@ -357,8 +359,17 @@ async fn test_ldap_remote_enrollment_validation(_: PgPoolOptions, options: PgCon
     let response = client.patch("/api/v1/settings").json(&patch).send().await;
     assert_eq!(
         response.status(),
-        StatusCode::BAD_REQUEST,
-        "enabling send_invite without remote enrollment enabled should return 400"
+        StatusCode::OK,
+        "enabling send_invite without remote enrollment enabled is allowed (validation relaxed, see #3394)"
+    );
+    let from_db = Settings::get(&pool).await.unwrap().unwrap();
+    assert!(
+        from_db.ldap_remote_enrollment_send_invite,
+        "ldap_remote_enrollment_send_invite must be persisted even while remote enrollment is disabled"
+    );
+    assert!(
+        !from_db.ldap_remote_enrollment_enabled,
+        "remote enrollment must stay disabled - setting send_invite does not enable it"
     );
 
     // re-enable remote enrollment, then enabling send_invite must succeed


### PR DESCRIPTION
Remove unnecessary validation of LDAP remote enrollment settings.

Closes https://github.com/DefGuard/defguard/issues/3394