### PR TITLE
continue on postures step during network creation test

### DIFF
--- a/e2e/utils/controllers/vpn/createNetwork.ts
+++ b/e2e/utils/controllers/vpn/createNetwork.ts
@@ -93,6 +93,7 @@ export const createServiceLocation = async (browser: Browser, network: NetworkFo
   await page.getByTestId('continue').click();
   await page.getByTestId('continue').click();
   await page.getByTestId('acl-continue').click();
+  await page.getByTestId('posture-continue').click();
   await page.getByTestId('create-location').click();
   await page.locator('.icon-button .icon[data-kind="close"]').click();
 


### PR DESCRIPTION
Related issue: https://github.com/DefGuard/defguard/issues/3462

Posture check step is no longer hidden during service location creation wizard.
This PR updates e2e tests to respect that.