### PR TITLE
trigger firewall update from LDAP/AD sync

### DIFF
--- a/crates/defguard_core/src/enterprise/directory_sync/mod.rs
+++ b/crates/defguard_core/src/enterprise/directory_sync/mod.rs
@@ -37,6 +37,7 @@ use crate::{
     events::{DirectorySyncEvent, DirectorySyncEventType, LdapSyncEventType},
     grpc::GatewayCommand,
     handlers::user::check_username,
+    location_management::sync_all_networks,
     user_management::{delete_user_and_cleanup_devices, disable_user, sync_allowed_user_devices},
 };
 
@@ -783,7 +784,7 @@ async fn sync_all_users_state(
     )
     .await?;
 
-    sync_active_directory_users(
+    let users_reenabled = sync_active_directory_users(
         &mut transaction,
         &active_directory_users,
         &mut modified_users,
@@ -1119,6 +1120,22 @@ async fn sync_all_users_state(
     debug!("Done processing missing users");
 
     transaction.commit().await?;
+
+    if users_reenabled {
+        match pool.acquire().await {
+            Ok(mut conn) => {
+                if let Err(err) = sync_all_networks(&mut conn, gateway_tx).await {
+                    error!("Failed to sync all networks after directory user re-enablement: {err}");
+                }
+            }
+            Err(err) => {
+                error!(
+                    "Failed to acquire a connection to sync networks after directory user re-enablement: {err}"
+                );
+            }
+        }
+    }
+
     update_counts(pool).await?;
 
     emit_directory_sync_events(dirsync_tx, &settings.name, dirsync_events);
@@ -1199,7 +1216,7 @@ async fn sync_active_directory_users(
     active_directory_users: &[&DirectoryUser],
     modified_users: &mut Vec<User<Id>>,
     dirsync_events: &mut Vec<DirectorySyncEventType>,
-) -> Result<(), DirectorySyncError> {
+) -> Result<bool, DirectorySyncError> {
     // find all inactive Defguard users enabled in directory
     let enabled_users_emails = active_directory_users
         .iter()
@@ -1216,6 +1233,7 @@ async fn sync_active_directory_users(
         "There are {} inactive Defguard users enabled in the directory. Enabling them in Defguard.",
         users_to_enable.len()
     );
+    let mut users_reenabled = false;
     for mut user in users_to_enable {
         if user.is_active {
             debug!("User {} is already enabled, skipping", user.email);
@@ -1227,12 +1245,13 @@ async fn sync_active_directory_users(
         );
         user.is_active = true;
         user.save(&mut *transaction).await?;
+        users_reenabled = true;
         dirsync_events.push(DirectorySyncEventType::UserEnabled { user: user.clone() });
         modified_users.push(user);
     }
     debug!("Done processing active directory users");
 
-    Ok(())
+    Ok(users_reenabled)
 }
 
 // The default inverval for the directory sync job

--- a/crates/defguard_core/src/enterprise/directory_sync/tests.rs
+++ b/crates/defguard_core/src/enterprise/directory_sync/tests.rs
@@ -213,6 +213,104 @@ mod test {
         assert!(gateway_rx.try_recv().is_err());
     }
 
+    #[sqlx::test]
+    async fn test_users_state_reenable_refreshes_firewall(
+        _: PgPoolOptions,
+        options: PgConnectOptions,
+    ) {
+        let pool = setup_pool(options).await;
+
+        let config = DefGuardConfig::new_test_config();
+        let _ = SERVER_CONFIG.set(config);
+        let (gateway_tx, mut gateway_rx) = broadcast::channel::<GatewayCommand>(16);
+        make_test_provider(
+            &pool,
+            DirectorySyncUserBehavior::Keep,
+            DirectorySyncUserBehavior::Keep,
+            DirectorySyncTarget::All,
+            false,
+        )
+        .await;
+
+        let mut network = get_test_network(&pool).await;
+        network.acl_enabled = true;
+        let network_id = network.id;
+        network.save(&pool).await.unwrap();
+
+        let mut user = make_test_user_and_device("reenabled_user", &pool).await;
+        user.is_active = false;
+        user.save(&pool).await.unwrap();
+
+        let license = License::new(
+            "test".to_owned(),
+            false,
+            None,
+            Some(LicenseLimits {
+                users: 100,
+                devices: 100,
+                locations: 100,
+                network_devices: Some(100),
+            }),
+            None,
+            LicenseTier::Business,
+            SupportType::Basic,
+            vec![],
+        );
+        set_cached_license(Some(license));
+        update_counts(&pool).await.unwrap();
+
+        let directory_user = DirectoryUser {
+            id: None,
+            email: user.email.clone(),
+            active: true,
+            user_details: None,
+        };
+        let (ldap_tx, _ldap_rx) = ldap_test_channel();
+        let (dirsync_tx, _dirsync_rx) = dirsync_test_channel();
+        sync_all_users_state(
+            &pool,
+            &gateway_tx,
+            &ldap_tx,
+            &dirsync_tx,
+            &[directory_user],
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            get_test_user(&pool, "reenabled_user")
+                .await
+                .unwrap()
+                .is_active
+        );
+        let firewall_updates = std::iter::from_fn(|| gateway_rx.try_recv().ok())
+            .filter(|event| {
+                matches!(event, GatewayCommand::FirewallConfigChanged(id, _) if *id == network_id)
+            })
+            .count();
+        assert_eq!(firewall_updates, 1);
+
+        let (ldap_tx, _ldap_rx) = ldap_test_channel();
+        let (dirsync_tx, _dirsync_rx) = dirsync_test_channel();
+        sync_all_users_state(
+            &pool,
+            &gateway_tx,
+            &ldap_tx,
+            &dirsync_tx,
+            &[DirectoryUser {
+                id: None,
+                email: user.email,
+                active: true,
+                user_details: None,
+            }],
+            None,
+        )
+        .await
+        .unwrap();
+        assert!(gateway_rx.try_recv().is_err());
+    }
+
     // Delete users, keep admins
     #[sqlx::test]
     async fn test_users_state_delete_users(_: PgPoolOptions, options: PgConnectOptions) {

--- a/crates/defguard_core/src/enterprise/ldap/sync.rs
+++ b/crates/defguard_core/src/enterprise/ldap/sync.rs
@@ -1128,6 +1128,7 @@ impl super::LDAPConnection {
     async fn apply_user_sync_changes(
         &mut self,
         pool: &PgPool,
+        wg_tx: &Sender<GatewayCommand>,
         mut changes: UserSyncChanges,
         ldap_tx: &UnboundedSender<LdapSyncEventType>,
     ) -> Result<(), LdapError> {
@@ -1152,13 +1153,17 @@ impl super::LDAPConnection {
                     admin_count -= 1;
                     debug!("Deleting admin user {} from Defguard", user.username);
                     let deleted_user = user.clone();
-                    user.delete(&mut *transaction).await?;
+                    delete_user_and_cleanup_devices(user.clone(), &mut transaction, wg_tx)
+                        .await
+                        .map_err(|err| LdapError::UserStatusUpdate(err.to_string()))?;
                     events.push(LdapSyncEventType::UserDeleted { user: deleted_user });
                 }
             } else {
                 debug!("Deleting user {} from Defguard", user.username);
                 let deleted_user = user.clone();
-                user.delete(&mut *transaction).await?;
+                delete_user_and_cleanup_devices(user.clone(), &mut transaction, wg_tx)
+                    .await
+                    .map_err(|err| LdapError::UserStatusUpdate(err.to_string()))?;
                 events.push(LdapSyncEventType::UserDeleted { user: deleted_user });
             }
         }

--- a/crates/defguard_core/src/enterprise/ldap/sync.rs
+++ b/crates/defguard_core/src/enterprise/ldap/sync.rs
@@ -97,9 +97,7 @@ use crate::{
     grpc::GatewayCommand,
     hashset,
     location_management::sync_all_networks,
-    user_management::{
-        delete_user_and_cleanup_devices, disable_user, sync_allowed_user_devices,
-    },
+    user_management::{delete_user_and_cleanup_devices, disable_user, sync_allowed_user_devices},
 };
 
 fn emit_ldap_sync_events(
@@ -716,7 +714,9 @@ impl super::LDAPConnection {
                     }
                 }
                 Err(err) => {
-                    error!("Failed to acquire a connection to sync networks after LDAP membership changes: {err}");
+                    error!(
+                        "Failed to acquire a connection to sync networks after LDAP membership changes: {err}"
+                    );
                 }
             }
         }
@@ -908,7 +908,9 @@ impl super::LDAPConnection {
                     }
                 }
                 Err(err) => {
-                    error!("Failed to acquire a connection to sync networks after LDAP membership changes: {err}");
+                    error!(
+                        "Failed to acquire a connection to sync networks after LDAP membership changes: {err}"
+                    );
                 }
             }
         }

--- a/crates/defguard_core/src/enterprise/ldap/sync.rs
+++ b/crates/defguard_core/src/enterprise/ldap/sync.rs
@@ -96,7 +96,10 @@ use crate::{
     events::LdapSyncEventType,
     grpc::GatewayCommand,
     hashset,
-    user_management::{disable_user, sync_allowed_user_devices},
+    location_management::sync_all_networks,
+    user_management::{
+        delete_user_and_cleanup_devices, disable_user, sync_allowed_user_devices,
+    },
 };
 
 fn emit_ldap_sync_events(
@@ -701,8 +704,22 @@ impl super::LDAPConnection {
             authority,
             &self.config,
         );
-        self.apply_user_group_sync_changes(pool, changes, ldap_tx)
+        let memberships_changed = self
+            .apply_user_group_sync_changes(pool, changes, ldap_tx)
             .await?;
+
+        if memberships_changed {
+            match pool.acquire().await {
+                Ok(mut conn) => {
+                    if let Err(err) = sync_all_networks(&mut conn, wg_tx).await {
+                        error!("Failed to sync all networks after LDAP membership changes: {err}");
+                    }
+                }
+                Err(err) => {
+                    error!("Failed to acquire a connection to sync networks after LDAP membership changes: {err}");
+                }
+            }
+        }
 
         Ok(())
     }
@@ -877,10 +894,24 @@ impl super::LDAPConnection {
             &self.config,
         );
 
-        self.apply_user_sync_changes(pool, user_changes, ldap_tx)
+        self.apply_user_sync_changes(pool, wg_tx, user_changes, ldap_tx)
             .await?;
-        self.apply_user_group_sync_changes(pool, membership_changes, ldap_tx)
+        let memberships_changed = self
+            .apply_user_group_sync_changes(pool, membership_changes, ldap_tx)
             .await?;
+
+        if memberships_changed {
+            match pool.acquire().await {
+                Ok(mut conn) => {
+                    if let Err(err) = sync_all_networks(&mut conn, wg_tx).await {
+                        error!("Failed to sync all networks after LDAP membership changes: {err}");
+                    }
+                }
+                Err(err) => {
+                    error!("Failed to acquire a connection to sync networks after LDAP membership changes: {err}");
+                }
+            }
+        }
 
         if full {
             debug!("Full LDAP sync completed");
@@ -976,10 +1007,11 @@ impl super::LDAPConnection {
         pool: &PgPool,
         changes: GroupSyncChanges<'_>,
         ldap_tx: &UnboundedSender<LdapSyncEventType>,
-    ) -> Result<(), LdapError> {
+    ) -> Result<bool, LdapError> {
         debug!("Applying group memberships sync changes");
         let mut transaction = pool.begin().await?;
         let mut admin_count = User::find_admins(&mut *transaction).await?.len();
+        let mut memberships_changed = false;
         let mut events = Vec::new();
         for (groupname, members) in changes.delete_defguard {
             if members.is_empty() {
@@ -1008,6 +1040,7 @@ impl super::LDAPConnection {
                         );
                         admin_count -= 1;
                         if member.remove_from_group(&mut *transaction, &group).await? {
+                            memberships_changed = true;
                             events.push(LdapSyncEventType::GroupMemberRemoved {
                                 group: group.clone(),
                                 user: member,
@@ -1017,6 +1050,7 @@ impl super::LDAPConnection {
                 } else {
                     debug!("Removing user {} from group {}", member.username, groupname);
                     if member.remove_from_group(&mut *transaction, &group).await? {
+                        memberships_changed = true;
                         events.push(LdapSyncEventType::GroupMemberRemoved {
                             group: group.clone(),
                             user: member,
@@ -1042,6 +1076,7 @@ impl super::LDAPConnection {
                     User::find_by_username(&mut *transaction, &member.username).await?
                 {
                     if user.add_to_group(&mut *transaction, &group).await? {
+                        memberships_changed = true;
                         events.push(LdapSyncEventType::GroupMemberAdded {
                             group: group.clone(),
                             user,
@@ -1087,7 +1122,7 @@ impl super::LDAPConnection {
             }
         }
 
-        Ok(())
+        Ok(memberships_changed)
     }
 
     async fn apply_user_sync_changes(

--- a/crates/defguard_core/src/enterprise/ldap/tests.rs
+++ b/crates/defguard_core/src/enterprise/ldap/tests.rs
@@ -3,6 +3,8 @@ use std::{collections::HashMap, str::FromStr};
 use defguard_common::{
     db::{
         models::{
+            Device, DeviceType, WireguardNetwork,
+            device::WireguardNetworkDevice,
             group::Permission,
             settings::{LdapSyncStatus, initialize_current_settings},
         },
@@ -109,6 +111,49 @@ fn drain_ldap_sync_events(rx: &mut UnboundedReceiver<LdapSyncEventType>) -> Vec<
         events.push(event);
     }
     events
+}
+
+fn drain_gateway_commands(rx: &mut Receiver<GatewayCommand>) -> Vec<GatewayCommand> {
+    let mut events = Vec::new();
+    while let Ok(event) = rx.try_recv() {
+        events.push(event);
+    }
+    events
+}
+
+async fn make_test_acl_location(pool: &sqlx::PgPool) -> WireguardNetwork<Id> {
+    let mut location = WireguardNetwork::default()
+        .try_set_address("10.0.0.1/24")
+        .unwrap();
+    location.acl_enabled = true;
+    location.save(pool).await.unwrap()
+}
+
+async fn make_test_device(
+    pool: &sqlx::PgPool,
+    user: &User<Id>,
+    location: &WireguardNetwork<Id>,
+) -> Device<Id> {
+    let device = Device::new(
+        format!("{}-device", user.username),
+        format!("{}-key", user.username),
+        user.id,
+        DeviceType::User,
+        None,
+        true,
+    )
+    .save(pool)
+    .await
+    .unwrap();
+    WireguardNetworkDevice {
+        wireguard_network_id: location.id,
+        wireguard_ips: vec!["10.0.0.2".parse().unwrap()],
+        device_id: device.id,
+    }
+    .insert(pool)
+    .await
+    .unwrap();
+    device
 }
 
 fn set_test_license_business() {
@@ -2037,6 +2082,126 @@ async fn test_sync_does_not_repeat_group_events_for_out_of_scope_users(
     // The stored membership must survive, only the reporting stops.
     let members = group.member_usernames(&pool).await.unwrap();
     assert_eq!(members, vec!["disabled_user".to_owned()]);
+}
+
+#[sqlx::test]
+async fn test_ldap_membership_changes_refresh_firewall_once(
+    _: PgPoolOptions,
+    options: PgConnectOptions,
+) {
+    let pool = setup_pool(options).await;
+    let (wg_tx, mut wg_rx) = wg_test_channel();
+    let (ldap_tx, _ldap_rx) = ldap_test_channel();
+    let _ = initialize_current_settings(&pool).await;
+    set_test_license_business();
+
+    let location = make_test_acl_location(&pool).await;
+    let mut user = make_test_user(
+        "membership_user",
+        Some("membership_user".to_owned()),
+        Some("ou=users,dc=example,dc=com".to_owned()),
+    );
+    user.from_ldap = true;
+    let user = user.save(&pool).await.unwrap();
+    make_test_device(&pool, &user, &location).await;
+
+    let ldap_user = user.clone().as_noid();
+    let group = Group::new("ldap-group");
+    let mut ldap_conn = super::LDAPConnection::create().await.unwrap();
+    let config = ldap_conn.config.clone();
+    ldap_conn
+        .test_client_mut()
+        .add_test_user(&ldap_user, &config);
+    ldap_conn.test_client_mut().add_test_group(&group, &config);
+    ldap_conn
+        .test_client_mut()
+        .add_test_membership(&group, &ldap_user, &config);
+
+    ldap_conn
+        .sync(&pool, false, &wg_tx, &ldap_tx)
+        .await
+        .unwrap();
+    assert_eq!(
+        drain_gateway_commands(&mut wg_rx)
+            .iter()
+            .filter(|event| matches!(
+                event,
+                GatewayCommand::FirewallConfigChanged(id, _) if *id == location.id
+            ))
+            .count(),
+        1
+    );
+
+    // Repeating an already-applied membership change must not refresh the firewall.
+    ldap_conn
+        .sync(&pool, false, &wg_tx, &ldap_tx)
+        .await
+        .unwrap();
+    assert!(!drain_gateway_commands(&mut wg_rx).iter().any(
+        |event| matches!(event, GatewayCommand::FirewallConfigChanged(id, _) if *id == location.id)
+    ));
+
+    ldap_conn
+        .test_client_mut()
+        .remove_test_membership(&group, &ldap_user, &config);
+    ldap_conn
+        .sync(&pool, false, &wg_tx, &ldap_tx)
+        .await
+        .unwrap();
+    assert_eq!(
+        drain_gateway_commands(&mut wg_rx)
+            .iter()
+            .filter(|event| matches!(
+                event,
+                GatewayCommand::FirewallConfigChanged(id, _) if *id == location.id
+            ))
+            .count(),
+        1
+    );
+}
+
+#[sqlx::test]
+async fn test_ldap_user_deletion_cleans_up_devices(_: PgPoolOptions, options: PgConnectOptions) {
+    let pool = setup_pool(options).await;
+    let (wg_tx, mut wg_rx) = wg_test_channel();
+    let (ldap_tx, _ldap_rx) = ldap_test_channel();
+    let _ = initialize_current_settings(&pool).await;
+    set_test_license_business();
+
+    let mut user = make_test_user(
+        "deleted_user",
+        Some("deleted_user".to_owned()),
+        Some("ou=users,dc=example,dc=com".to_owned()),
+    );
+    user.from_ldap = true;
+    let user = user.save(&pool).await.unwrap();
+    let location = make_test_acl_location(&pool).await;
+    let device = make_test_device(&pool, &user, &location).await;
+
+    let mut ldap_conn = super::LDAPConnection::create().await.unwrap();
+    ldap_conn
+        .sync(&pool, false, &wg_tx, &ldap_tx)
+        .await
+        .unwrap();
+
+    assert!(User::find_by_id(&pool, user.id).await.unwrap().is_none());
+    assert!(
+        Device::find_by_id(&pool, device.id)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    let network_device = sqlx::query_scalar::<_, Id>(
+        "SELECT device_id FROM wireguard_network_device WHERE device_id = $1",
+    )
+    .bind(device.id)
+    .fetch_optional(&pool)
+    .await
+    .unwrap();
+    assert!(network_device.is_none());
+    assert!(drain_gateway_commands(&mut wg_rx).iter().any(
+        |event| matches!(event, GatewayCommand::DeviceDeleted(info) if info.device.id == device.id)
+    ));
 }
 
 /// The dry run previews not yet saved settings, so user scoping must follow the connection's

--- a/crates/defguard_core/src/handlers/wireguard.rs
+++ b/crates/defguard_core/src/handlers/wireguard.rs
@@ -419,6 +419,8 @@ pub(crate) async fn modify_network(
         .set_allowed_groups(&mut transaction, &data.allowed_groups)
         .await?;
 
+    // `NetworkModified` sends the complete peer list. The gateway compares the peer count and
+    // public keys, then replaces its peers, so separate device events are not needed.
     let _events = sync_location_allowed_devices(&network, &mut transaction, None).await?;
 
     let peers = get_location_allowed_peers(&network, &mut transaction).await?;

--- a/crates/defguard_core/src/user_management.rs
+++ b/crates/defguard_core/src/user_management.rs
@@ -55,7 +55,6 @@ pub async fn delete_user_and_cleanup_devices(
     let was_default_admin = Settings::get_current_settings().default_admin_id == Some(user.id);
 
     user.delete(&mut *conn).await?;
-    update_counts(&mut *conn).await?;
 
     // Update settings because they may also change due to a DB constraint.
     if was_default_admin && let Some(settings) = Settings::get(&mut *conn).await? {


### PR DESCRIPTION
Update ACLs when LDAP/AD sync changes group membership.
Also handle a similar case of directory sync re-enabling users.

Resolves https://github.com/DefGuard/defguard/issues/3643

Suggested follow up issues:
- https://github.com/DefGuard/defguard/issues/3660
- https://github.com/DefGuard/defguard/issues/3661