### PR TITLE
Fix TypeError: undefined is not an object

### DIFF
--- a/web/src/shared/api/api.ts
+++ b/web/src/shared/api/api.ts
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 import { cloneDeep } from 'lodash-es';
+import { isPresent } from '../defguard-ui/utils/isPresent';
 import { narrowLicenseSupport } from '../utils/license';
 import { removeEmptyStrings } from '../utils/removeEmptyStrings';
 import { client } from './api-client';
@@ -616,10 +617,11 @@ const api = {
     client
       .get<LicenseInfoResponse>(`/enterprise_info`)
       .then((res): LicenseInfo | null => {
-        if (res.data.license_info === null) return null;
+        const licenseInfo = res.data?.license_info;
+        if (!isPresent(licenseInfo)) return null;
         return {
-          ...res.data.license_info,
-          support_type_narrow: narrowLicenseSupport(res.data.license_info),
+          ...licenseInfo,
+          support_type_narrow: narrowLicenseSupport(licenseInfo),
         };
       }),
   support: {

--- a/web/src/shared/api/types.ts
+++ b/web/src/shared/api/types.ts
@@ -522,7 +522,7 @@ export interface LicenseInfoApi {
 }
 
 export interface LicenseInfoResponse {
-  license_info: LicenseInfo | null;
+  license_info: LicenseInfoApi | null;
 }
 
 export interface LdapInfo {


### PR DESCRIPTION
If `/enterprise_info` returns anything else with a 2xx — an HTML/empty body from a reverse proxy or session-expiry redirect, a body without the key — `res.data.license_info` is undefined, sails past the `=== null` check, and `narrowLicenseSupport(undefined)` throws on `license.support_type`.