### PR TITLE
table and skeleton should be mutually exclusive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2249,7 +2249,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2695,9 +2695,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -5058,7 +5058,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5542,7 +5542,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6579,7 +6579,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7663,7 +7663,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/web/src/pages/RulesPage/tabs/RulesDeployedTab.tsx
+++ b/web/src/pages/RulesPage/tabs/RulesDeployedTab.tsx
@@ -59,6 +59,7 @@ export const RulesDeployedTab = () => {
       )}
       {!isEmpty && loading && <TableSkeleton />}
       {!isEmpty &&
+        !loading &&
         isPresent(aliases) &&
         isPresent(destinations) &&
         isPresent(locations) &&

--- a/web/src/pages/RulesPage/tabs/RulesPendingTab.tsx
+++ b/web/src/pages/RulesPage/tabs/RulesPendingTab.tsx
@@ -58,6 +58,7 @@ export const RulesPendingTab = () => {
       )}
       {!isEmpty && loading && <TableSkeleton />}
       {!isEmpty &&
+        !loading &&
         isPresent(aliases) &&
         isPresent(destinations) &&
         isPresent(locations) &&

--- a/web/src/pages/RulesPage/useRuleDeps.tsx
+++ b/web/src/pages/RulesPage/useRuleDeps.tsx
@@ -3,11 +3,8 @@ import { useMemo } from 'react';
 import {
   getAppliedAliasesQueryOptions,
   getAppliedDestinationsQueryOptions,
-  getGroupsInfoQueryOptions,
   getLicenseInfoQueryOptions,
   getLocationsQueryOptions,
-  getNetworkDevicesQueryOptions,
-  getUsersQueryOptions,
 } from '../../shared/query';
 import { resourceById } from '../../shared/utils/resourceById';
 
@@ -21,36 +18,18 @@ export const useRuleDeps = () => {
   const { data: destinations, isLoading: destinationsLoading } = useQuery(
     getAppliedDestinationsQueryOptions,
   );
-  const { data: groups, isLoading: groupsLoading } = useQuery(getGroupsInfoQueryOptions);
   const { data: locations, isLoading: locationsLoading } = useQuery(
     getLocationsQueryOptions,
-  );
-  const { data: users, isLoading: usersLoading } = useQuery(getUsersQueryOptions);
-  const { data: devices, isLoading: devicesLoading } = useQuery(
-    getNetworkDevicesQueryOptions,
   );
 
   const destinationsById = useMemo(() => resourceById(destinations), [destinations]);
   const aliasesById = useMemo(() => resourceById(aliases), [aliases]);
-  const groupsById = useMemo(() => resourceById(groups), [groups]);
   const locationsById = useMemo(() => resourceById(locations), [locations]);
-  const usersById = useMemo(() => resourceById(users), [users]);
-  const devicesById = useMemo(() => resourceById(devices), [devices]);
 
   return {
-    loading:
-      aliasesLoading ||
-      groupsLoading ||
-      locationsLoading ||
-      usersLoading ||
-      devicesLoading ||
-      destinationsLoading ||
-      licenseLoading,
+    loading: aliasesLoading || locationsLoading || destinationsLoading || licenseLoading,
     aliases: aliasesById,
-    groups: groupsById,
     locations: locationsById,
-    users: usersById,
-    devices: devicesById,
     destinations: destinationsById,
     license: licenseInfo,
   };


### PR DESCRIPTION
Related issue: https://github.com/DefGuard/defguard/issues/3550

Make table and skeleton components mutually exclusive on firewall rules page. 