### PR TITLE
Prevent adding wireguard device for disabled users

### DIFF
--- a/.sqlx/query-4e56d679555dcaa12b341673cb37d47d60a29d7da6e2fe36d2afaf07156b31be.json
+++ b/.sqlx/query-4e56d679555dcaa12b341673cb37d47d60a29d7da6e2fe36d2afaf07156b31be.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT EXISTS(SELECT 1 FROM \"user\" u JOIN group_user gu ON gu.user_id = u.id JOIN \"group\" g ON gu.group_id = g.id WHERE u.id = $1 AND u.is_active AND g.\"name\" IN (SELECT * FROM UNNEST($2::text[])))",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "exists",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "4e56d679555dcaa12b341673cb37d47d60a29d7da6e2fe36d2afaf07156b31be"
+}

--- a/.sqlx/query-c471ac17a519490c139b05a603ddfa30e5ff7e37553b73a75ca79de524c0cf4c.json
+++ b/.sqlx/query-c471ac17a519490c139b05a603ddfa30e5ff7e37553b73a75ca79de524c0cf4c.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT EXISTS(SELECT 1 FROM \"user\" u WHERE u.id = $1 AND u.is_active)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "exists",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "c471ac17a519490c139b05a603ddfa30e5ff7e37553b73a75ca79de524c0cf4c"
+}

--- a/crates/defguard_common/src/db/models/wireguard.rs
+++ b/crates/defguard_common/src/db/models/wireguard.rs
@@ -451,9 +451,12 @@ impl WireguardNetwork<Id> {
         }
     }
 
-    /// Get a list of all devices belonging to users in allowed groups.
+    /// Get a list of all devices belonging to active users in allowed groups.
     /// Admin users should always be allowed to access a network.
     /// Note: Doesn't check if the devices are really in the network.
+    ///
+    /// For a single device, use [`Self::is_device_allowed_in_network`] instead of
+    /// fetching this whole list.
     pub async fn get_allowed_devices(
         &self,
         transaction: &mut PgConnection,
@@ -468,7 +471,7 @@ impl WireguardNetwork<Id> {
                 JOIN \"user\" u ON d.user_id = u.id \
                 WHERE u.is_active \
                 AND d.device_type = 'user'::device_type \
-                ORDER BY d.id ASC"
+                ORDER BY d.id ASC",
             )
             .fetch_all(&mut *transaction)
             .await
@@ -488,11 +491,47 @@ impl WireguardNetwork<Id> {
                 AND u.is_active \
                 AND d.device_type = 'user'::device_type \
                 ORDER BY d.id ASC",
-            &allowed_groups
+            &allowed_groups,
         )
         .fetch_all(&mut *transaction)
         .await?;
         Ok(devices)
+    }
+
+    /// Checks if a single device is allowed in this network: its user must be active
+    /// and, unless the network allows all groups, a member of one of its allowed groups.
+    pub async fn is_device_allowed_in_network(
+        &self,
+        conn: &mut PgConnection,
+        device: &Device<Id>,
+    ) -> Result<bool, ModelError> {
+        if device.device_type != DeviceType::User {
+            return Ok(false);
+        }
+        if self.allow_all_groups {
+            let allowed = query_scalar!(
+                "SELECT EXISTS(SELECT 1 FROM \"user\" u WHERE u.id = $1 AND u.is_active)",
+                device.user_id
+            )
+            .fetch_one(&mut *conn)
+            .await?;
+            return Ok(allowed.unwrap_or(false));
+        }
+
+        let allowed_groups = self.get_allowed_groups(&mut *conn).await?;
+        let allowed = query_scalar!(
+            "SELECT EXISTS(SELECT 1 FROM \"user\" u \
+                JOIN group_user gu ON gu.user_id = u.id \
+                JOIN \"group\" g ON gu.group_id = g.id \
+                WHERE u.id = $1 \
+                AND u.is_active \
+                AND g.\"name\" IN (SELECT * FROM UNNEST($2::text[])))",
+            device.user_id,
+            &allowed_groups
+        )
+        .fetch_one(&mut *conn)
+        .await?;
+        Ok(allowed.unwrap_or(false))
     }
 
     /// Get a list of devices belonging to a user which are also in the network's allowed groups.
@@ -574,11 +613,12 @@ impl WireguardNetwork<Id> {
         reserved_ips: Option<&[IpAddr]>,
     ) -> Result<WireguardNetworkDevice, WireguardNetworkError> {
         info!("Assigning IP in network {self} for {device}");
-        let allowed_devices = self.get_allowed_devices(&mut *conn).await?;
-        let allowed_device_ids = allowed_devices.iter().map(|dev| dev.id).collect::<Vec<_>>();
-        let used_ips = self.all_used_ips_for_network(&mut *conn).await?;
+        let allowed = self
+            .is_device_allowed_in_network(&mut *conn, device)
+            .await?;
 
-        if allowed_device_ids.contains(&device.id) {
+        if allowed {
+            let used_ips = self.all_used_ips_for_network(&mut *conn).await?;
             let wireguard_network_device = device
                 .assign_next_network_ip(&mut *conn, self, &used_ips, reserved_ips, None)
                 .await?;

--- a/crates/defguard_core/src/device_access/mod.rs
+++ b/crates/defguard_core/src/device_access/mod.rs
@@ -16,6 +16,7 @@ use defguard_common::{
     device_config_gen::create_wireguard_config,
 };
 use sqlx::PgConnection;
+use tracing::warn;
 
 use crate::enterprise::allowed_ips::get_effective_allowed_ips;
 
@@ -104,7 +105,13 @@ pub async fn join_device_to_all_networks(
             .await
         {
             Ok(d) => d,
-            Err(WireguardNetworkError::DeviceNotAllowed(_)) => continue,
+            Err(WireguardNetworkError::DeviceNotAllowed(_)) => {
+                warn!(
+                    "Device {device} not allowed in network {network}, skipping config \
+                    generation for this network"
+                );
+                continue;
+            }
             Err(WireguardNetworkError::DeviceError(DeviceError::NetworkFull(_))) => {
                 return Err(DeviceError::NetworkFull(network.name.clone()));
             }

--- a/crates/defguard_core/src/handlers/wireguard.rs
+++ b/crates/defguard_core/src/handlers/wireguard.rs
@@ -851,8 +851,10 @@ pub(crate) async fn add_device(
         return Err(WebError::Forbidden("Manual device management is disabled"));
     }
 
-    // Let admins manage devices for disabled users
-    if !user.is_active && !session.is_admin {
+    // Disabled users' devices never get network access (see
+    // `is_device_allowed_in_network`), and get stripped on the next sync even if
+    // briefly assigned.
+    if !user.is_active {
         warn!(
             "User {} tried to add a device for a disabled user {username}",
             session.user.username

--- a/crates/defguard_core/tests/integration/api/wireguard.rs
+++ b/crates/defguard_core/tests/integration/api/wireguard.rs
@@ -34,7 +34,8 @@ use serde_json::json;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 
 use super::common::{
-    authenticate_admin, exceed_enterprise_limits, make_network, make_test_client, setup_pool,
+    authenticate_admin, exceed_enterprise_limits, fetch_user_details, make_network,
+    make_test_client, setup_pool,
 };
 
 const INVALID_MFA_PEER_DISCONNECT_THRESHOLD: i32 = 119;
@@ -1449,6 +1450,66 @@ async fn test_user_device_configs_auth(_: PgPoolOptions, options: PgConnectOptio
         StatusCode::NOT_FOUND,
         "non-admin user should not access another user's device config"
     );
+}
+
+/// Regression test: an admin manually adding a device for a disabled user used to
+/// silently succeed with an empty config list, since the device was never actually
+/// allowed to join any network. Disabled users' devices are also stripped from every
+/// network on the next sync anyway (see `process_device_access_changes`), so letting
+/// an admin add one would only work until that sync runs.
+#[sqlx::test]
+async fn test_add_device_for_disabled_user(_: PgPoolOptions, options: PgConnectOptions) {
+    let pool = setup_pool(options).await;
+    let (mut client, _) = make_test_client(pool).await;
+    authenticate_admin(&mut client).await;
+
+    // Network open to all users, so the only thing blocking the device is `is_active`.
+    client
+        .post("/api/v1/network")
+        .json(&json!({
+            "name": "network",
+            "address": "10.1.1.1/24",
+            "port": 55555,
+            "endpoint": "192.168.4.14",
+            "allowed_ips": "10.1.1.0/24",
+            "dns": "1.1.1.1",
+            "mtu": 1420,
+            "fwmark": 0,
+            "allowed_groups": [],
+            "allow_all_groups": true,
+            "keepalive_interval": 25,
+            "peer_disconnect_threshold": 300,
+            "acl_enabled": false,
+            "acl_default_allow": false,
+            "allowed_ips_from_acl": false,
+            "location_mfa_mode": "disabled",
+            "service_location_mode": "disabled"
+        }))
+        .send()
+        .await;
+
+    // Disable hpotter.
+    let mut user_details = fetch_user_details(&client, "hpotter").await;
+    user_details.user.is_active = false;
+    let response = client
+        .put("/api/v1/user/hpotter")
+        .json(&user_details.user)
+        .send()
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Admin tries to add a device for the disabled user manually. Should be rejected
+    // outright, not silently created with no usable config.
+    let device_payload = json!({
+        "name": "disabled-user-device",
+        "wireguard_pubkey": "LQKsT6/3HWKuJmMulH63R8iK+5sI8FyYEL6WDIi6lQU=",
+    });
+    let response = client
+        .post("/api/v1/device/hpotter")
+        .json(&device_payload)
+        .send()
+        .await;
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
 }
 
 /// MFA locations (internal/external) must be excluded from the user device config endpoint.

--- a/web/src/pages/user-profile/UserProfilePage/tabs/ProfileDevicesTab/components/ProfileDevicesTable/ProfileDevicesTable.tsx
+++ b/web/src/pages/user-profile/UserProfilePage/tabs/ProfileDevicesTab/components/ProfileDevicesTable/ProfileDevicesTable.tsx
@@ -109,7 +109,7 @@ const DevicesTable = ({ rowData }: { rowData: RowData[] }) => {
       variant: 'primary',
       testId: 'add-device',
       iconLeft: 'add-device',
-      disabled: !info.network_present || !canModifyDevices,
+      disabled: !info.network_present || !canModifyDevices || !user.is_active,
       onClick: () => {
         useAddUserDeviceModal.getState().open({
           devices,


### PR DESCRIPTION
Previously admins could add a wireguard device for disabled users which didn't produce a wg configuration, as disabled devices are not added to a network and thus have no IP address, which makes them unusable.