### PR TITLE
add migration to fix invalid SMTP settings caused by backfill edge case

### DIFF
--- a/migrations/20260729120000_[2.0.3]_fix_smtp_auth_backfill.down.sql
+++ b/migrations/20260729120000_[2.0.3]_fix_smtp_auth_backfill.down.sql
@@ -1,0 +1,3 @@
+-- No-op: this migration repairs data and cannot be safely reversed. Rows that
+-- were originally unauthenticated are indistinguishable from repaired ones, so
+-- there is nothing to restore.

--- a/migrations/20260729120000_[2.0.3]_fix_smtp_auth_backfill.up.sql
+++ b/migrations/20260729120000_[2.0.3]_fix_smtp_auth_backfill.up.sql
@@ -1,0 +1,11 @@
+-- Repair rows mis-classified by the [2.0.2] smtp_xoauth2 back-fill.
+-- That migration set smtp_authentication = 'login' whenever smtp_user and
+-- smtp_password were merely NOT NULL, but empty-string credentials (valid and
+-- common under 2.0.1, where SMTP authentication was optional) then fail the
+-- stricter SmtpSettings::is_configured() check. That in turn makes settings
+-- validation reject "gateway disconnect notifications" at startup and aborts
+-- the core process. Fall back to 'none' for those rows, restoring 2.0.1 behavior.
+UPDATE settings SET smtp_authentication = 'none'
+  WHERE smtp_authentication = 'login'
+    AND (smtp_user IS NULL OR smtp_user = ''
+      OR smtp_password IS NULL OR smtp_password = '');


### PR DESCRIPTION
Backfill migration logic in 2.0.2 could produce invalid settings in an edge case when for whatever reason both SMTP username and password were empty strings (instead of actual NULL values), causing a crash on startup.

Closes https://github.com/DefGuard/defguard/issues/3490